### PR TITLE
Add intlayer into coding agent list

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [automateyournetwork/pyATS_MCP](https://github.com/automateyournetwork/pyATS_MCP) - Cisco pyATS server enabling structured, model-driven interaction with network devices.
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
 - [tufantunc/ssh-mcp](https://github.com/tufantunc/ssh-mcp) 📇 🏠 🐧 🪟 - MCP server exposing SSH control for Linux and Windows servers via Model Context Protocol. Securely execute remote shell commands with password or SSH key authentication.
+- [aymericzip/intlayer](https://github.com/aymericzip/intlayer) 📇 ☁️ 🏠 - A MCP Server that enhance your IDE with AI-powered assistance for Intlayer i18n / CMS tool: smart CLI access, access to the docs.
 
 ### 💬 <a name="communication"></a>Communication
 


### PR DESCRIPTION
# [@intlayer/mcp](https://www.npmjs.com/package/@intlayer/mcp) – MCP server for i18n / CMS solution 

The `@intlayer/mcp` server offers seamless IDE integration for developers using [Intlayer](https://github.com/aymericzip/intlayer), an internationalization library tailored for modern JavaScript and TypeScript projects using AI.

By connecting your IDE to this MCP server (e.g., in [Cursor](https://www.cursor.so)), you get instant access to:

 **CLI integration** – Inline guidance and command completion for Intlayer’s CLI tooling. (list / build / pull / push / fill dictionaries)
***Integrated access to the documentation** – Provide access to the Intlayer doc to the IDE

 – To add into your `.cursor/mcp.json`.

Ideal for teams working with multilingual content, component-based architectures, and modern frameworks like Next.js. Perfectly bridges AI and content localization.