### PR TITLE
Add Pantheon Security MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [recursechat/mcp-server-apple-shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts) 📇 🏠 🍎 - An MCP Server Integration with Apple Shortcuts
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [imprvhub/mcp-browser-agent](https://github.com/imprvhub/mcp-browser-agent) 📇 🏠 - A Model Context Protocol (MCP) integration that provides Claude Desktop with autonomous browser automation capabilities.
+- [Pantheon-Security/chrome-mcp-secure](https://github.com/Pantheon-Security/chrome-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Security-hardened Chrome automation with post-quantum encryption (ML-KEM-768 + ChaCha20-Poly1305), secure credential vault, memory scrubbing, and audit logging. 22 tools for browser automation and secure logins.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 
@@ -997,6 +998,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 Tools for conducting research, surveys, interviews, and data collection.
 
 - [thinkchainai/agentinterviews_mcp](https://github.com/thinkchainai/agentinterviews_mcp) - Conduct AI-powered qualitative research interviews and surveys at scale with [Agent Interviews](https://agentinterviews.com). Create interviewers, manage research projects, recruit participants, and analyze interview data through MCP.
+- [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 


### PR DESCRIPTION
## Summary

Adding two security-hardened MCP servers from Pantheon Security:

### 1. chrome-mcp-secure (Browser Automation)
https://github.com/Pantheon-Security/chrome-mcp-secure

Security-hardened fork of chrome-mcp with enterprise-grade protection:
- Post-quantum encryption (ML-KEM-768 + ChaCha20-Poly1305)
- Secure credential vault with auto-wipe
- Memory scrubbing after sensitive operations
- Tamper-evident audit logging
- 22 tools for browser automation and secure logins
- Production tested: 4+ hour sessions, zero crashes

### 2. notebooklm-mcp-secure (Research)
https://github.com/Pantheon-Security/notebooklm-mcp-secure

Query Google NotebookLM from Claude/AI agents:
- 14 security hardening layers
- Session-based conversations for deep research
- Notebook library management
- Source-grounded responses (minimizes hallucinations)

Both are TypeScript-based, cross-platform (macOS, Windows, Linux), and actively maintained.