### PR TITLE
Add Stape and GTM MCP servers under Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,9 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [marketplaceadpros/amazon-ads-mcp-server](https://github.com/MarketplaceAdPros/amazon-ads-mcp-server) 📇 ☁️  - Enables tools to interact with Amazon Advertising, analyzing campaign metrics and configurations.
 - [open-strategy-partners/osp_marketing_tools](https://github.com/open-strategy-partners/osp_marketing_tools) 🐍 🏠 - A suite of marketing tools from Open Strategy Partners including writing style, editing codes, and product marketing value map creation.
 - [pipeboard-co/meta-ads-mcp](https://github.com/pipeboard-co/meta-ads-mcp) 🐍 ☁️ 🏠 - Enables AI agents to monitor and optimize Meta ad performance, analyze campaign metrics, adjust audience targeting, manage creative assets, and make data-driven recommendations for ad spend and campaign settings through seamless Graph API integration.
+- [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) ☁️ 🧠 – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
+- [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) ☁️ 🔐 – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
+
 
 ### 📊 <a name="monitoring"></a>Monitoring
 

--- a/README.md
+++ b/README.md
@@ -751,8 +751,8 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [marketplaceadpros/amazon-ads-mcp-server](https://github.com/MarketplaceAdPros/amazon-ads-mcp-server) 📇 ☁️  - Enables tools to interact with Amazon Advertising, analyzing campaign metrics and configurations.
 - [open-strategy-partners/osp_marketing_tools](https://github.com/open-strategy-partners/osp_marketing_tools) 🐍 🏠 - A suite of marketing tools from Open Strategy Partners including writing style, editing codes, and product marketing value map creation.
 - [pipeboard-co/meta-ads-mcp](https://github.com/pipeboard-co/meta-ads-mcp) 🐍 ☁️ 🏠 - Enables AI agents to monitor and optimize Meta ad performance, analyze campaign metrics, adjust audience targeting, manage creative assets, and make data-driven recommendations for ad spend and campaign settings through seamless Graph API integration.
-- [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) ☁️ 🧠 – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
-- [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) ☁️ 🔐 – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
+- [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
+- [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 
 
 ### 📊 <a name="monitoring"></a>Monitoring


### PR DESCRIPTION
This PR adds two MCP servers under the 🎯 Marketing category:

- [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server): An MCP server for interacting with the Stape API using AI tools like Claude and IDEs like Cursor.
- [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server): A Google OAuth-enabled MCP server exposing the GTM API for remote access to containers, tags, and workspaces.

These additions support server-side tracking, automation, and marketing analytics use cases.