### PR TITLE
Add IO aerospace MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 ### 🚀 <a name="aerospace-and-astrodynamics"></a>Aerospace & Astrodynamics
 
-- [IO-Aerospace-software-engineering/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
+- [IO-Aerospace-software-community/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 


### PR DESCRIPTION
This pull request adds a new section to the `README.md` to highlight MCP servers for aerospace and astrodynamics, and includes a new server listing focused on this domain.

New content and server listing:

* Added an "Aerospace & Astrodynamics" section to the `README.md` to categorize MCP servers relevant to aerospace.

* Listed the `IO-Aerospace-software-community/mcp-server`, a .NET-based MCP server for aerospace and astrodynamics tasks, with details on its features and deployment options.