### PR TITLE
Adding Deep Research MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 - [zhsama/duckduckgo-mcp-server](https://github.com/zhsama/duckduckgo-mpc-server/) 📇 🏠 ☁️ - This is a TypeScript-based MCP server that provides DuckDuckGo search functionality.
 - [vectorize-io/vectorize-mcp-server](https://github.com/vectorize-io/vectorize-mcp-server/) ☁️ 📇 - [Vectorize](https://vectorize.io) MCP server for advanced retrieval, Private Deep Research, Anything-to-Markdown file extraction and text chunking.
 - [jae-jae/fetcher-mcp](https://github.com/jae-jae/fetcher-mcp) 📇 🏠 - MCP server for fetching web page content using Playwright headless browser, supporting Javascript rendering and intelligent content extraction, and outputting Markdown or HTML format.
+- [reading-plus-ai/mcp-server-deep-research](https://github.com/reading-plus-ai/mcp-server-deep-research) 📇 ☁️ - MCP server providing OpenAI/Perplexity-like autonomous deep research, structured query elaboration, and concise reporting.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adding Deep Research MCP server to the community MCP server list.

Youtube：https://youtu.be/_a7sfo5yxoI
Github：https://github.com/reading-plus-ai/mcp-server-deep-research