### PR TITLE
Add OMOP MCP server for clinical terminology mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [longevity-genie/synergy-age-mcp](https://github.com/longevity-genie/synergy-age-mcp) 🎖️ 🐍 🏠 ☁️ - MCP server for the SynergyAge database of synergistic and antagonistic genetic interactions in longevity.
 - [wso2/fhir-mcp-server](https://github.com/wso2/fhir-mcp-server) 🐍 🏠 ☁️ - Model Context Protocol server for Fast Healthcare Interoperability Resources (FHIR) APIs. Provides seamless integration with FHIR servers, enabling AI assistants to search, retrieve, create, update, and analyze clinical healthcare data with SMART-on-FHIR authentication support.
 - [JamesANZ/medical-mcp](https://github.com/JamesANZ/medical-mcp) 📇 🏠 - An MCP server that provides access to medical information, drug databases, and healthcare resources. Enables AI assistants to query medical data, drug interactions, and clinical guidelines.
+- [OHNLP/omop_mcp](https://github.com/OHNLP/omop_mcp) 🐍 🏠 ☁️ - Map clinical terminology to OMOP concepts using LLMs for healthcare data standardization and interoperability.
 
 ### 📂 <a name="browser-automation"></a>Browser Automation
 


### PR DESCRIPTION
## Summary
- Adding [OMOP MCP server](https://github.com/OHNLP/omop_mcp) to the Biology, Medicine and Bioinformatics section.

## Description
- Map clinical terminology to OMOP concepts for healthcare data standardization and interoperability. This server enables AI agents to work with medical vocabularies (SNOMED, LOINC, RxNorm, etc.) and convert them to standardized OMOP concepts.

- The server underwent evaluation by medical experts with hundreds of medical concepts for usability; a pre-print for this research is currently under review.