### PR TITLE
Add Template MCP Server to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [rectalogic/langchain-mcp](https://github.com/rectalogic/langchain-mcp) 🐍 - Provides MCP tool calling support in LangChain, allowing for the integration of MCP tools into LangChain workflows.
 - [salty-flower/ModelContextProtocol.NET](https://github.com/salty-flower/ModelContextProtocol.NET) #️⃣ 🏠 - A C# SDK for building MCP servers on .NET 9 with NativeAOT compatibility ⚡ 🔌
 - [spring-ai-mcp](https://github.com/spring-projects-experimental/spring-ai-mcp) ☕ 🌱 - Java SDK and Spring Framework integration for building MCP client and MCP servers with various, plugable, transport options.
+- [Template MCP Server](https://github.com/mcpdotdirect/template-mcp-server) 📇 - A CLI tool to create a new Model Context Protocol server project with TypeScript support, dual transport options, and an extensible structure
 - [@marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) - CodeMirror extension that implements the Model Context Protocol (MCP) for resource mentions and prompt commands.
 - [mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns.
 


### PR DESCRIPTION
# Add Template MCP Server to Frameworks section

This PR adds [Template MCP Server](https://github.com/mcpdotdirect/template-mcp-server) to the Frameworks section of the README.

## Description
Template MCP Server is a CLI tool to create new Model Context Protocol server projects with TypeScript support, dual transport options, and an extensible structure.
It allows anyone to run :
`npx npx @mcpdotdirect/create-mcp-server`
and a new a new MCP server project will be setup in the current directory.

## Changes
- Added Template MCP Server to the "For servers" subsection in the Frameworks section

## Checklist
- [x] Entry is added in alphabetical order
- [x] Description is clear and concise
- [x] Link is correct and working