### PR TITLE
Add gin-mcp (Go Gin Framework Bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.
 - [axliupore/mcp-code-runner](https://github.com/axliupore/mcp-code-runner) 📇 🏠 - An MCP server for running code locally via Docker and supporting multiple programming languages.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
+- [gin-mcp](https://github.com/ckanthony/gin-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose existing Gin web framework APIs as MCP tools.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.
 - [axliupore/mcp-code-runner](https://github.com/axliupore/mcp-code-runner) 📇 🏠 - An MCP server for running code locally via Docker and supporting multiple programming languages.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
-- [gin-mcp](https://github.com/ckanthony/gin-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose existing Gin web framework APIs as MCP tools.
+- [ckanthony/gin-mcp](https://github.com/ckanthony/gin-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose existing Gin web framework APIs as MCP tools.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 


### PR DESCRIPTION
Adds `gin-mcp` to the list of MCP tools/libraries.

**[gin-mcp](https://github.com/ckanthony/gin-mcp)** is a Go library that provides a zero-configuration bridge to automatically expose existing Gin web framework APIs as MCP tools. It helps developers connect their backend services to MCP clients like Cursor with minimal effort.

Key features:
- Automatic route discovery and basic schema inference.
- Mounts directly onto an existing `gin.Engine`.
- Option to register custom schemas and filter exposed endpoints.