### PR TITLE
Add the automated debugger: "Claude Debugs For You"

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Tools and integrations that enhance the development workflow and environment man
 - [@haris-musa/excel-mcp-server](https://github.com/haris-musa/excel-mcp-server) 🐍 🏠 - An Excel manipulation server providing workbook creation, data operations, formatting, and advanced features (charts, pivot tables, formulae).
 - [@jasonjmcghee/claude-debugs-for-you](https://github.com/jasonjmcghee/claude-debugs-for-you) 📇 🏠 - An MCP Server and VS Code Extension which enables (language agnostic) automatic debugging via breakpoints and expression evaluation.
 
-
 ### 🧮 Data Science Tools
 
 Integrations and tools designed to simplify data exploration, analysis and enhance data science workflows.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [@pskill9/website-downloader](https://github.com/pskill9/website-downloader) 🗄️ 🚀 - This MCP server provides a tool to download entire websites using wget. It preserves the website structure and converts links to work locally.
 - [@lamemind/mcp-server-multiverse](https://github.com/lamemind/mcp-server-multiverse) 📇 🏠 🛠️ - A middleware server that enables multiple isolated instances of the same MCP servers to coexist independently with unique namespaces and configurations.
 - [@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer) 🐍 - MCP server that provides SQL analysis, linting, and dialect conversion using [SQLGlot](https://github.com/tobymao/sqlglot)
+- [@jasonjmcghee/claude-debugs-for-you](https://github.com/jasonjmcghee/claude-debugs-for-you) 📇 🏠 - An MCP Server and VS Code Extension which enables (language agnostic) automatic debugging via breakpoints and expression evaluation.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
Adds "[Claude Debugs For You](https://github.com/jasonjmcghee/claude-debugs-for-you)", which (though originally built with Claude Desktop in mind) enables a given MCP client to use the debugger in VS Code, which means the LLM can set breakpoints, continue execution, evaluate expressions in-context along with finding and reading files, if required.

It's language agnostic - the burden is on the developer to be using the proper `launch.json` to enable debugging (in general).

LLMs seem to be able to solve problems much better if they can directly inspect values in code during execution (go figure), so it's valuable as an MCP Server.

Here's an example of it being used alongside Continue.

https://github.com/user-attachments/assets/fc4a55dc-2f09-4a7d-8518-b1c360d49bbc

