### PR TITLE
Added isaacwasserman/mcp-vegalite-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [@llmindset/mcp-hfspace](https://github.com/evalstate/mcp-hfspace) 📇 ☁️ - Use HuggingFace Spaces directly from Claude. Use Open Source Image Generation, Chat, Vision tasks and more. Supports Image, Audio and text uploads/downloads.
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 📇 🏠 - CLI tool for testing MCP servers
+- [isaacwasserman/mcp-vegalite-server](https://github.com/isaacwasserman/mcp-vegalite-server) 🐍 🏠 - Generate visualizations from fetched data using the VegaLite format and renderer.
 
 ## Frameworks
 


### PR DESCRIPTION
The current list of community servers has lots of data sources but seems to be missing any sort of data visualization tools. While Claude Desktop natively renders Recharts visualizations well, it would be beneficial to have a way to produce charts in a canonical MCP-like way (especially for alternative clients). `mcp-vegalite-server` meets this requirement.