### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,8 @@ security vulnerabilities. Built with remote npm registry integration for real-ti
 Tools for accessing sports-related data, results, and statistics.
 
 - [r-huijts/firstcycling-mcp](https://github.com/r-huijts/firstcycling-mcp) 📇 ☁️ - Access cycling race data, results, and statistics through natural language. Features include retrieving start lists, race results, and rider information from firstcycling.com.
-
+- [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs
+  
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 
 Tools for managing customer support, IT service management, and helpdesk operations.


### PR DESCRIPTION
# Add Strava MCP Server to Sports Section

This PR adds the [Strava MCP server](https://github.com/r-huijts/strava-mcp) to the list of community servers in the Sports section.

## Description

The Strava MCP server provides a bridge between AI assistants and the Strava API, allowing natural language interaction with fitness data through the Model Context Protocol.

### Features
- 🏃 Access recent activities, profile information, and athletic statistics
- 🔍 View detailed activity and segment effort information
- 👥 List club memberships
- 🗺️ Explore, star, and view segment efforts
- 📍 List and view route details with GPX/TCX export capabilities

Built with TypeScript and uses the Strava API v3 with automatic token refreshing.

## Placement
Added to the Sports section with the following entry:
```markdown
- [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - Strava API integration for accessing activity data, athlete stats, segments, routes, and clubs through natural language