### PR TITLE
Add GitHub Enterprise(GHES) MCP Server Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ Interact with Git repositories and version control platforms. Enables repository
 - [@oschina/mcp-gitee](https://github.com/oschina/gitee) 🏎️ ☁️ 🏠 - Gitee API integration, repository, issue, and pull request management, and more.
 - [@modelcontextprotocol/server-git](https://github.com/modelcontextprotocol/servers/tree/main/src/git) 🐍 🏠 - Direct Git repository operations including reading, searching, and analyzing local repositories
 - [adhikasp/mcp-git-ingest](https://github.com/adhikasp/mcp-git-ingest) 🐍 🏠 - Read and analyze GitHub repositories with your LLM
+- [ddukbg/github-enterprise-mcp](https://github.com/ddukbg/github-enterprise-mcp) 📇 ☁️ 🏠 - MCP server for GitHub Enterprise API integration
+
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 


### PR DESCRIPTION
This PR adds a new entry for the GitHub Enterprise MCP server to the list. 
The server integrates with the GitHub Enterprise Server API for seamless repository, issues, PR, and workflow management. 
Thank you for curating this awesome collection!

repository: https://github.com/ddukbg/github-enterprise-mcp