### PR TITLE
Add browser-control-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [@co-browser/browser-use-mcp-server](https://github.com/co-browser/browser-use-mcp-server) 🌐🔮 - browser-use packaged as an MCP server with SSE transport. includes a dockerfile to run chromium in docker + a vnc server.
 - [@34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) 📇 🏠 - A MCP server that supports searching for Bilibili content. Provides LangChain integration examples and test scripts.
 - [@getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 🐍 🏠 - Extract structured data from any website. Just prompt and get JSON.
-
+- [@eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 


### PR DESCRIPTION
Add browser-control-mcp, which is An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).