### PR TITLE
Added balldontlie-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ security vulnerabilities. Built with remote npm registry integration for real-ti
 
 Tools for accessing sports-related data, results, and statistics.
 
+- [balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) 📇 - MCP server that integrates balldontlie api to provide information about players, teams and games for the NBA, NFL and MLB
 - [r-huijts/firstcycling-mcp](https://github.com/r-huijts/firstcycling-mcp) 📇 ☁️ - Access cycling race data, results, and statistics through natural language. Features include retrieving start lists, race results, and rider information from firstcycling.com.
 - [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs
   

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ security vulnerabilities. Built with remote npm registry integration for real-ti
 
 Tools for accessing sports-related data, results, and statistics.
 
-- [balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) 📇 - MCP server that integrates balldontlie api to provide information about players, teams and games for the NBA, NFL and MLB
+- [mikechao/balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) 📇 - MCP server that integrates balldontlie api to provide information about players, teams and games for the NBA, NFL and MLB
 - [r-huijts/firstcycling-mcp](https://github.com/r-huijts/firstcycling-mcp) 📇 ☁️ - Access cycling race data, results, and statistics through natural language. Features include retrieving start lists, race results, and rider information from firstcycling.com.
 - [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs
   


### PR DESCRIPTION
# Add balldontlie-mcp to the Sports Section
This PR adds the [balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) to the list of community servers in the Sports section.

# Description
The balldontlie-mcp leverages the [balldontlie api](https://www.balldontlie.io/) to provide information about players, teams and games for the NBA, MLB and NFL.

## Tools

- **get_teams**

  - Get a list of teams for the NBA, NFL or MLB
  - Inputs:
    - `league` (enum ['NBA', 'NFL', 'MLB']): The sports league to get teams for

- **get_players**

  - Gets a list of players for the NBA, NFL or MLB
  - Inputs:
    - `league` (enum ['NBA', 'NFL', 'MLB']): The sports league to get players for
    - `firstName` (string, optional): The first name of the player to search for
    - `lastName` (string, optional): The last name of the player to search for
    - `cursor` (number, optional): Cursor for pagination

- **get_games**

  - Gets the list of games for the NBA, NFL or MLB
  - Inputs:
    - `league` (enum ['NBA', 'NFL', 'MLB']): The sports league to get games for
    - `dates` (string[], optional): Get games for specific dates, format: YYYY-MM-DD
    - `teamIds` (string[], optional): Get games for specific games
    - `cursor` (number, optional): Cursor for pagination

- **get_game**

  - Get a specific game from one of the following leagues NBA, MLB, NFL
  - Inputs:
      - `league` (enum ['NBA', 'NFL', 'MLB']): The sports league to get the game for
      - `gameId` (number): The id of the game from the get_games tool

# Placement
Added to the Sports section with the following entry:
```
- [balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) 📇 - MCP server that integrates balldontlie api to provide information about players, teams and games for the NBA, NFL and MLB
```