### PR TITLE
Added DesktopCommanderMCP to Command Line tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Cloud platform service integration. Enables management and interaction with clou
 
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 🖥️ 📂 🛠️ 📇 🏠 - Comprehensive tool to execute commands and read/write/search/edit files.
 - [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies


### PR DESCRIPTION
This is a popular MCP server for executing commands and editing files.  I've been using it on Linux for programming, and I believe it works on MacOS & Windows too.  Since it works by executing commands, even if it's running a test for a program which it's also editing, I think this belongs with CLI tools rather than programming tools.