### PR TITLE
Add Cloudbet Sports MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ Tools for accessing sports-related data, results, and statistics.
 - [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs
 - [RobSpectre/mvf1](https://github.com/RobSpectre/mvf1) 🐍 ☁️ - MCP server that controls [MultiViewer](https://multiviewer.app), an app for watching motorsports like Formula 1, World Endurance Championship, IndyCar and others. 
 - [willvelida/mcp-afl-server](https://github.com/willvelida/mcp-afl-server) ☁️ - MCP server that integrates with the Squiggle API to provide information on Australian Football League teams, ladder standings, results, tips, and power rankings.
+- [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server) 🏎️ ☁️ – Access structured sports data via the Cloudbet API. Query upcoming events, live odds, stake limits, and market info across soccer, basketball, tennis, esports, and more.
 
 
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management


### PR DESCRIPTION
Adds [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server), a Go-based MCP server that provides access to structured sports and esports data.

Key features:
* Supports querying for fixtures, odds, stake limits, and market data
* Supports football, basketball, tennis, MMA, etc. and esports
* Implements fuzzy matching for league query resolution
* **No API key required — free and anonymous access**
