### PR TITLE
Add Atlassian MCP Server for Jira and Confluence Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Tools for managing customer support, IT service management, and helpdesk operati
 
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.
+- [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) 🐍 ☁️ - MCP server for Atlassian products (Confluence and Jira). Supports Confluence Cloud, Jira Cloud, and Jira Server/Data Center. Provides comprehensive tools for searching, reading, creating, and managing content across Atlassian workspaces.
 
 ### 🌎 <a name="translation-services"></a>Translation Services
 


### PR DESCRIPTION
This pull request adds the Atlassian MCP server to the collection, which provides integration capabilities with Atlassian products (Jira and Confluence).

Key features added:
- Jira integration for issue tracking, project management, and agile workflows
- Confluence integration for documentation and knowledge management
- Support for common Atlassian operations like searching, creating, and updating content
- Comprehensive API coverage for both Jira and Confluence functionalities

The server has been added following the repository's guidelines:
- Maintained alphabetical ordering within its category
- Included clear description of functionality
- Followed existing formatting and style
- Added appropriate links to the repository

This addition will help users integrate Atlassian tools into their MCP workflows, enhancing project management and documentation capabilities.