### PR TITLE
chore: Added MCP server for hacker news

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ Interact with Git repositories and version control platforms. Enables repository
 - [SecretiveShell/MCP-wolfram-alpha](https://github.com/SecretiveShell/MCP-wolfram-alpha) 🐍 ☁️ - An MCP server for querying wolfram alpha API.
 - [Amazon Bedrock Nova Canvas](https://github.com/zxkane/mcp-server-amazon-bedrock) 📇 ☁️ - Use Amazon Nova Canvas model for image generation.
 - [apinetwork/piapi-mcp-server](https://github.com/apinetwork/piapi-mcp-server) 📇 ☁️ PiAPI MCP server makes user able to generate media content with Midjourney/Flux/Kling/Hunyuan/Udio/Trellis directly from Claude or any other MCP-compatible apps.
-- [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🚀 ☁️ Tools to the query and execute of Dify workflows
-- [@pskill9/hn-server]https://github.com/pskill9/hn-server) - 🚀 ☁️ Parses the HTML content from news.ycombinator.com and provides structured data for different types of stories (top, new, ask, show, jobs).
+- [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
+- [@pskill9/hn-server](https://github.com/pskill9/hn-server) - 📇 ☁️ Parses the HTML content from news.ycombinator.com (Hacker News) and provides structured data for different types of stories (top, new, ask, show, jobs).
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Amazon Bedrock Nova Canvas](https://github.com/zxkane/mcp-server-amazon-bedrock) 📇 ☁️ - Use Amazon Nova Canvas model for image generation.
 - [apinetwork/piapi-mcp-server](https://github.com/apinetwork/piapi-mcp-server) 📇 ☁️ PiAPI MCP server makes user able to generate media content with Midjourney/Flux/Kling/Hunyuan/Udio/Trellis directly from Claude or any other MCP-compatible apps.
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🚀 ☁️ Tools to the query and execute of Dify workflows
+- [@pskill9/hn-server]https://github.com/pskill9/hn-server) - 🚀 ☁️ Parses the HTML content from news.ycombinator.com and provides structured data for different types of stories (top, new, ask, show, jobs).
 
 ## Frameworks
 


### PR DESCRIPTION
### Hacker News MCP Server
> A Model Context Protocol (MCP) server that provides tools for fetching stories from Hacker News. This server parses the HTML content from news.ycombinator.com and provides structured data for different types of stories (top, new, ask, show, jobs).

### Features
- Fetch different types of stories (top, new, ask, show, jobs)
- Get structured data including titles, URLs, points, authors, timestamps, and comment counts
- Configurable limit on number of stories returned
- Clean error handling and validation