### PR TITLE
Add deploy-mcp to Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [davidan90/time-node-mcp](https://github.com/davidan90/time-node-mcp) 📇 🏠 - Timezone-aware date and time operations with support for IANA timezones, timezone conversion, and Daylight Saving Time handling.
 - [davidlin2k/pox-mcp-server](https://github.com/davidlin2k/pox-mcp-server) 🐍 🏠 - MCP server for the POX SDN controller to provides network control and management capabilities.
 - [delano/postman-mcp-server](https://github.com/delano/postman-mcp-server) 📇 ☁️ - Interact with [Postman API](https://www.postman.com/postman/postman-public-workspace/)
+- [deploy-mcp/deploy-mcp](https://github.com/alexpota/deploy-mcp) 📇 ☁️ 🏠 - Universal deployment tracker for AI assistants with live status badges and deployment monitoring
 - [docker/hub-mcp](https://github.com/docker/hub-mcp) 🎖️ 📇 ☁️ 🏠 - Official MCP server to interact with Docker Hub, providing access to repositories, hub search and Docker Hardened Images
 - [endorhq/cli](https://github.com/endorhq/cli) 📇 ☁️ 🏠 🪟 🐧 🍎 - Endor lets your AI agents run services like MariaDB, Postgres, Redis, Memcached, Alpine, or Valkey in isolated sandboxes. Get pre-configured applications that boot in less than 5 seconds.
 - [flipt-io/mcp-server-flipt](https://github.com/flipt-io/mcp-server-flipt) 📇 🏠 - Enable AI assistants to interact with your feature flags in [Flipt](https://flipt.io).


### PR DESCRIPTION
## Summary

  Adding deploy-mcp to the Developer Tools section following the contributing guidelines.

  deploy-mcp provides universal deployment tracking for AI assistants with live status badges and deployment monitoring for Vercel, Netlify, and Cloudflare Pages.

  ## Details

  - **Repository:** https://github.com/alexpota/deploy-mcp
  - **Category:** Developer Tools (deployment monitoring enhances development workflow)
  - **Alphabetical position:** Correctly placed between delano/postman-mcp-server and docker/hub-mcp
  - **Format compliance:** Follows existing format with proper emoji indicators (📇 ☁️ 🏠)

  ## Key Features

  - Live deployment status badges at https://deploy-mcp.io
  - Real-time webhook integration for deployment updates
  - MCP tools for AI assistants to query deployment status
  - Support for Vercel, Netlify, and Cloudflare Pages