### PR TITLE
Add TwelveTake REAPER MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [r-huijts/oorlogsbronnen-mcp](https://github.com/r-huijts/oorlogsbronnen-mcp) 📇 ☁️ - Oorlogsbronnen (War Sources) API integration for accessing historical WWII records, photographs, and documents from the Netherlands (1940-1945)
 - [r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp) 📇 ☁️ - Rijksmuseum API integration for artwork search, details, and collections
 - [samuelgursky/davinci-resolve-mcp](https://github.com/samuelgursky/davinci-resolve-mcp) 🐍 - MCP server integration for DaVinci Resolve providing powerful tools for video editing, color grading, media management, and project control
+- [TwelveTake-Studios/reaper-mcp](https://github.com/TwelveTake-Studios/reaper-mcp) 🐍 🏠 🍎 🪟 🐧 - MCP server enabling AI assistants to control REAPER DAW for mixing, mastering, MIDI composition, and full music production with 129 tools
 - [yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp) 📇 ☁️ - A MCP server integrating AniList API for anime and manga information
 
 


### PR DESCRIPTION
Adds [TwelveTake REAPER MCP](https://github.com/TwelveTake-Studios/reaper-mcp) to the Art & Culture section.

**Description:** MCP server enabling AI assistants to control REAPER DAW for mixing, mastering, MIDI composition, and full music production with 129 tools.

**Features:**
- 129 MCP tools for complete DAW control
- File-based communication (reliable, no network dependencies)
- Track operations, FX, routing, automation
- MIDI composition and audio editing
- Mastering helpers

**Links:**
- GitHub: https://github.com/TwelveTake-Studios/reaper-mcp
- PyPI: https://pypi.org/project/twelvetake-reaper-mcp/