### PR TITLE
Add shodh-memory to Knowledge & Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp) 📇 🏠 - Memory manager for AI apps and Agents using various graph and vector stores and allowing ingestion from 30+ data sources
 - [unibaseio/membase-mcp](https://github.com/unibaseio/membase-mcp) 📇 ☁️ - Save and query your agent memory in distributed way by Membase
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
+- [varun29ankuS/shodh-memory](https://github.com/varun29ankuS/shodh-memory) 🦀 🏠 - Cognitive memory for AI agents with Hebbian learning, 3-tier architecture, and knowledge graphs. Single ~15MB binary, runs offline on edge devices.
 - [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 ☁️ 🏠 - Hindsight: Agent Memory That Works Like Human Memory - Built for AI Agents to manage Long Term Memory
 - [JamesANZ/memory-mcp](https://github.com/JamesANZ/memory-mcp) 📇 🏠 - An MCP server that stores and retrieves memories from multiple LLMs using MongoDB. Provides tools for saving, retrieving, adding, and clearing conversation memories with timestamps and LLM identification.
 - [JamesANZ/cross-llm-mcp](https://github.com/JamesANZ/cross-llm-mcp) 📇 🏠 - An MCP server that enables cross-LLM communication and memory sharing, allowing different AI models to collaborate and share context across conversations.


### PR DESCRIPTION
## Description

Adding **shodh-memory** to the Knowledge & Memory section.

## What is shodh-memory?

Cognitive memory system for AI agents with:

- **Hebbian learning** - Associations strengthen with use ("neurons that fire together, wire together")
- **3-tier architecture** - Working → Session → Long-term memory based on Cowan's model
- **Knowledge graphs** - Spreading activation for associative retrieval
- **Hybrid decay** - Exponential + power-law based on forgetting curve research
- **Edge-ready** - Single ~15MB binary, runs offline on Raspberry Pi, Jetson, air-gapped systems

## Why it belongs here

- 688 tests passing, production-ready
- Unique: Only MCP memory server with genuine Hebbian learning
- Works with Claude, Cursor, GPT, LangChain, custom agents
- Active development, responsive maintainer

## Links

- GitHub: https://github.com/varun29ankuS/shodh-memory
- Documentation: https://www.shodh-rag.com/memory
- npm: @shodh/memory-mcp