### PR TITLE
Add Console Automation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [misiektoja/kill-process-mcp](https://github.com/misiektoja/kill-process-mcp) 🐍 🏠 🍎 🪟 🐧 - List and terminate OS processes via natural language queries
 - [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) 🐍 🏠 - Command line interface with secure execution and customizable security policies
 - [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) 🐍 🏠 - A DeepSeek MCP-like Server for Terminal
+- [ooples/mcp-console-automation](https://github.com/ooples/mcp-console-automation) 📇 🏠 🍎 🪟 🐧 - Production-ready MCP server for AI-driven console automation and monitoring. 40 tools for session management, SSH, testing, monitoring, and background jobs. Like Playwright for terminal applications.
 - [sonirico/mcp-shell](https://github.com/sonirico/mcp-shell) - 🏎️ 🏠 🍎 🪟 🐧 Give hands to AI. MCP server to run shell commands securely, auditably, and on demand on isolated environments like docker.
 - [tufantunc/ssh-mcp](https://github.com/tufantunc/ssh-mcp) 📇 🏠 🐧 🪟 - MCP server exposing SSH control for Linux and Windows servers via Model Context Protocol. Securely execute remote shell commands with password or SSH key authentication.
 - [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) - A secure shell command execution server implementing the Model Context Protocol (MCP)


### PR DESCRIPTION
Adds Console Automation to the Command Line section - a production-ready MCP server for AI-driven console automation and monitoring.

Repository: https://github.com/ooples/mcp-console-automation
Category: Command Line

Features 40 comprehensive tools for session management, SSH, testing, monitoring, and background jobs.

Added alphabetically in the Command Line section.