### PR TITLE
Add Qlik Cloud MCP server to Data Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 Data Platforms for data integration, transformation and pipeline orchestration. 
 
 - [JordiNei/mcp-databricks-server](https://github.com/JordiNeil/mcp-databricks-server) - Connect to Databricks API, allowing LLMs to run SQL queries, list jobs, and get job status.
+- [jwaxman19/qlik-mcp](https://github.com/jwaxman19/qlik-mcp) 📇 ☁️ - MCP Server for Qlik Cloud API that enables querying applications, sheets, and extracting data from visualizations with comprehensive authentication and rate limiting support.
 - [keboola/keboola-mcp-server](https://github.com/keboola/keboola-mcp-server) - interact with Keboola Connection Data Platform. This server provides tools for listing and accessing data from Keboola Storage API.
 
 ### 💻 <a name="developer-tools"></a>Developer Tools


### PR DESCRIPTION
Added jwaxman19/qlik-mcp to the Data Platforms section. This MCP server enables interaction with Qlik Cloud API for querying applications, sheets, and extracting data from visualizations.