### PR TITLE
Add Conan MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ckreiling/mcp-server-docker](https://github.com/ckreiling/mcp-server-docker) 🐍 🏠 - Integrate with Docker to manage containers, images, volumes, and networks.
 - [CodeLogicIncEngineering/codelogic-mcp-server](https://github.com/CodeLogicIncEngineering/codelogic-mcp-server) 🎖️ 🐍 ☁️ 🍎 🪟 🐧 - Official MCP server for CodeLogic, providing access to code dependency analytics, architectural risk analysis, and impact assessment tools.
 - [Comet-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp) 🎖️ 📇 ☁️ 🏠 - Use natural language to explore LLM observability, traces, and monitoring data captured by Opik.
+- [conan-io/conan-mcp](https://github.com/conan-io/conan-mcp) 🎖️ 🐍 🏠 🍎 🪟 🐧 - Official MCP server for Conan C/C++ package manager. Create projects, manage dependencies, check licenses, and scan for security vulnerabilities.
 - [ConfigCat/mcp-server](https://github.com/configcat/mcp-server) 🎖️ 📇 ☁️ - MCP server for interacting with ConfigCat feature flag platform. Supports managing feature flags, configs, environments, products and organizations.
 - [cqfn/aibolit-mcp-server](https://github.com/cqfn/aibolit-mcp-server) ☕ - Helping Your AI Agent Identify Hotspots for Refactoring; Help AI Understand How to 'Make Code Better'
 - [currents-dev/currents-mcp](https://github.com/currents-dev/currents-mcp) 🎖️ 📇 ☁️ Enable AI Agents to fix Playwright test failures reported to [Currents](https://currents.dev).


### PR DESCRIPTION
## Summary

Adds Conan C and C++ Package Manager MCP Server to the Developer Tools section.

More information: https://blog.conan.io/mcp/ai/gpt/conan/conan-mcp/2025/12/04/From-Zero-to-Package-in-Seconds-the-new-Conan-MCP.html

## Server Details

- **Repository:** https://github.com/conan-io/conan-mcp
- **Organization:** [conan-io](https://github.com/conan-io) (Official Conan team)
- **Language:** Python 🐍
- **Platforms:** macOS 🍎, Windows 🪟, Linux 🐧

## Key Features

- 📦 Create new Conan projects with templates (CMake, Meson, Bazel, etc.)
- 🔍 List and search packages from local cache and remote registries
- ⬇️ Install dependencies
- 📜 Collect license information for all dependencies
- 🔒 Scan dependencies for security vulnerabilities
- ⚙️ Manage Conan profiles and configurations

## Entry Added

- [conan-io/conan-mcp](https://github.com/conan-io/conan-mcp) 🎖️ 🐍 🏠 🍎 🪟 🐧 - Official MCP server for Conan C/C++ package manager. Create projects, manage dependencies, check licenses, and scan for security vulnerabilities.

