### PR TITLE
Add src-to-kb MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [SDGLBL/mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code) 🐍 🏠 - An implementation of Claude Code capabilities using MCP, enabling AI code understanding, modification, and project analysis with comprehensive tool support.
 - [sequa-ai/sequa-mcp](https://github.com/sequa-ai/sequa-mcp) 📇 ☁️ 🐧 🍎 🪟 - Stop stitching context for Copilot and Cursor. With Sequa MCP, your AI tools know your entire codebase and docs out of the box.
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Connect any HTTP/REST API server using an Open API spec (v3)
+- [vezlo/src-to-kb](https://github.com/vezlo/src-to-kb) 📇 🏠 ☁️ - Convert source code repositories into searchable knowledge bases with AI-powered search using GPT-5, intelligent chunking, and OpenAI embeddings for semantic code understanding.
 - [spacecode-ai/SpaceBridge-MCP](https://github.com/spacecode-ai/SpaceBridge-MCP) 🐍 🏠 🍎 🐧 - Bring structure and preserve context in vibe coding by automatically tracking issues.
 - [st3v3nmw/sourcerer-mcp](https://github.com/st3v3nmw/sourcerer-mcp) 🏎️ ☁️ - MCP for semantic code search & navigation that reduces token waste
 - [stass/lldb-mcp](https://github.com/stass/lldb-mcp) 🐍 🏠 🐧 🍎 - A MCP server for LLDB enabling AI binary and core file analysis, debugging, disassembling.


### PR DESCRIPTION
## Description
Adds **vezlo/src-to-kb** to the Developer Tools category.

## About src-to-kb
src-to-kb is an MCP server that converts source code repositories into searchable knowledge bases with:
- 🤖 AI-powered search using OpenAI GPT-5
- 📂 Support for 20+ programming languages
- 🔍 Intelligent code chunking with configurable overlap
- 💡 OpenAI embeddings for semantic search
- 🛠️ 7 MCP tools for generating, searching, and managing knowledge bases

## Links
- GitHub: https://github.com/vezlo/src-to-kb
- npm: https://www.npmjs.com/package/@vezlo/src-to-kb

## Placement
Added alphabetically in the Developer Tools section between `snaggle-ai/openapi-mcp-server` and `spacecode-ai/SpaceBridge-MCP`.

Thank you for maintaining this awesome list!