### PR TITLE
Add Apple Books MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp) 📇 🏠 - Memory manager for AI apps and Agents using various graph and vector stores and allowing ingestion from 30+ data sources
 - [unibaseio/membase-mcp](https://github.com/unibaseio/membase-mcp) 📇 ☁️ - Save and query your agent memory in distributed way by Membase
 - [entanglr/zettelkasten-mcp](https://github.com/entanglr/zettelkasten-mcp) 🐍 🏠 - A Model Context Protocol (MCP) server that implements the Zettelkasten knowledge management methodology, allowing you to create, link, and search atomic notes through Claude and other MCP-compatible clients.
+- [vgnshiyer/apple-books-mcp](https://github.com/vgnshiyer/apple-books-mcp) 📙 - Transform your Apple Books to a queryable knowledge base.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
The Apple Books MCP server bridges the gap between your personal reading journey and AI capabilities by transforming static book collections into interactive knowledge repositories.

This server empowers readers

* to summarize highlights with a simple prompt
* search annotations by color-coding systems
* organize sprawling libraries by genre
* receive personalized book recommendations
* perform cross-book analysis on related topics. And much more.

By eliminating the manual effort traditionally required to manage reading insights, it creates a interface between your accumulated literary wisdom and conversational AI. For academics, lifelong learners, and casual readers alike, this integration transforms Apple Books from a mere content container into an accessible, queryable knowledge base that evolves alongside your reading habits.