### PR TITLE
Add Starknet MCP server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Financial data access and cryptocurrency market information. Enables querying re
 - [ferdousbhai/tasty-agent](https://github.com/ferdousbhai/tasty-agent) 🐍 ☁️ - Tastyworks API integration to handle trading activities on Tastytrade
 - [ferdousbhai/investor-agent](https://github.com/ferdousbhai/investor-agent) 🐍 ☁️ - Yahoo Finance integration to fetch stock market data including options recommendations
 - [mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server) 📇 ☁️ - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
+- [mcpdotdirect/starknet-mcp-server](https://github.com/mcpdotdirect/starknet-mcp-server) 📇 ☁️ - Comprehensive Starknet blockchain integration with support for native tokens (ETH, STRK), smart contracts, StarknetID resolution, and token transfers.
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) 📇 ☁️ - Bankless Onchain API to interact with smart contracts, query transaction and token information
 - [kukapay/cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server) 🐍 ☁️ - Providing latest cryptocurrency news to AI agents, powered by CryptoPanic.
 - [kukapay/whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp) 🐍 ☁️ -  A mcp server for tracking cryptocurrency whale transactions.


### PR DESCRIPTION
# Add Starknet MCP Server

This PR adds the [Starknet MCP Server](https://github.com/mcpdotdirect/starknet-mcp-server) to the Finance & Fintech section.

The server provides a comprehensive toolkit for interacting with the Starknet blockchain ecosystem, enabling AI agents to:

- Query account balances for ETH and STRK tokens
- Interact with smart contracts (read and write)
- Resolve human-readable StarknetIDs to addresses
- Manage NFT tokens and collections
- Check transaction status and block information
- Perform token transfers

The entry has been added in alphabetical order with appropriate emoji tags (📇 ☁️). 