### PR TITLE
Adding new servers - simple-timeserver and simple-openai-assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Interact with Git repositories and version control platforms. Enables repository
 - [anaisbetts/mcp-installer](https://github.com/anaisbetts/mcp-installer) 🐍 🏠 -  An MCP server that installs other MCP servers for you.
 - [tanigami/mcp-server-perplexity](https://github.com/tanigami/mcp-server-perplexity) 🐍 ☁️ - Interacting with Perplexity API.
 - [future-audiences/wikimedia-enterprise-model-context-protocol](https://gitlab.wikimedia.org/repos/future-audiences/wikimedia-enterprise-model-context-protocol) 🐍 ☁️  - Wikipedia Article lookup API
+- [andybrandt/mcp-simple-timeserver](https://github.com/andybrandt/mcp-simple-timeserver) 🐍 🏠☁️ - An MCP server that allows checking local time on the client machine or current UTC time from an NTP server
+- [andybrandt/mcp-simple-openai-assistant](https://github.com/andybrandt/mcp-simple-openai-assistant) - 🐍 ☁️  MCP to talk to OpenAI assistants (Claude can use any GPT model as his assitant)
+
 
 ## Frameworks
 


### PR DESCRIPTION
Adding two new servers:
 - simple-timeserver - server to allow checking both local machine time and UTC time from an NTP server
 - simple-openai-assistant - server enabling use of OpenAI's assistants