### PR TITLE
Added link to domain-lookup-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [HenryHaoson/Yuque-MCP-Server](https://github.com/HenryHaoson/Yuque-MCP-Server) - 📇 ☁️ A Model-Context-Protocol (MCP) server for integrating with Yuque API, allowing AI models to manage documents, interact with knowledge bases, search content, and access analytics data from the Yuque platform.
 - [tumf/web3-mcp](https://github.com/tumf/web3-mcp) 🐍 ☁️ - An MCP server implementation wrapping Ankr Advanced API. Access to NFT, token, and blockchain data across multiple chains including Ethereum, BSC, Polygon, Avalanche, and more.
 - [danielkennedy1/pdf-tools-mcp](https://github.com/danielkennedy1/pdf-tools-mcp) 🐍 - PDF download, view & manipulation utilities.
+- [dotemacs/domain-lookup-mcp](https://github.com/dotemacs/domain-lookup-mcp) 🏎️ - Domain name lookup service, first via [RDAP](https://en.wikipedia.org/wiki/Registration_Data_Access_Protocol) and then as a fallback via [WHOIS](https://en.wikipedia.org/wiki/WHOIS)
 
 ## Frameworks
 


### PR DESCRIPTION
The server looks up a single or a group of domain names and reports if they are `registered` or `available`.

First via RDAP and if RDAP isn't available (since WHOIS is officially being deprecated, but not all the NICs migrated to RDAP), then fall back to WHOIS.