### PR TITLE
Add Home Automation category with FRITZ!Box MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 📂 - [File Systems](#file-systems)
 * 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
+* 🏠 - [Home Automation](#home-automation)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * ⚖️ - [Legal](#legal)
 * 🗺️ - [Location Services](#location-services)
@@ -880,6 +881,12 @@ Integration with gaming related data, game engines, and services
 - [sonirico/mpc-stockfish](https://github.com/sonirico/mcp-stockfish) - 🏎️ 🏠 🍎 🪟 🐧️ MCP server connecting AI systems to Stockfish chess engine.
 - [stefan-xyz/mcp-server-runescape](https://github.com/stefan-xyz/mcp-server-runescape) 📇 - An MCP server with tools for interacting with RuneScape (RS) and Old School RuneScape (OSRS) data, including item prices, player hiscores, and more.
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
+
+### 🏠 <a name="home-automation"></a>Home Automation
+
+Control smart home devices, home network equipment, and automation systems.
+
+- [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
This PR proposes adding a new **Home Automation** category for MCP servers that control smart home devices and home network equipment.

### Rationale
The FRITZ!Box MCP Server controls home networking equipment (routers with smart home features), which doesn't fit existing categories:
- ❌ Embedded Systems - targets microcontrollers
- ❌ Monitoring - passive observation only
- ❌ Cloud Platforms - this is local hardware

### Alternative category names considered
If "Home Automation" doesn't fit your taxonomy:
- **Networking Equipment** (focuses on router/network aspect)
- **Network Management** (broader networking scope)

### Entry
Added under **Home Automation** category with appropriate emoji (🏠) and description that covers both smart home devices and network equipment control.