### PR TITLE
Add mcp-client-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [boilingdata/mcp-server-and-gw](https://github.com/boilingdata/mcp-server-and-gw) An MCP stdio to HTTP SSE transport gateway with example server and MCP client.
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) A gateway demo for MCP SSE Server.
 - [mark3labs/mcphost](https://github.com/mark3labs/mcphost) A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP).
+- [adhikasp/mcp-client-cli](https://github.com/adhikasp/mcp-client-cli/) CLI client that support Anthorpic, OpenAI, Groq, and ollama model via langchain
 
 ## Tips and Tricks
 


### PR DESCRIPTION
mcp-client-cli is yet another CLI Python program that implement MCP client protocol