### PR TITLE
Add triplyfy-mcp to servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ Access to travel and transportation information. Enables querying schedules, rou
 - [Pradumnasaraf/aviationstack-mcp](https://github.com/Pradumnasaraf/aviationstack-mcp) 🐍 ☁️ 🍎 🪟 🐧 - An MCP server using the AviationStack API to fetch real-time flight data including airline flights, airport schedules, future flights and aircraft types.
 - [r-huijts/ns-mcp-server](https://github.com/r-huijts/ns-mcp-server) 📇 ☁️ - Access Dutch Railways (NS) travel information, schedules, and real-time updates
 - [skedgo/tripgo-mcp-server](https://github.com/skedgo/tripgo-mcp-server) 📇 ☁️ - Provides tools from the TripGo API for multi-modal trip planning, transport locations, and public transport departures, including real-time information.
+- [helpful-AIs/triplyfy-mcp](https://github.com/helpful-AIs/triplyfy-mcp) 📇 ☁️ - An MCP server that lets LLMs plan and manage itineraries with interactive maps in Triplyfy; manage itineraries, places and notes, and search/save flights.
 - [srinath1510/alltrails-mcp-server](https://github.com/srinath1510/alltrails-mcp-server) 🐍 ☁️ - A MCP server that provides access to AllTrails data, allowing you to search for hiking trails and get detailed trail information
 
 ### 🔄 <a name="version-control"></a>Version Control


### PR DESCRIPTION
Add [triplyfy-mcp](https://github.com/helpful-AIs/triplyfy-mcp), an MCP server to plan and manage itineraries in Triplyfy with interactive maps. Users can create/read/update trips, organize places and notes via drag-and-drop, and search/save flights.
