### PR TITLE
add `simple-mcp` typescript framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [quarkiverse/quarkus-mcp-server](https://github.com/quarkiverse/quarkus-mcp-server) ☕ - Java SDK for building MCP servers using Quarkus.
 - [lastmile-ai/mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns.
 - [mullerhai/sakura-mcp](https://github.com/mullerhai/sakura-mcp) 🦀 ☕ - Scala MCP Framework for Build effective agents with MCP servers and MCP clients shade from modelcontextprotocol.io.
+- [simple-mcp](https://github.com/ribeirogab/simple-mcp) 📇 - A simple TypeScript library for creating MCP servers.
   
 ## Utilities
 


### PR DESCRIPTION
Adding the GitHub link for the `simple-mcp` library.

- NPM package: https://www.npmjs.com/package/simple-mcp