### PR TITLE
add scala mcp framework

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -357,7 +357,7 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 - [salty-flower/ModelContextProtocol.NET](https://github.com/salty-flower/ModelContextProtocol.NET) #️⃣🏠 - 基于 .NET 9 的 C# MCP 服务器 SDK ，支持 NativeAOT ⚡ 🔌
 - [spring-ai-mcp](https://github.com/spring-projects-experimental/spring-ai-mcp) ☕ 🌱 - 用于构建 MCP 客户端和服务器的 Java SDK 和 Spring Framework 集成，支持多种可插拔的传输选项
 - [@marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) - CodeMirror 扩展，实现了用于资源提及和提示命令的模型上下文协议 (MCP)
-
+- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🌸 🔌 - Scala MCP 框架 构建企业级MCP客户端和服务端 shade from modelcontextprotocol.io.🏒🏒
 ## 实用工具
 
 - [boilingdata/mcp-server-and-gw](https://github.com/boilingdata/mcp-server-and-gw) 📇 - 带有示例服务器和 MCP 客户端的 MCP stdio 到 HTTP SSE 传输网关

--- a/README-zh.md
+++ b/README-zh.md
@@ -357,7 +357,7 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 - [salty-flower/ModelContextProtocol.NET](https://github.com/salty-flower/ModelContextProtocol.NET) #️⃣🏠 - 基于 .NET 9 的 C# MCP 服务器 SDK ，支持 NativeAOT ⚡ 🔌
 - [spring-ai-mcp](https://github.com/spring-projects-experimental/spring-ai-mcp) ☕ 🌱 - 用于构建 MCP 客户端和服务器的 Java SDK 和 Spring Framework 集成，支持多种可插拔的传输选项
 - [@marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) - CodeMirror 扩展，实现了用于资源提及和提示命令的模型上下文协议 (MCP)
-- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🌸 🔌 - Scala MCP 框架 构建企业级MCP客户端和服务端 shade from modelcontextprotocol.io.🏒🏒
+- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🦀☕ 🔌 - Scala MCP 框架 构建企业级MCP客户端和服务端 shade from modelcontextprotocol.io.
 ## 实用工具
 
 - [boilingdata/mcp-server-and-gw](https://github.com/boilingdata/mcp-server-and-gw) 📇 - 带有示例服务器和 MCP 客户端的 MCP stdio 到 HTTP SSE 传输网关

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [@marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) - CodeMirror extension that implements the Model Context Protocol (MCP) for resource mentions and prompt commands.
 - [quarkus-mcp-server](https://github.com/quarkiverse/quarkus-mcp-server) ☕ - Java SDK for building MCP servers using Quarkus.
 - [mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns.
-- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🌸 🔌 - Scala MCP Framework for Build effective agents with MCP servers and MCP clients shade from modelcontextprotocol.io.🏒🏒
+- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🦀 ☕ - Scala MCP Framework for Build effective agents with MCP servers and MCP clients shade from modelcontextprotocol.io.
   
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,8 @@ Interact with Git repositories and version control platforms. Enables repository
 - [@marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) - CodeMirror extension that implements the Model Context Protocol (MCP) for resource mentions and prompt commands.
 - [quarkus-mcp-server](https://github.com/quarkiverse/quarkus-mcp-server) ☕ - Java SDK for building MCP servers using Quarkus.
 - [mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns.
-
+- [sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🌸 🔌 - Scala MCP Framework for Build effective agents with MCP servers and MCP clients shade from modelcontextprotocol.io.🏒🏒
+  
 ## Utilities
 
 - [boilingdata/mcp-server-and-gw](https://github.com/boilingdata/mcp-server-and-gw) 📇 - An MCP stdio to HTTP SSE transport gateway with example server and MCP client.


### PR DESCRIPTION
Hi,
        now I have write scala mcp framwork ,shade from modelcontextprotocol.io .
        --1. Enterprise-grade high-throughput performance and high-throughput capabilities.
        --2. Support for the Spring AI framework.
        --3. Support for asynchronous, multi-threaded invocations.
        --4. Multi-tenant support, with local PyTorch model deployment and invocation, 
        --5. Support integration with big data frameworks like Spark and Flink.