### PR TITLE
Add new ffmpeg-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🗺️ - [Location Services](#location-services)
 * 🎯 - [Marketing](#marketing)
 * 📊 - [Monitoring](#monitoring)
+* 🎥 - [Multimedia Process](#multimedia-process)
 * 🔎 - [Search & Data Extraction](#search)
 * 🔒 - [Security](#security)
 * 🏃 - [Sports](#sports)
@@ -447,7 +448,10 @@ Access and analyze application monitoring data. Enables AI models to review erro
 - [pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp) 🎖️ 🐍 ☁️ - Provides access to OpenTelemetry traces and metrics through Logfire
 - [seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor) 🏎️ 🏠 - A system monitoring tool that exposes system metrics via the Model Context Protocol (MCP). This tool allows LLMs to retrieve real-time system information through an MCP-compatible interface.（support CPU、Memory、Disk、Network、Host、Process）
 
-### 🎥 <a name="media-process"></a>Video & Audio Process
+### 🎥 <a name="multimedia-process"></a>Multimedia Process
+
+Provides the ability to handle multimedia, such as audio and video editing, playback, format conversion, also includes video filters, enhancements, and so on
+
 - [video-creator/ffmpeg-mcp](https://github.com/video-creator/ffmpeg-mcp.git) 🎥 🔊 - Using ffmpeg command line to achieve an mcp server, can be very convenient, through the dialogue to achieve the local video search, tailoring, stitching, playback and other functions
 
 ### 🔎 <a name="search"></a>Search & Data Extraction

--- a/README.md
+++ b/README.md
@@ -447,6 +447,9 @@ Access and analyze application monitoring data. Enables AI models to review erro
 - [pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp) 🎖️ 🐍 ☁️ - Provides access to OpenTelemetry traces and metrics through Logfire
 - [seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor) 🏎️ 🏠 - A system monitoring tool that exposes system metrics via the Model Context Protocol (MCP). This tool allows LLMs to retrieve real-time system information through an MCP-compatible interface.（support CPU、Memory、Disk、Network、Host、Process）
 
+### 🎥 <a name="media-process"></a>Video & Audio Process
+- [video-creator/ffmpeg-mcp](https://github.com/video-creator/ffmpeg-mcp.git) 🎥 🔊 - Using ffmpeg command line to achieve an mcp server, can be very convenient, through the dialogue to achieve the local video search, tailoring, stitching, playback and other functions
+
 ### 🔎 <a name="search"></a>Search & Data Extraction
 
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration


### PR DESCRIPTION
# FFmpeg-MCP
Using ffmpeg command line to achieve an mcp server, can be very convenient, through the dialogue to achieve the local video search, tailoring, stitching, playback and other functions

## Support Tools
The server implements the following tools: <br/>
- `find_video_path`
  The parameters are directory and file name, file name can be complete, or is not suffixed, recursive search in the directory, return the full path
- `clip_video`
  The parameter is the file path, start time, end time or duration, and returns the trimmed file path
- `concat_videos`
  The parameters are the list of files, the output path, and if the video elements in the list of files, such as width, height, frame rate, etc., are consistent, quick mode synthesis is automatically used
<br/>
More features are coming

## Installation procedure
1. Download project
```
git clone  https://github.com/video-creator/ffmpeg-mcp.git
cd ffmpeg-mcp
uv sync
```

2. Configuration in Cline
```
{
  "mcpServers": {
    "ffmpeg-mcp": {
      "autoApprove": [],
      "disabled": false,
      "timeout": 60,
      "command": "uv",
      "args": [
        "--directory",
        "/Users/xxx/Downloads/ffmpeg-mcp",
        "run",
        "ffmpeg-mcp"
      ],
      "transportType": "stdio"
    }
  }
}
```
Note: the value:`/Users/XXX/Downloads/ffmpeg` in args  need to replace the actual download ffmpeg-mcp directory
