### PR TITLE
Add LeadFuze MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,8 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
 - [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 - [tomba-io/tomba-mcp-server](https://github.com/tomba-io/tomba-mcp-server) 📇 ☁️ - Email discovery, verification, and enrichment tools. Find email addresses, verify deliverability, enrich contact data, discover authors and LinkedIn profiles, validate phone numbers, and analyze technology stacks.
+- [leadfuze/mcp-server](https://github.com/leadfuze/mcp-server) ☁️ - Sales-ready enrichment: contact + company enrichment from email/LinkedIn URL, with email validation, plus firmographics (industry, employee range, revenue band) and phone fields when available. Hosted MCP: https://mcp.leadfuze.com/mcp (API key required).
+
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
Adds LeadFuze MCP Server (hosted at https://mcp.leadfuze.com/mcp) for contact/company enrichment from email/LinkedIn URL plus email validation. API key required.
