### PR TITLE
Add new alpaca-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Financial data access and analysis tools. Enables AI models to work with market 
 - [kukapay/uniswap-poolspy-mcp](https://github.com/kukapay/uniswap-poolspy-mcp) 🐍 ☁️ -  An MCP server that tracks newly created liquidity pools on Uniswap across multiple blockchains.
 - [kukapay/uniswap-trader-mcp](https://github.com/kukapay/uniswap-trader-mcp) 🐍 ☁️ -  An MCP server for AI agents to automate token swaps on Uniswap DEX across multiple blockchains.
 - [kukapay/whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp) 🐍 ☁️ -  A mcp server for tracking cryptocurrency whale transactions.
+- [laukikk/alpaca-mcp](https://github.com/laukikk/alpaca-mcp) 🐍 ☁️ - An MCP Server for the Alpaca trading API to manage stock and crypto portfolios, place trades, and access market data.
 - [longportapp/openapi](https://github.com/longportapp/openapi/tree/main/mcp) - 🐍 ☁️ - LongPort OpenAPI provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.
 - [mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server) 📇 ☁️ - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - [mcpdotdirect/starknet-mcp-server](https://github.com/mcpdotdirect/starknet-mcp-server) 📇 ☁️ - Comprehensive Starknet blockchain integration with support for native tokens (ETH, STRK), smart contracts, StarknetID resolution, and token transfers.


### PR DESCRIPTION
Adding the Alpaca Trading MCP Server to the collection.

This PR adds the Alpaca Trading MCP Server, which provides an interface to the Alpaca trading API. It allows users to manage their stock and crypto portfolios, place trades, and access market data through MCP.

**Key features:**

- Account Management: View account details, balances, and portfolio status
- Trading: Place market, limit, stop, and stop-limit orders
- Portfolio Management: View positions, calculate performance, and close positions
- Market Data: Access real-time quotes and historical price data
- Asset Information: Get details about tradable assets

This server provides resources for account information, positions, orders, market quotes, and asset information, as well as tools for placing and managing orders using the Alpaca Trading API.

