### PR TITLE
feat(readme): add Xcode MCP Server to Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 Tools and integrations that enhance the development workflow and environment management.
 
 - [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) 🏎️ 🏠 - Docker container management and operations through MCP
+- [r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server) 📇 🏠 🍎 - Xcode integration for project management, file operations, and build automation
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Connect any HTTP/REST API server using an Open API spec (v3)
 - [jetbrains/mcpProxy](https://github.com/JetBrains/mcpProxy) 🎖️ 📇 🏠 - Connect to JetBrains IDE 
 - [tumf/mcp-text-editor](https://github.com/tumf/mcp-text-editor) 🐍 🏠 - A line-oriented text file editor. Optimized for LLM tools with efficient partial file access to minimize token usage.


### PR DESCRIPTION
Add r-huijts/xcode-mcp-server with TypeScript, local service, and macOS support indicators. The server provides Xcode IDE integration for project management, file operations, and build automation.