### PR TITLE
chore: add mcp-rs-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Interact with Git repositories and version control platforms. Enables repository
 - [@modelcontextprotocol/server-langchain](https://github.com/rectalogic/langchain-mcp) 🐍 - Provides MCP tool calling support in LangChain, allowing for the integration of MCP tools into LangChain workflows.
 - [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) 🏎️ - Golang SDK for building MCP Servers and Clients.
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
+- [mcp-rs-template](https://github.com/linux-china/mcp-rs-template) 🦀 - MCP CLI server template for Rust
+
 
 ## Tips and Tricks
 


### PR DESCRIPTION
mcp-rs-template is a MCP CLI server project template for Rust