### PR TITLE
Add the Metoro MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 
 - [@modelcontextprotocol/server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry) 🐍 ☁️ - Sentry.io integration for error tracking and performance monitoring
 - [@modelcontextprotocol/server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun) 📇 ☁️ - Raygun API V3 integration for crash reporting and real user monitoring
+- [metoro-io/metoro-mcp-server](https://github.com/metoro-io/metoro-mcp-server) 🎖️ 🏎️ ☁️ - Query and interact with kubernetes environments monitored by Metoro
 
 ### 🔎 <a name="search"></a>Search
 


### PR DESCRIPTION
We built an MCP server - https://github.com/metoro-io/metoro-mcp-server - for Metoro which allows MCP clients to directly query the status of their Kubernetes clusters and all workloads running inside using natural language.