### PR TITLE
add: pluggedin-mcp-proxy to Aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [PipedreamHQ/pipedream](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) ☁️ 🏠 - Connect with 2,500 APIs with 8,000+ prebuilt tools, and manage servers for your users, in your own app.
+- [VeriTeknik/pluggedin-mcp-proxy](https://github.com/VeriTeknik/pluggedin-mcp-proxy)  📇 🏠 - A comprehensive proxy server that combines multiple MCP servers into a single interface with extensive visibility features. It provides discovery and management of tools, prompts, resources, and templates across servers, plus a playground for debugging when building MCP servers.
+
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 


### PR DESCRIPTION
## Description
This PR adds the pluggedin-mcp-proxy to the Aggregators section. Plugged.in MCP Server acts as a proxy server that combines multiple MCP servers into a single unified interface with extensive visibility features. It fetches tool, prompt, and resource configurations from the plugged.in App and intelligently routes requests to the appropriate underlying MCP servers.

## Features
- Universal MCP Compatibility with any MCP client (Claude, Cline, Cursor, etc.)
- Multi-Server Support for both STDIO and WebSocket MCP servers
- Namespace Isolation to keep joined MCPs separate and organized
- Multi-Workspace Layer to switch between different sets of MCP configurations
- Extensive visibility of prompts, resources, and templates across all connected servers
- Discovery functionality to see details of available servers and tools
- Playground for extensive debugging when building MCP Servers
- Collections creation for different clients (Claude Desktop, Cursor, Cline)
- Tool Management across all connected MCP servers
- Intelligent Routing of tool calls to the appropriate underlying MCP server

## Checklist
- [x] The entry follows the repository's format
- [x] The description is concise and informative
- [x] The appropriate emojis are used (TypeScript, Local Service)
- [x] The GitHub repository link is valid