### PR TITLE
Add RepoMapper MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 - [jinzcdev/leetcode-mcp-server](https://github.com/jinzcdev/leetcode-mcp-server) 📇 ☁️ - MCP server enabling automated access to **LeetCode**'s programming problems, solutions, submissions and public data with optional authentication for user-specific features (e.g., notes), supporting both `leetcode.com` (global) and `leetcode.cn` (China) sites.
 - [juehang/vscode-mcp-server](https://github.com/juehang/vscode-mcp-server) 📇 🏠 - A MCP Server that allows AI such as Claude to read from the directory structure in a VS Code workspace, see problems picked up by linter(s) and the language server, read code files, and make edits.
 - [micl2e2/code-to-tree](https://github.com/micl2e2/code-to-tree) 🌊 🏠 📟 🐧 🪟 🍎 - A single-binary MCP server that converts source code into AST, regardless of language.
+- [pdavis68/RepoMapper](https://github.com.mcas.ms/pdavis68/RepoMapper) 🐧 🪟 🍎 - An MCP server (and command-line tool) to provide a dynamic map of chat-related files from the repository with their function prototypes and related files in order of relevance. Based on the "Repo Map" functionality in Aider.chat
 
 ### 🖥️ <a name="command-line"></a>Command Line
 


### PR DESCRIPTION
An MCP to give your chat agent a better understanding of your application's architecture in the context of the current chat. Based on Aider's Repo Map functionality.

[Github Repo](https://github.com.mcas.ms/pdavis68/RepoMapper)

Instructions for setting up as an [MCP Server](https://github.com.mcas.ms/pdavis68/RepoMapper#running-as-an-mcp-server)

