### PR TITLE
Add clippy MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.
+- [neilberkman/clippy](https://github.com/neilberkman/clippy) 🏎️ 🏠 🍎 - MCP server for macOS clipboard operations. Have Claude draft emails/documents and place them in your clipboard for pasting into any app. Also handles files and recent downloads.
 - [Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal) 🐍 🏠 ☁️ - Access any storage with Apache OpenDAL™
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech


### PR DESCRIPTION
Adding clippy - an MCP server for macOS clipboard operations that enables AI assistants to interact with the system clipboard. Allows drafting emails/documents and placing them directly in clipboard for pasting into any application.