### PR TITLE
Add Maven Tools MCP to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [jeannier/homebrew-mcp](https://github.com/jeannier/homebrew-mcp) 🐍 🏠 🍎 - Control your macOS Homebrew setup using natural language via this MCP server. Simply manage your packages, or ask for suggestions, troubleshoot brew issues etc.
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.
+- [arvindand/maven-tools-mcp](https://github.com/arvindand/maven-tools-mcp) ☕ 🏠 🍎 🪟 🐧 - Maven Central dependency intelligence for JVM build tools. Supports Maven, Gradle, SBT, Mill with Context7 integration for documentation support.
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.


### PR DESCRIPTION
## Summary

Add Maven Tools MCP server to the Developer Tools section of awesome-mcp-servers.

## Changes

- Added Maven Tools MCP entry in correct alphabetical order in Developer Tools section
- Entry follows the established format with appropriate emojis and concise description
- Highlights Maven Central dependency intelligence for all JVM build tools

## Server Details

**Maven Tools MCP** provides:
- Maven Central dependency intelligence for JVM build tools
- Support for Maven, Gradle, SBT, Mill, and other JVM build systems
- Context7 integration for documentation support
- Dependency analysis, version checking, and project health assessment
- Multi-platform support (macOS, Windows, Linux)

Repository: https://github.com/arvindand/maven-tools-mcp
Docker: `arvindand/maven-tools-mcp:latest`