### PR TITLE
Add kiarash-portfolio-mcp link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1253,6 +1253,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
 - [imprvhub/mcp-claude-spotify](https://github.com/imprvhub/mcp-claude-spotify) 📇 ☁️ 🏠 - An integration that allows Claude Desktop to interact with Spotify using the Model Context Protocol (MCP).
 - [nanana-app/mcp-server-nano-banana](https://github.com/nanana-app/mcp-server-nano-banana) 🐍 🏠 🍎 🪟 🐧 - AI image generation using Google Gemini's nano banana model.
+- [kiarash-portfolio-mcp](https://kiarash-adl.pages.dev/.well-known/mcp.llmfeed.json) – WebMCP-enabled portfolio with Ed25519 signed discovery. AI agents can query projects, skills, and execute terminal commands. Built on Cloudflare Pages Functions.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds my portfolio's WebMCP server to the registry.

**Features:**
- Ed25519 signed discovery manifest
- 2 tools: `get_project_details`, `run_terminal_command`
- Runs on Cloudflare Pages edge network
- Standard WebMCP format at `/.well-known/mcp.llmfeed.json`

**Live endpoint:** https://kiarash-adl.pages.dev/.well-known/mcp.llmfeed.json