### PR TITLE
Add SecretiveShell/MCP-timeserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Geographic and location-based services integration. Enables access to mapping data, directions, and place information.
 
 - [@modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps) 📇 ☁️ - Google Maps integration for location services, routing, and place details
+- [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
Access global time data

This is useful if you have friends in different countries and you need to get the delta time.

Lets the LLM query the users current time, which is useful for general purpose agent stuff.

Uses the local system clock so that needs to be accurate.