### PR TITLE
Added MCPDocSearch server to Knowledge & Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ Integration with gaming related data, game engines, and services
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.
 
 - [0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer) 📕 ☁️ - AI Summarization MCP Server, Support for multiple content types: Plain text, Web pages, PDF documents, EPUB books, HTML content
+- [alizdavoodi/MCPDocSearch](https://github.com/alizdavoodi/MCPDocSearch) 🐍 🏠 - Crawl websites and generate searchable Markdown documentation with semantic search capabilities using vector embeddings and caching
 - [apecloud/ApeRAG](https://github.com/apecloud/ApeRAG) 🐍 ☁️ 🏠 - Production-ready RAG platform combining Graph RAG, vector search, and full-text search. Best choice for building your own Knowledge Graph and for Context Engineering
 - [chatmcp/mcp-server-chatsum](https://github.com/chatmcp/mcp-server-chatsum) - Query and summarize your chat messages with AI prompts.
 - [CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh) 📇 🏠 - Enhanced graph-based memory with a focus on AI role-play and story generation


### PR DESCRIPTION
This PR adds MCPDocSearch to the Knowledge & Memory section of the awesome MCP servers list.

MCPDocSearch is a Python-based MCP server that crawls websites to generate searchable Markdown documentation with semantic search capabilities using vector embeddings and caching. It fits well in the Knowledge & Memory category as it enables persistent storage and retrieval of structured documentation.

The entry follows the established format and is placed in alphabetical order within the section.