### PR TITLE
Add xxczaki/local-history-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.
 - [Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal) 🐍 🏠 ☁️ - Access any storage with Apache OpenDAL™
+- [xxczaki/local-history-mcp](https://github.com/xxczaki/local-history/mcp) 📇 🏠 🍎 🪟 🐧  - MCP server for accessing VS Code/Cursor Local History
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 


### PR DESCRIPTION
Added `xxczaki/local-history-mcp` to the list – an MCP server that allows AI tools to access VS Code/Cursor's Local History. Can be useful for file recovery, like in this case:

<img width="400" alt="Demo" src="https://github.com/user-attachments/assets/abf9b913-c46c-4fe2-b6f2-ccd081d14832" />
