### PR TITLE
Added Label Studio MCP to data science tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [kdqed/zaturn](https://github.com/kdqed/zaturn) 🐍 🏠 🪟 🐧 🍎 - Link multiple data sources (SQL, CSV, Parquet, etc.) and ask AI to analyze the data for insights and visualizations.
 - [mckinsey/vizro-mcp](https://github.com/mckinsey/vizro/tree/main/vizro-mcp) 🎖️ 🐍 🏠 - Tools and templates to create validated and maintainable data charts and dashboards.
 - [growthbook/growthbook-mcp](https://github.com/growthbook/growthbook-mcp) 🎖️ 📇 🏠 🪟 🐧 🍎 — Tools for creating and interacting with GrowthBook feature flags and experiments.
+- [HumanSignal/label-studio-mcp-server](https://github.com/HumanSignal/label-studio-mcp-server) 🎖️ 🐍 ☁️ 🪟 🐧 🍎 - Create, manage, and automate Label Studio projects, tasks, and predictions for data labeling workflows.
 
 ### 📟 <a name="embedded-system"></a>Embedded System
 


### PR DESCRIPTION
# Add Label Studio MCP Server to Data Science Tools Section
## Description
This PR adds the HumanSignal/label-studio-mcp-server to the Data Science Tools section of the README.md.
## Details
- Added entry for HumanSignal/label-studio-mcp-server
- Placed in alphabetical order within the Data Science Tools section
- Includes tags: 🎖️ 🐍 ☁️ 🪟 🐧 🍎 (Official, Python codebase, Cloud Service (local or cloud), Windows, Linux, macOS)
- Added a description highlighting project, task, and prediction management for Label Studio data labeling workflows
## Features
- Create, manage, and automate Label Studio projects, tasks, and predictions
- Streamlines data labeling workflows for machine learning and annotation teams
- Supports integration with LLMs and automation tools via MCP
This contribution follows the guidelines outlined in CONTRIBUTING.md.