### PR TITLE
Add xiaohongshu-mcp to Community section

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -77,6 +77,7 @@
 * ☁️ - [云平台](#cloud-platforms)
 * 🤖 - [编程智能体](#coding-agents)
 * 🖥️ - [命令行](#command-line)
+* 🌍 - [社区](#community)
 * 💬 - [社交](#communication)
 * 👤 - [客户数据平台](#customer-data-platforms)
 * 🗄️ - [数据库](#databases)
@@ -183,6 +184,12 @@ Web 内容访问和自动化功能。支持以 AI 友好格式搜索、抓取和
 - [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) 📇 🏠 - 使用`run_command`和`run_script`工具运行任何命令。
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - 具有安全执行和可定制安全策略的命令行界面
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) 实现模型上下文协议 (MCP) 的安全 shell 命令执行服务器
+
+### 🌍 <a name="community"></a>社区
+
+与社区和社交平台集成，实现内容创作和互动。使AI模型能够与社区和社交媒体服务进行交互。
+
+- [xpzouying/xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) 🐍 ☁️ - 小红书 MCP 服务器 - 支持登录、发布图文、获取推荐列表、搜索内容
 
 ### 💬 <a name="communication"></a>社交
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 👨‍💻 - [Code Execution](#code-execution)
 * 🤖 - [Coding Agents](#coding-agents)
 * 🖥️ - [Command Line](#command-line)
+* 🌍 - [Community](#community)
 * 💬 - [Communication](#communication)
 * 👤 - [Customer Data Platforms](#customer-data-platforms)
 * 🗄️ - [Databases](#databases)
@@ -289,6 +290,12 @@ Run commands, capture output and otherwise interact with shells and command line
 - [tufantunc/ssh-mcp](https://github.com/tufantunc/ssh-mcp) 📇 🏠 🐧 🪟 - MCP server exposing SSH control for Linux and Windows servers via Model Context Protocol. Securely execute remote shell commands with password or SSH key authentication.
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) - A secure shell command execution server implementing the Model Context Protocol (MCP)
 - [wonderwhy-er/DesktopCommanderMCP](https://github.com/wonderwhy-er/DesktopCommanderMCP) 📇 🏠 🍎 🪟 🐧 - A swiss-army-knife that can manage/execute programs and read/write/search/edit code and text files.
+
+### 🌍 <a name="community"></a>Community
+
+Integration with social and community platforms for content creation and interaction. Enables AI models to engage with community and social media services.
+
+- [xpzouying/xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) 🐍 ☁️ - xiaohongshu/RedNote MCP server - Login, publish posts (text/image), get recommendations, search content
 
 ### 💬 <a name="communication"></a>Communication
 


### PR DESCRIPTION
# Summary

- Add new Community section for social and community platforms integration
- Add xiaohongshu-mcp (小红书 MCP) server to the Community section

# Details

This PR adds my xiaohongshu-mcp server to the awesome-mcp-servers list. The server provides integration with xiaohongshu/RedNote platform.

# Features supported:

- Login functionality
- Publish posts (currently supports text/image posts)
- Get recommendation feed
- Search content by keywords

The Community section is added before the Communication section to differentiate between social/community platforms and communication/messaging tools.

# Changes
- Added new Community section in both English (README.md) and Chinese (README-zh.md) versions
- Added xiaohongshu-mcp server entry with appropriate description and features