### PR TITLE
Add geoserver-mcp to Location section

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
 - [ipfind/ipfind-mcp-server](https://github.com/ipfind/ipfind-mcp-server) 🐍 ☁️ - IP Address location service using the [IP Find](https://ipfind.com) API
-- [geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) – 🏠 A Model Context Protocol (MCP) server implementation that connects LLMs to the GeoServer REST API, enabling AI assistants to interact with geospatial data and services.
+- [mahdin75/geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) 🏠 – A Model Context Protocol (MCP) server implementation that connects LLMs to the GeoServer REST API, enabling AI assistants to interact with geospatial data and services.
 
 ### 🎯 <a name="marketing"></a>Marketing
 

--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
 - [ipfind/ipfind-mcp-server](https://github.com/ipfind/ipfind-mcp-server) 🐍 ☁️ - IP Address location service using the [IP Find](https://ipfind.com) API
+- [geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) – 🏠 A Model Context Protocol (MCP) server implementation that connects LLMs to the GeoServer REST API, enabling AI assistants to interact with geospatial data and services.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
This PR adds my MCP server implementation [geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) to the Location section. It connects LLMs to the GeoServer REST API, allowing AI assistants to interact with geospatial data and services.
