### PR TITLE
Added MCP Server for Hackernews

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 - [SecretiveShell/MCP-searxng](https://github.com/SecretiveShell/MCP-searxng) 🐍 🏠 - An MCP Server to connect to searXNG instances
 - [Bigsy/Clojars-MCP-Server](https://github.com/Bigsy/Clojars-MCP-Server) 📇 ☁️ - Clojars MCP Server for upto date dependency information of Clojure libraries
 - [Ihor-Sokoliuk/MCP-SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng) 📇 🏠/☁️ - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
+- [erithwik/mcp-hn](https://github.com/erithwik/mcp-hn) 🐍 ☁️ - An MCP server to search Hacker News, get top stories, and more.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Added a new MCP server that has the following features for interacting with hackernews:
```
get_stories Fetching (top, new, ask_hn, show_hn) stories
get_story_info Fetching comments associated with a story
search_stories Searching for stories by query
get_user_info Fetching user info
```