### PR TITLE
Add TexMCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,7 @@ Interact with Git repositories and version control platforms. Enables repository
 ### 🏢 <a name="workplace-and-productivity"></a>Workplace & Productivity
 
 - [bivex/kanboard-mcp](https://github.com/bivex/kanboard-mcp) 🏎️ ☁️ 🏠 - A Model Context Protocol (MCP) server written in Go that empowers AI agents and Large Language Models (LLMs) to seamlessly interact with Kanboard. It transforms natural language commands into Kanboard API calls, enabling intelligent automation of project, task, and user management, streamlining workflows, and enhancing productivity.
+- [devroopsaha744/TexMCP](https://github.com/devroopsaha744/TexMCP) 🐍 🏠 - An MCP server that converts LaTeX into high-quality PDF documents. It provides tools for rendering both raw LaTeX input and customizable templates, producing shareable, production-ready artifacts such as reports, resumes, and research papers.
 - [giuseppe-coco/Google-Workspace-MCP-Server](https://github.com/giuseppe-coco/Google-Workspace-MCP-Server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server that seamlessly interacts with your Google Calendar, Gmail, Drive and so on.
 - [MarkusPfundstein/mcp-gsuite](https://github.com/MarkusPfundstein/mcp-gsuite) 🐍 ☁️ - Integration with gmail and Google Calendar.
 - [takumi0706/google-calendar-mcp](https://github.com/takumi0706/google-calendar-mcp) 📇 ☁️ - An MCP server to interface with the Google Calendar API. Based on TypeScript.


### PR DESCRIPTION
## Summary

**What changed:**  
Added one-line entry to `README.md` listing the **TexMCP** MCP server.

**Why:**  
TexMCP converts LaTeX sources into production-quality PDF artifacts (reports, resumes, research papers).  
It fits under the *Workplace & Productivity* category and helps users discover the tool.

**Location:**  
`README.md` — inserted under **"Workplace & Productivity"** in alphabetical order.

**Entry added:**
```
 devroopsaha744/TexMCP  🐍 🏠 - An MCP server that converts LaTeX into high-quality PDF documents. It provides tools for rendering both raw LaTeX input and customizable templates, producing shareable, production-ready artifacts such as reports, resumes, and research papers.
```

**Notes:**
- One server per line and alphabetical order maintained per `CONTRIBUTING.md`.  
- Added the repository links.

---

## Checklist for Reviewers
- [ ] Confirm placement and alphabetical order in *Workplace & Productivity*.  
- [ ] Merge when approved.