### PR TITLE
Add weekly weather MCP server with full 7-day forecasted data

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps) 📇 ☁️ - Google Maps integration for location services, routing, and place details
 - [QGIS MCP](https://github.com/jjsantos01/qgis_mcp) - connects QGIS Desktop to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - [SaintDoresh/Weather-MCP-ClaudeDesktop](https://github.com/SaintDoresh/Weather-MCP-ClaudeDesktop.git) 🐍 ☁️ - An MCP tool that provides real-time weather data, forecasts, and historical weather information using the OpenWeatherMap API.
+- [rossshannon/Weekly-Weather-mcp](https://github.com/rossshannon/weekly-weather-mcp.git) 🐍 ☁️ - Weekly Weather MCP server which returns 7 full days of detailed weather forecasts anywhere in the world.
 - [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
 


### PR DESCRIPTION
Other servers don't give back a full week or only give a single forecast for each day instead of broken down by time of day.

![68747470733a2f2f726f73737368616e6e6f6e2e6769746875622e696f2f7765656b6c792d776561746865722d6d63702f696d616765732f776561746865722d666f7265636173742d6578616d706c652e706e67](https://github.com/user-attachments/assets/a30ac4fa-5769-46f3-9a93-3a375385a595)
