### PR TITLE
Add Dumpling AI MCP Server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 ### 🔎 <a name="search"></a>Search
 
 - [@modelcontextprotocol/server-brave-search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) 📇 ☁️ - Web search capabilities using Brave's Search API
+- [Dumpling-AI/mcp-server-dumplingai](https://github.com/Dumpling-AI/mcp-server-dumplingai) 🎖️ 📇 ☁️ - Access data, web scraping, and document conversion APIs by [Dumpling AI](https://www.dumplingai.com/)
 - [@angheljf/nyt](https://github.com/angheljf/nyt) 📇 ☁️ - Search articles using the NYTimes API
 - [@modelcontextprotocol/server-fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) 🐍 🏠 ☁️ - Efficient web content fetching and processing for AI consumption
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration


### PR DESCRIPTION
Added the official Dumpling AI MCP server to the README file. This MCP service can be used to connect to [Dumpling AI](https://www.dumplingai.com/) APIs.