### PR TITLE
add godot-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ Financial data access and cryptocurrency market information. Enables querying re
 
 Integration with gaming related data, game engines, and services
 
-- [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.
 - [Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp) 📇 🏠 - A MCP server for interacting with the Godot game engine, providing tools for editing, running, debugging, and managing scenes in Godot projects.
+- [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ Financial data access and cryptocurrency market information. Enables querying re
 
 ### 🎮 <a name="gaming"></a>Gaming
 
-Integration with gaming related data, and services
+Integration with gaming related data, game engines, and services
 
 - [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.
+- [Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp) 📇 🏠 - A MCP server for interacting with the Godot game engine, providing tools for editing, running, debugging, and managing scenes in Godot projects.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
I noticed the Gaming section was a bit lonely, so I'd like to add my Godot MCP server that I've been developing for a couple of weeks.

This server provides comprehensive Godot engine integration, allowing:
- Launching the Godot editor for specific projects
- Running and debugging Godot projects
- Creating and managing scenes programmatically
- Adding nodes with customizable properties
- Loading sprites and textures
- Exporting 3D scenes as MeshLibrary resources
- UID management for Godot 4.4+

Thanks!