### PR TITLE
Add mcp-server-ipinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Geographic and location-based services integration. Enables access to mapping da
 - [@modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps) 📇 ☁️ - Google Maps integration for location services, routing, and place details
 - [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
+- [@briandconnelly/mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo) 🐍 ☁️  - IP address geolocation and network information using IPInfo API
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
Add an entry for [mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo) to the _Location Services_ section.

This server uses the [IPInfo](https://ipinfo.io) API to retrieve information about the user's geographic location and network information via their IP address.