### PR TITLE
Add desktop commander mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ Cloud platform service integration. Enables management and interaction with clou
 
 Run commands, capture output and otherwise interact with shells and command line tools.
 
-- [DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 🖥️ 📂 🛠️ 📇 🏠 - Comprehensive tool to execute commands and read/write/search/edit files.
 - [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) A secure shell command execution server implementing the Model Context Protocol (MCP)
+- [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and search/read/write/edit code and text files.
 
 ### 💬 <a name="communication"></a>Communication
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) A secure shell command execution server implementing the Model Context Protocol (MCP)
-- [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and search/read/write/edit code and text files.
+- [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 
 ### 💬 <a name="communication"></a>Communication
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Cloud platform service integration. Enables management and interaction with clou
 
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 🖥️ 📂 🛠️ 📇 🏠 - Comprehensive tool to execute commands and read/write/search/edit files.
 - [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) 🖥️ 🛠️ 💬 - A Model Context Protocol server that provides access to iTerm. You can run commands and ask questions about what you see in the iTerm terminal.
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - Run any command with `run_command` and `run_script` tools.
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies


### PR DESCRIPTION
This tool is fairly popular with 1.5k stars.  I've been using it 10 days.  It has around 20 MCP tools for controlling your local machine (eg. edit_block, move_file, search_code kill_process and execute_command).

I don't understand how to use the Category icons when something can be used for the Command line, Search, Filesystems, and developing, so this only has filesystem, scope & OS icons.