### PR TITLE
MCP Server for JDBC

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [xing5/mcp-google-sheets](https://github.com/xing5/mcp-google-sheets) 🐍 ☁️ - A Model Context Protocol server for interacting with Google Sheets. This server provides tools to create, read, update, and manage spreadsheets through the Google Sheets API.
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.
 - [zilliztech/mcp-server-milvus](https://github.com/zilliztech/mcp-server-milvus) 🐍 🏠 ☁️ - MCP Server for Milvus / Zilliz, making it possible to interact with your database.
+- [openlink/mcp-server-jdbc](https://github.com/OpenLinkSoftware/mcp-jdbc-server) 🐍 🏠 - An MCP server for generic Database Management System (DBMS) Connectivity via the Java Database Connectivity (JDBC) protocol
 
 ### 📊 <a name="data-platforms"></a>Data Platforms
 


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->
Added JDBC (Open Database Connectivity) MCP Servers to the Reference Servers list.
## Description
JDBC MCP Server that provide generic data connectivity using existing JDBC Drivers (Connectors) provided by any DBMS. These connectors work with any JDBC Driver.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: database management system (dbms)<!-- e.g., filesystem, github -->
- Changes to: resources <!-- e.g., tools, resources, prompts -->

## Motivation and Context
A Generic MCP Server that connects to JDBC-accessible databases is a powerful showcase of the practical utility of MCP. Fundamentally, this improves the context of any LLM-based MCP client by providing rich context from database management systems -- in generic, rather than DBMS-specific, manner. 

This MCP server has been developed by JDBC experts knowledgeable in both the usage and driver implementation aspects of the data access protocol.

## How Has This Been Tested?
* Claude Desktop
* Cline extension to Visual Studio Code
* MCP Inspector
