### PR TITLE
Add code-to-tree server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
   * 🦀 – Rust codebase
   * #️⃣ - C# Codebase
   * ☕ - Java codebase
+  * 🌊 – C/C++ codebase
 * scope
   * ☁️ - Cloud Service
   * 🏠 - Local Service
@@ -220,6 +221,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 - [doggybee/mcp-server-leetcode](https://github.com/doggybee/mcp-server-leetcode) 📇 ☁️ - An MCP server that enables AI models to search, retrieve, and solve LeetCode problems. Supports metadata filtering, user profiles, submissions, and contest data access.
 - [jinzcdev/leetcode-mcp-server](https://github.com/jinzcdev/leetcode-mcp-server) 📇 ☁️ - MCP server enabling automated access to **LeetCode**'s programming problems, solutions, submissions and public data with optional authentication for user-specific features (e.g., notes), supporting both `leetcode.com` (global) and `leetcode.cn` (China) sites.
 - [juehang/vscode-mcp-server](https://github.com/juehang/vscode-mcp-server) 📇 🏠 - A MCP Server that allows AI such as Claude to read from the directory structure in a VS Code workspace, see problems picked up by linter(s) and the language server, read code files, and make edits.
+- [micl2e2/code-to-tree](https://github.com/micl2e2/code-to-tree) 🌊 🏠📟 🐧🪟🍎 - A single-binary MCP server that converts source code into AST, regardless of language.
 
 ### 🖥️ <a name="command-line"></a>Command Line
 


### PR DESCRIPTION
A server using C SDK mentioned in https://github.com/punkpeye/awesome-mcp-devtools?tab=readme-ov-file#cc, it is used to help LLM convert code snippets into corresponding AST.

Could you help take a look? @punkpeye 