### PR TITLE
Add Django REST Framework MCP to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ Interact with Git repositories and version control platforms. Enables repository
 > [!NOTE]
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 
+- [Django REST Framework MCP](https://github.com/zacharypodbela/djangorestframework-mcp) 🐍 ☁️ - Expose Django REST Framework APIs as MCP tools for LLMs and agentic applications
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript
 


### PR DESCRIPTION
This PR adds Django REST Framework MCP to the Frameworks section of the awesome-mcp-servers list.

## About Django REST Framework MCP

Django REST Framework MCP is a Python library that enables developers to expose Django REST Framework APIs as MCP (Model Context Protocol) tools for LLMs and agentic applications.

Key features:
- Transform any DRF ViewSet into MCP tools with a single decorator `@mcp_viewset()`
- Automatic tool schema generation from DRF serializers
- Preserves existing permissions, authentication, and filtering

I've placed it in the Frameworks section since it's specifically a framework for integrating Django REST Framework with MCP, positioned alphabetically before FastMCP.

- **Repository:** https://github.com/zacharypodbela/djangorestframework-mcp
- **PyPI:** https://pypi.org/project/django-rest-framework-mcp/
- **License:** MIT