### PR TITLE
Add AI Counsel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
 - [JamesANZ/memory-mcp](https://github.com/JamesANZ/memory-mcp) 📇 🏠 - An MCP server that stores and retrieves memories from multiple LLMs using MongoDB. Provides tools for saving, retrieving, adding, and clearing conversation memories with timestamps and LLM identification.
 - [JamesANZ/cross-llm-mcp](https://github.com/JamesANZ/cross-llm-mcp) 📇 🏠 - An MCP server that enables cross-LLM communication and memory sharing, allowing different AI models to collaborate and share context across conversations.
-- [AI Counsel](https://github.com/harrison/ai-counsel) - 🐍 🏠 🍎 🪟 🐧 - Deliberative consensus engine enabling multi-round debate between AI models with structured voting, convergence detection, and persistent decision graph memory.
+- [harrison/ai-counsel](https://github.com/harrison/ai-counsel) - 🐍 🏠 🍎 🪟 🐧 - Deliberative consensus engine enabling multi-round debate between AI models with structured voting, convergence detection, and persistent decision graph memory.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
## Summary
Add AI Counsel to the awesome-mcp-servers list.

AI Counsel is an MCP server that enables true deliberative consensus between AI models through
multi-round structured debate with convergence detection, structured voting, and persistent decision
graph memory.

## Details
- **Repository**: https://github.com/blueman82/ai-counsel
- **Language**: Python
- **Scope**: Local
- **OS Support**: macOS, Windows, Linux
- **Category**: Knowledge & Memory (or Frameworks)

## Changes
- Added AI Counsel entry to README.md in alphabetical order within the appropriate category