### PR TITLE
Add new Webhook Tester MCP server under Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [axliupore/mcp-code-runner](https://github.com/axliupore/mcp-code-runner) 📇 🏠 - An MCP server for running code locally via Docker and supporting multiple programming languages.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
 - [ckanthony/gin-mcp](https://github.com/ckanthony/gin-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose existing Gin web framework APIs as MCP tools.
+- [Webhook Tester MCP](https://github.com/alimo7amed93/webhook-tester-mcp)  🐍 🚀 ☁️ – A FastMCP-based server for interacting with webhook-test.com. Enables users to create, retrieve, and delete webhooks locally using Claude.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [axliupore/mcp-code-runner](https://github.com/axliupore/mcp-code-runner) 📇 🏠 - An MCP server for running code locally via Docker and supporting multiple programming languages.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
 - [ckanthony/gin-mcp](https://github.com/ckanthony/gin-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose existing Gin web framework APIs as MCP tools.
-- [Webhook Tester MCP](https://github.com/alimo7amed93/webhook-tester-mcp)  🐍 🚀 ☁️ – A FastMCP-based server for interacting with webhook-test.com. Enables users to create, retrieve, and delete webhooks locally using Claude.
+- [alimo7amed93/webhook-tester-mcp](https://github.com/alimo7amed93/webhook-tester-mcp)  🐍 ☁️ – A FastMCP-based server for interacting with webhook-test.com. Enables users to create, retrieve, and delete webhooks locally using Claude.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 


### PR DESCRIPTION
Add new Webhook Tester MCP server under Developer Tools.

A FastMCP server for interacting with webhook-test.com, designed to automate and manage Webhook URLs. It enables users to create, retrieve, and delete webhooks. Tested with demo using Claude.