### PR TITLE
Add piston-mcp to Code Execution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Code execution servers. Allow LLMs to execute code in a secure environment, e.g.
 - [r33drichards/mcp-js](https://github.com/r33drichards/mcp-js) 🦀 🏠 🐧 🍎 - A Javascript code execution sandbox that uses v8 to isolate code to run AI generated javascript locally without fear. Supports heap snapshotting for persistent sessions.
 - [yepcode/mcp-server-js](https://github.com/yepcode/mcp-server-js) 🎖️ 📇 ☁️ - Execute any LLM-generated code in a secure and scalable sandbox environment and create your own MCP tools using JavaScript or Python, with full support for NPM and PyPI packages
 - [dagger/container-use](https://github.com/dagger/container-use) 🏎️ 🏠 🐧 🍎 🪟 - Containerized environments for coding agents. Multiple agents can work independently, isolated in fresh containers and git branches. No conflicts, many experiments. Full execution history, terminal access to agent environments, git workflow. Any agent/model/infra stack.
+- [alvii147/piston-mcp](https://github.com/alvii147/piston-mcp) 🐍 ☁️ 🐧 🍎 🪟 - MCP server that lets LLMs execute code through the Piston remote code execution engine, with a zero-config `uv` setup and a ready-to-use Claude Desktop config example.
 
 ### 🤖 <a name="coding-agents"></a>Coding Agents
 


### PR DESCRIPTION
Hello, I've added [piston-mcp](https://github.com/alvii147/piston-mcp) to the list of code execution MCPs. piston-mcp allows users to connect LLMs to the publicly deployed [Piston](https://github.com/engineer-man/piston) code execution server. Let me know if you have any questions. Thanks!