### PR TITLE
Add spotify-bulk-actions-mcp to Art & Culture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [djalal/quran-mcp-server](https://github.com/djalal/quran-mcp-server) 📇 ☁️ MCP server to interact with Quran.com corpus via the official REST API v4.
 - [raveenb/fal-mcp-server](https://github.com/raveenb/fal-mcp-server) 🐍 ☁️ - Generate AI images, videos, and music using Fal.ai models (FLUX, Stable Diffusion, MusicGen) directly in Claude Desktop
 - [GenWaveLLC/svgmaker-mcp](https://github.com/GenWaveLLC/svgmaker-mcp) 📇 ☁️ - Provides AI-driven SVG generation and editing via natural language, with real-time updates and secure file handling.
+- [khglynn/spotify-bulk-actions-mcp](https://github.com/khglynn/spotify-bulk-actions-mcp) 🐍 ☁️ - Bulk Spotify operations with confidence-scored song matching, batch playlist creation from CSV/podcast lists, and library exports for discovering your most-saved artists and albums.
 - [mikechao/metmuseum-mcp](https://github.com/mikechao/metmuseum-mcp) 📇 ☁️ - Metropolitan Museum of Art Collection API integration to search and display artworks in the collection.
 - [molanojustin/smithsonian-mcp](https://github.com/molanojustin/smithsonian-mcp) 🐍 ☁️ - MCP server that provides AI assistants with access to the Smithsonian Institution's Open Access collections.  
 - [OctoEverywhere/mcp](https://github.com/OctoEverywhere/mcp) #️⃣ ☁️ - A 3D printer MCP server that allows for getting live printer state, webcam snapshots, and printer control.


### PR DESCRIPTION
## New Server

**Name:** spotify-bulk-actions-mcp  
**Repository:** https://github.com/khglynn/spotify-bulk-actions-mcp  
**Category:** Art & Culture (music-related)

## Description

MCP server for bulk Spotify operations:
- Confidence-scored song matching (HIGH/MEDIUM/LOW)
- Batch playlist creation from CSV/podcast lists
- Library exports for discovering most-saved artists and albums
- Human-in-the-loop review for uncertain matches
- Handles 500+ songs with built-in rate limiting

## Why This Category

Added to Art & Culture alongside other music-related servers (Discogs, REAPER, Fal.ai MusicGen).

## Checklist
- [x] Entry follows the format guidelines
- [x] Placed in alphabetical order within the section
- [x] Description is clear and concise