### PR TITLE
Add official Hydrolix MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.
 - [zilliztech/mcp-server-milvus](https://github.com/zilliztech/mcp-server-milvus) 🐍 🏠 ☁️ - MCP Server for Milvus / Zilliz, making it possible to interact with your database.
 - [openlink/mcp-server-jdbc](https://github.com/OpenLinkSoftware/mcp-jdbc-server) 🐍 🏠 - An MCP server for generic Database Management System (DBMS) Connectivity via the Java Database Connectivity (JDBC) protocol
+- [hydrolix/mcp-hydrolix](https://github.com/hydrolix/mcp-hydrolix) 🎖️ 🐍 ☁️ - Hydrolix time-series datalake integration providing schema exploration and query capabilities to LLM-based workflows.
 
 ### 📊 <a name="data-platforms"></a>Data Platforms
 


### PR DESCRIPTION
Adds https://github.com/hydrolix/mcp-hydrolix. Unfortunately, I only speak English and will need some help with the localization for the other READMEs.

See also https://glama.ai/mcp/servers/@hydrolix/mcp-hydrolix