### PR TITLE
Add AWS MCP Server to Cloud Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 Cloud platform service integration. Enables management and interaction with cloud infrastructure and services.
 
 - [Cloudflare MCP Server](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1
+- [alexei-led/aws-mcp-server](https://github.com/alexei-led/aws-mcp-server) 🐍 ☁️ - A lightweight but powerful server that enables AI assistants to execute AWS CLI commands, use Unix pipes, and apply prompt templates for common AWS tasks in a safe Docker environment with multi-architecture support
 - [Kubernetes MCP Server](https://github.com/strowk/mcp-k8s-go) - 🏎️ ☁️/🏠 Kubernetes cluster operations through MCP
 - [@flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes) - 📇 ☁️/🏠 Typescript implementation of Kubernetes cluster operations for pods, deployments, services.
 - [@manusa/Kubernetes MCP Server](https://github.com/manusa/kubernetes-mcp-server) - 🏎️ 🏠 A powerful Kubernetes MCP server with additional support for OpenShift. Besides providing CRUD operations for **any** Kubernetes resource, this server provides specialized tools to interact with your cluster.


### PR DESCRIPTION
This PR adds the AWS MCP Server to the Cloud Platforms section. This server enables AI assistants to execute AWS CLI commands, use Unix pipes, and apply prompt templates for common AWS tasks, all within a secure Docker environment with multi-architecture support (AMD64/ARM64).

### Changes:
- Added AWS MCP Server in alphabetical order within the Cloud Platforms section
- Included appropriate icons (Python, Cloud Service)
- Provided a concise description highlighting the key capabilities

The AWS MCP Server is an open-source project that extends AI assistants' capabilities to interact with AWS infrastructure in a secure and controlled manner.