### PR TITLE
Add Arcade.dev

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -256,6 +256,7 @@ Gitリポジトリおよびバージョン管理プラットフォームとの�
 
 ## フレームワーク
 
+- [Arcade.dev](https://github.com/ArcadeAI/arcade-ai) ☁️ 🏠 - MCP サーバーを通じて公開されるサービスにユーザーを安全に接続し、認証します。
 - [Genkit MCP](https://github.com/firebase/genkit/tree/main/js/plugins/mcp) 📇 – [Genkit](https://github.com/firebase/genkit/tree/main) とモデルコンテキストプロトコル（MCP）との統合を提供します。
 - [@modelcontextprotocol/server-langchain](https://github.com/rectalogic/langchain-mcp) 🐍 - LangChainでのMCPツール呼び出しサポートを提供し、LangChainワークフローにMCPツールを統合できるようにします。
 - [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) 🏎️ - MCPサーバーとクライアントを構築するためのGolang SDK。

--- a/README-zh.md
+++ b/README-zh.md
@@ -363,6 +363,8 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 - [NakaokaRei/swift-mcp-gui](https://github.com/NakaokaRei/swift-mcp-gui.git) 🏠 🍏 - MCP服务器，可以执行键盘输入、鼠标移动等命令
 
 ## 框架
+
+- [Arcade.dev](https://github.com/ArcadeAI/arcade-ai) ☁️ 🏠 - 安全地连接并授权用户使用通过 MCP 服务器公开的服务
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - 用于在 Python 中构建 MCP 服务器的高级框架
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - 用于在 TypeScript 中构建 MCP 服务器的高级框架
 - [Foxy Contexts](https://github.com/strowk/foxy-contexts) 🏎️ - 用于以声明方式编写 MCP 服务器的 Golang 库，包含功能测试

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ## Frameworks
 
+- [Arcade.dev](https://github.com/ArcadeAI/arcade-ai) ☁️ 🏠 - Securely connect and authorize users to services exposed through MCP servers
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript
 - [Foxy Contexts](https://github.com/strowk/foxy-contexts) 🏎️ - Golang library to write MCP Servers declaratively with functional testing included


### PR DESCRIPTION
Adding [Arcade.dev](https://www.arcade.dev/) to the Frameworks section.

I used Google Translate for the Chinese and Japanese versions, so I hope they are ok!