### PR TITLE
Add three new MCP servers for iMessage, SQLite, and Documentation RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Run commands, capture output and otherwise interact with shells and command line
 
 Integration with communication platforms for message management and channel operations. Enables AI models to interact with team communication tools.
 
+- [hannesrudolph/imessage-query-fastmcp-mcp-server](https://github.com/hannesrudolph/imessage-query-fastmcp-mcp-server) 🐍 🏠 🍎 - An MCP server that provides safe access to your iMessage database through Model Context Protocol (MCP), enabling LLMs to query and analyze iMessage conversations with proper phone number validation and attachment handling
 - [@modelcontextprotocol/server-slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack) 📇 ☁️ - Slack workspace integration for channel management and messaging
 - [@modelcontextprotocol/server-bluesky](https://github.com/keturiosakys/bluesky-context-server) 📇 ☁️ - Bluesky instance integration for querying and interaction
 - [MarkusPfundstein/mcp-gsuite](https://github.com/MarkusPfundstein/mcp-gsuite) - 🐍 ☁️ - Integration with gmail and Google Calendar.
@@ -160,6 +161,7 @@ Financial data access and cryptocurrency market information. Enables querying re
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.
 - [@modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) 📇 🏠 - Knowledge graph-based persistent memory system for maintaining context
 - [/CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh) 📇 🏠 - Enhanced graph-based memory with a focus on AI role-play and story generation
+- [@hannesrudolph/mcp-ragdocs](https://github.com/hannesrudolph/mcp-ragdocs) 🐍 🏠 - An MCP server implementation that provides tools for retrieving and processing documentation through vector search, enabling AI assistants to augment their responses with relevant documentation context
 
 ### 🗺️ <a name="location-services"></a>Location Services
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [KashiwaByte/vikingdb-mcp-server](https://github.com/KashiwaByte/vikingdb-mcp-server) 🐍 ☁️ - VikingDB integration with collection and index introduction, vector store and search capabilities.
 - [neo4j-contrib/mcp-neo4j](https://github.com/neo4j-contrib/mcp-neo4j) 🐍 🏠 - Model Context Protocol with Neo4j
 - [isaacwasserman/mcp-snowflake-server](https://github.com/isaacwasserman/mcp-snowflake-server) 🐍 ☁️ - Snowflake integration implementing read and (optional) write opertions as well as insight tracking
+- [hannesrudolph/sqlite-explorer-fastmcp-mcp-server](https://github.com/hannesrudolph/sqlite-explorer-fastmcp-mcp-server) 🐍 🏠 - An MCP server that provides safe, read-only access to SQLite databases through Model Context Protocol (MCP). This server is built with the FastMCP framework, which enables LLMs to explore and query SQLite databases with built-in safety features and query validation.
 
 ### 💻 <a name="developer-tools"></a>Developer Tools
 


### PR DESCRIPTION
# Add three new MCP servers for iMessage, SQLite, and Documentation RAG

This PR adds three new MCP server implementations:

- imessage-query-fastmcp-mcp-server: A Python-based MCP server that provides secure access to iMessage databases on macOS. Features include:
  - Safe, validated phone number handling
  - Proper attachment management
  - Built with FastMCP framework

- sqlite-explorer-fastmcp-mcp-server: A Python-based MCP server for exploring SQLite databases with:
  - Read-only access for safety
  - Built-in query validation
  - FastMCP framework integration

- mcp-ragdocs: A Python-based MCP server that enhances AI capabilities with:
  - Documentation retrieval through vector search
  - Context augmentation for AI responses
  - Efficient documentation processing