### PR TITLE
Add mcp-rubber-duck to Coding Agents category

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 - [rinadelph/Agent-MCP](https://github.com/rinadelph/Agent-MCP) 🐍 🏠 - A framework for creating multi-agent systems using MCP for coordinated AI collaboration, featuring task management, shared context, and RAG capabilities.
 - [stippi/code-assistant](https://github.com/stippi/code-assistant) 🦀 🏠 - Coding agent with basic list, read, replace_in_file, write, execute_command and web search tools. Supports multiple projects concurrently.
 - [tiianhk/MaxMSP-MCP-Server](https://github.com/tiianhk/MaxMSP-MCP-Server) 🐍 🏠 🎵 🎥 - A coding agent for Max (Max/MSP/Jitter), which is a visual programming language for music and multimedia.
+- [nesquikm/mcp-rubber-duck](https://github.com/nesquikm/mcp-rubber-duck) 📇 🏠 ☁️ - An MCP server that bridges to multiple OpenAI-compatible LLMs - your AI rubber duck debugging panel for explaining problems to various AI "ducks" and getting different perspectives
 - [VertexStudio/developer](https://github.com/VertexStudio/developer) 🦀 🏠 🍎 🪟 🐧 - Comprehensive developer tools for file editing, shell command execution, and screen capture capabilities
 
 ### 🖥️ <a name="command-line"></a>Command Line


### PR DESCRIPTION
This PR adds the mcp-rubber-duck MCP server to the Coding Agents category.

mcp-rubber-duck is an MCP server that bridges to multiple OpenAI-compatible LLMs and serves as your AI rubber duck debugging panel. It allows explaining problems to various AI "ducks" and getting different perspectives.

Features:
- 🦆 Multiple LLM provider support (OpenAI, Gemini, Groq, Ollama, etc.)
- 💬 Conversation management with context
- 🏛️ Duck Council - get responses from all LLMs at once  
- 🔗 MCP Bridge support for extended functionality
- 📦 Available on NPM and Docker

The server is properly categorized under Coding Agents as it's specifically designed for programming assistance and debugging workflows.