### PR TITLE
Add iterm-mcp

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -112,7 +112,7 @@ Webコンテンツのアクセスと自動化機能。AIに優しい形式でWeb
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Open API spec (v3) を使用して任意のHTTP/REST APIサーバーに接続
 - [@joshuarileydev/terminal-mcp-server](https://www.npmjs.com/package/@joshuarileydev/terminal-mcp-server) 📇 🏠 - 任意のシェルターミナルコマンドを実行するためのMCPサーバー
 - [tumf/mcp-text-editor](https://github.com/tumf/mcp-text-editor) - ラインエディタ 行単位の取得と編集ができるので、特に大きなファイルの一部書き換えを効率的に行う
-- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 📇 🏠 - iTermへのアクセスを提供するモデルコンテキストプロトコルサーバー。コマンドを実行し、iTermターミナルで見た内容について質問することができます。
+- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - iTermへのアクセスを提供するモデルコンテキストプロトコルサーバー。コマンドを実行し、iTermターミナルで見た内容について質問することができます。
 
 ### 📂 <a name="file-systems"></a>ファイルシステム
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -112,6 +112,7 @@ Webコンテンツのアクセスと自動化機能。AIに優しい形式でWeb
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Open API spec (v3) を使用して任意のHTTP/REST APIサーバーに接続
 - [@joshuarileydev/terminal-mcp-server](https://www.npmjs.com/package/@joshuarileydev/terminal-mcp-server) 📇 🏠 - 任意のシェルターミナルコマンドを実行するためのMCPサーバー
 - [tumf/mcp-text-editor](https://github.com/tumf/mcp-text-editor) - ラインエディタ 行単位の取得と編集ができるので、特に大きなファイルの一部書き換えを効率的に行う
+- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 📇 🏠 - iTermへのアクセスを提供するモデルコンテキストプロトコルサーバー。コマンドを実行し、iTermターミナルで見た内容について質問することができます。
 
 ### 📂 <a name="file-systems"></a>ファイルシステム
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -139,6 +139,7 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 - [@joshuarileydev/simulator-mcp-server](https://github.com/JoshuaRileyDev/simulator-mcp-server) 📇 🏠 - 用于控制 iOS 模拟器的 MCP 服务器
 - [@joshuarileydev/app-store-connect-mcp-server](https://github.com/JoshuaRileyDev/app-store-connect-mcp-server) 📇 🏠 - 一个 MCP 服务器，用于与 iOS 开发者的 App Store Connect API 进行通信
 - [@sammcj/mcp-package-version](https://github.com/sammcj/mcp-package-version) 📦 🏠 - MCP 服务器可帮助 LLM 在编写代码时建议最新的稳定软件包版本。
+- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 📇 🏠 - 一个模型上下文协议服务器，提供对 iTerm 的访问。您可以运行命令并询问有关 iTerm 终端中看到的内容的问题。
 
 ### 🧮 数据科学工具
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Cloud platform service integration. Enables management and interaction with clou
 
 Run commands, capture output and otherwise interact with shells and command line tools.
 
-- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 📇 🏠 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
+- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) A secure shell command execution server implementing the Model Context Protocol (MCP)  

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Cloud platform service integration. Enables management and interaction with clou
 
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 📇 🏠 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) A secure shell command execution server implementing the Model Context Protocol (MCP)  


### PR DESCRIPTION
This PR adds iterm-mcp which provides iTerm access to the MCP client. You can interact with the terminal and ask questions about the display contents.

https://github.com/ferrislucas/iterm-mcp