### PR TITLE
feat: Added new website-downloader mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [@sammcj/mcp-package-version](https://github.com/sammcj/mcp-package-version) 📇 🏠 - An MCP Server to help LLMs suggest the latest stable package versions when writing code.
 - [@delano/postman-mcp-server](https://github.com/delano/postman-mcp-server) 📇 ☁️ - Interact with [Postman API](https://www.postman.com/postman/postman-public-workspace/)
 - [@vivekvells/mcp-pandoc](https://github.com/vivekVells/mcp-pandoc) 🗄️ 🚀 - MCP server for seamless document format conversion using Pandoc, supporting Markdown, HTML, PDF, DOCX (.docx), csv and more.
+- [@pskill9/website-downloader](https://github.com/pskill9/website-downloader) 🗄️ 🚀 - This MCP server provides a tool to download entire websites using wget. It preserves the website structure and converts links to work locally.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
> This MCP server provides a tool to download entire websites using wget. It preserves the website structure and converts links to work locally.

https://github.com/pskill9/website-downloader

## Usage

The server provides a tool called `download_website` with the following parameters:

- `url` (required): The URL of the website to download
- `outputPath` (optional): The directory where the website should be downloaded. Defaults to the current directory.
- `depth` (optional): Maximum depth level for recursive downloading. Defaults to infinite. Set to 0 for just the specified page, 1 for direct links, etc.

### Example

```json
{
  "url": "https://example.com",
  "outputPath": "/path/to/output",
  "depth": 2  // Optional: Download up to 2 levels deep
}
```

## Features

The website downloader:
- Downloads recursively with infinite depth
- Includes all page requisites (CSS, images, etc.)
- Converts links to work locally
- Adds appropriate extensions to files
- Restricts downloads to the same domain
- Preserves the website structure
