### PR TITLE
Add National Parks MCP Server to Travel & Transportation Category

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -181,6 +181,7 @@ Webコンテンツのアクセスと自動化機能。AIに優しい形式でWeb
 旅行および交通情報へのアクセス。スケジュール、ルート、およびリアルタイムの旅行データをクエリすることができます。
 
 - [NS Travel Information MCP Server](https://github.com/r-huijts/ns-mcp-server) 📇 ☁️ - オランダ鉄道（NS）の旅行情報、スケジュール、およびリアルタイムの更新にアクセス
+- [KyrieTangSheng/mcp-server-nationalparks](https://github.com/KyrieTangSheng/mcp-server-nationalparks) 📇 ☁️ - 米国国立公園局APIの統合で、米国国立公園の詳細情報、警報、ビジターセンター、キャンプ場、イベントの最新情報を提供
 
 ### 🔄 <a name="version-control"></a>バージョン管理
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -286,6 +286,7 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 访问旅行和交通信息。可以查询时刻表、路线和实时旅行数据。
 
 - [NS Travel Information MCP Server](https://github.com/r-huijts/ns-mcp-server) 📇 ☁️ - 了解荷兰铁路 (NS) 的旅行信息、时刻表和实时更新
+- [KyrieTangSheng/mcp-server-nationalparks](https://github.com/KyrieTangSheng/mcp-server-nationalparks) 📇 ☁️ - 美国国家公园管理局 API 集成，提供美国国家公园的详细信息、警报、游客中心、露营地和活动的最新信息
 
 ### 🔄 <a name="version-control"></a>版本控制
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Access to travel and transportation information. Enables querying schedules, rou
 
 - [Airbnb MCP Server](https://github.com/openbnb-org/mcp-server-airbnb) 📇 ☁️ - Provides tools to search Airbnb and get listing details.
 - [NS Travel Information MCP Server](https://github.com/r-huijts/ns-mcp-server) 📇 ☁️ - Access Dutch Railways (NS) travel information, schedules, and real-time updates
+- [KyrieTangSheng/mcp-server-nationalparks](https://github.com/KyrieTangSheng/mcp-server-nationalparks) 📇 ☁️ - National Park Service API integration providing latest information of park details, alerts, visitor centers, campgrounds, and events for U.S. National Parks
 
 ### 🔄 <a name="version-control"></a>Version Control
 


### PR DESCRIPTION

## Description

This PR adds the National Park Service API MCP server to the Travel & Transportation category in all three language versions of the README (English, Chinese, and Japanese).


## Changes Made

- Added entry for `KyrieTangSheng/mcp-server-nationalparks` to the Travel & Transportation section in:
  - README.md (English)
  - README-zh.md (Chinese)
  - README-ja.md (Japanese)
 
## Server Details
This MCP server provides integration with the National Park Service API, allowing AI assistants to access information about U.S. National Parks including park details, alerts, visitor centers, campgrounds, and events. It helps users plan trips to national parks and get up-to-date information about park conditions and activities.


## Checklist

- [x] Added server to appropriate category
- [x] Followed formatting guidelines
- [x] Added translations for all language versions
- [x] Verified GitHub repository link is correct

Thank you for maintaining this valuable resource for the MCP community!