### PR TITLE
feat: add Art & Culture category with Rijksmuseum MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 ## Server Implementations
 
 * 📂 - [Browser Automation](#browser-automation)
+* 🎨 - [Art & Culture](#art-and-culture)
 * ☁️ - [Cloud Platforms](#cloud-platforms)
 * 💬 - [Communication](#communication)
 * 👤 - [Customer Data Platforms](#customer-data-platforms)
@@ -52,6 +53,12 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [@automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🌐🖱️ - An MCP server for browser automation using Playwright 
 - [@modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer) 📇 🏠 - Browser automation for web scraping and interaction
 - [@kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript) 📇 ☁️ - Fetch YouTube subtitles and transcripts for AI analysis
+
+### 🎨 <a name="art-and-culture"></a>Art & Culture
+
+Access and explore art collections, cultural heritage, and museum databases. Enables AI models to search and analyze artistic and cultural content.
+
+- [r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp) 📇 ☁️ - Rijksmuseum API integration for artwork search, details, and collections
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
# Add Art & Culture Category with Rijksmuseum MCP Server

## Description
Added a new "Art & Culture" category (🎨) to organize MCP servers related to cultural institutions and artistic content. The Rijksmuseum MCP server is added as the first entry in this category, providing integration with the Rijksmuseum API for artwork search, details, and collections.

## Changes Made
- Added new "Art & Culture" category with descriptive introduction
- Added category to the navigation list with 🎨 emoji
- Added Rijksmuseum MCP server as first entry

## Checklist
- [x] Followed existing format and style
- [x] Maintained alphabetical order in category listings
- [x] Added appropriate emojis (📇 for TypeScript, ☁️ for Cloud Service)
- [x] Included clear description of server functionality
- [x] Verified all links are correct

This addition helps organize cultural/artistic integrations and sets the foundation for similar servers in the future.