### PR TITLE
Add new mashh-lab/mcp-agent-proxy server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Integration with communication platforms for message management and channel oper
 - [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) 🐍 🏎️ - An MCP server for searching your personal WhatsApp messages, contacts and sending messages to individuals or groups
 - [line/line-bot-mcp-server](https://github.com/line/line-bot-mcp-server) 🎖 📇 ☁️ - MCP Server for Integrating LINE Official Account
 - [MarkusPfundstein/mcp-gsuite](https://github.com/MarkusPfundstein/mcp-gsuite) 🐍 ☁️ - Integration with gmail and Google Calendar.
+- [mashh-lab/mcp-agent-proxy](https://github.com/mashh-lab/mcp-agent-proxy) 🤖🕸️ - Expose agents across different servers as MCP tools, enabling complex agent networks and coordination.
 - [modelcontextprotocol/server-bluesky](https://github.com/keturiosakys/bluesky-context-server) 📇 ☁️ - Bluesky instance integration for querying and interaction
 - [modelcontextprotocol/server-slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack) 📇 ☁️ - Slack workspace integration for channel management and messaging
 - [korotovsky/slack-mcp-server](https://github.com/korotovsky/slack-mcp-server) 📇 ☁️ - The most powerful MCP server for Slack Workspaces.


### PR DESCRIPTION
[mashh-lab/mcp-agent-proxy](https://github.com/mashh-lab/mcp-agent-proxy) is an MCP server that exposes local and remote agents across different servers as MCP tools.