### PR TITLE
Add new MCP server (converting REST API  into MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [paracetamol951/P-Link-MCP](https://github.com/paracetamol951/P-Link-MCP) 🏠 🐧 🍎 ☁️ - Implementation of HTTP 402 (payment required http code) relying on Solana
 - [themesberg/flowbite-mcp](https://github.com/themesberg/flowbite-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server that provides AI assistance for an open-source UI framework based on Tailwind CSS
 - [shadcn/studio MCP](https://shadcnstudio.com/mcp) - Integrate shadcn/studio MCP Server directly into your favorite IDE and craft stunning shadcn/ui Components, Blocks and Pages inspired by shadcn/studio.
+- [bbonnin/openapi-to-mcp](https://github.com/bbonnin/openapi-to-mcp) ☕ 🏠 🍎 🪟 🐧 - MCP server that automatically converts any OpenAPI/Swagger specification into a set of usable MCP tools
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Add new MCP server that  converts any REST API defined with OpenAPI/Swagger into MCP tools. 
It can be used to enable the adoption of the MCP protocol in context where you have multiple REST API, but no time to provide MCP interface for the API.