### PR TITLE
chore: add github.com/gabfr/waha-api-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [quarkiverse/quarkus-mcp-server](https://github.com/quarkiverse/quarkus-mcp-server) ☕ - Java SDK for building MCP servers using Quarkus.
 - [lastmile-ai/mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns.
 - [mullerhai/sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🦀 ☕ - Scala MCP Framework for Build effective agents with MCP servers and MCP clients shade from modelcontextprotocol.io.
+- [gabfr/waha-api-mcp-server](https://github.com/gabfr/waha-api-mcp-server) 💬 - An MCP server with openAPI specs for using the WhatsApp unnoficial API (https://waha.devlike.pro/ - also open source: https://github.com/devlikeapro/waha
   
 ## Utilities
 


### PR DESCRIPTION
This pull request includes an update to the `README.md` file, adding a new repository to the list of projects.

Projects update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R485): Added the `gabfr/waha-api-mcp-server` repository, which is an MCP server with openAPI specs for using the WhatsApp unofficial API.