### PR TITLE
Add insta-mcp to Social Media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1158,6 +1158,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 Integration with social media platforms to allow posting, analytics, and interaction management. Enables AI-driven automation for social presence.
 
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) 🏎️ ☁️ - AI‑powered YouTube uploader—no CLI, no YouTube Studio. Uploade videos directly from MCP clients with all AI capabilities.
+- [arjun1194/insta-mcp](https://github.com/arjun1194/insta-mcp) 📇 🏠 - Instagram MCP server for analytics and insights. Get account overviews, posts, followers, following lists, post insights, and search for users, hashtags, or places.
 - [gwbischof/bluesky-social-mcp](https://github.com/gwbischof/bluesky-social-mcp) 🐍 🏠 - An MCP server for interacting with Bluesky via the atproto client.
 - [HagaiHen/facebook-mcp-server](https://github.com/HagaiHen/facebook-mcp-server) 🐍 ☁️ - Integrates with Facebook Pages to enable direct management of posts, comments, and engagement metrics through the Graph API for streamlined social media management.
 - [karanb192/reddit-mcp-buddy](https://github.com/karanb192/reddit-mcp-buddy) 📇 🏠 - Browse Reddit posts, search content, and analyze user activity without API keys. Works out-of-the-box with Claude Desktop.


### PR DESCRIPTION
## Summary

Adding [insta-mcp](https://github.com/arjun1194/insta-mcp) to the Social Media section.

**insta-mcp** is an Instagram MCP server that provides AI assistants with tools for:
- Account overview (profile info, follower/following counts)
- Recent posts with engagement metrics
- Followers and following lists (for any public account)
- Post insights with likers and comments
- Compare follow lists (find unfollowers and fans)
- Search for users, hashtags, or places

## Checklist

- [x] Entry added in alphabetical order
- [x] Follows existing format and style
- [x] Link verified and working
- [x] Description is concise and informative