### PR TITLE
Add Base MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 Financial data access and cryptocurrency market information. Enables querying real-time market data, crypto prices, and financial analytics.
 
+- [@base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
 - [QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp) 📇 ☁️ - Real-time cryptocurrency market data integration using CoinCap's public API, providing access to crypto prices and market information without API keys
 - [anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server) 🐍 ☁️ - Coinmarket API integration to fetch cryptocurrency listings and quotes
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information


### PR DESCRIPTION
This PR adds the Base MCP server (@base/base-mcp) to the Finance & Fintech section. 

The server provides:
- Base Network integration for onchain tools
- Interaction with Base Network and Coinbase API
- Wallet management and fund transfers
- Smart contract deployment and interaction
- DeFi operations

The entry follows the contribution guidelines:
- Added in alphabetical order within the Finance & Fintech section
- Includes appropriate emoji indicators (🎖️ for official implementation, 📇 for TypeScript, ☁️ for Cloud Service)
- Provides a clear and concise description
- Maintains consistent formatting