### PR TITLE
Add Mercado Libre & Mercado Pago official MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,8 @@ Interact with Git repositories and version control platforms. Enables repository
 - [marcelmarais/Spotify](https://github.com/marcelmarais/spotify-mcp-server) - 📇 🏠 Control Spotify playback and manage playlists.
 - [MarkusPfundstein/mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) 🐍 ☁️ 🏠 - Interacting with Obsidian via REST API
 - [mediar-ai/screenpipe](https://github.com/mediar-ai/screenpipe) - 🎖️ 🦀 🏠 🍎 Local-first system capturing screen/audio with timestamped indexing, SQL/embedding storage, semantic search, LLM-powered history analysis, and event-triggered actions - enables building context-aware AI agents through a NextJS plugin ecosystem.
+- [Mercado Libre](https://mcp.mercadolibre.com/) 🎖️ ☁️ - Official MCP Server for Mercado Libre, to enhance developer experience integrating with the Latin American e-commerce platform
+- [Mercado Pago](https://mcp.mercadopago.com/) 🎖️ ☁️ - Official MCP Server for Mercado Pago, to enhance developer experience integrating with the Latin American payment platform
 - [modelcontextprotocol/server-everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) 📇 🏠 - MCP server that exercises all the features of the MCP protocol
 - [mrjoshuak/godoc-mcp](https://github.com/mrjoshuak/godoc-mcp) 🏎️ 🏠 - Token-efficient Go documentation server that provides AI assistants with smart access to package docs and types without reading entire source files
 - [Mtehabsim/ScreenPilot](https://github.com/Mtehabsim/ScreenPilot) 🐍 🏠 - enables AI to fully control and access GUI interactions by providing tools for mouse and keyboard, ideal for general automation, education, and experimentation.


### PR DESCRIPTION
# Description
Add official MCP Servers for Mercado Libre (http://mcp.mercadolibre.com/) & Mercado Pago (http://mcp.mercadopago.com/)

# Servers Details
Add new official MCP Servers for Mercado Libre & Mercado Pago, to enhance developer experience integrating with our e-commerce & payments solutions.
Both servers are hosted remotely by Mercadolibre supporting new Streamable HTTP Transport.
Details on how to connect to the server and example use cases are provided in [Mercado Libre's MCP Server](http://mcp.mercadolibre.com/) and [Mercado Pago MCP Server](http://mcp.mercadopago.com/) doc sites.