### PR TITLE
Add miro-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [NON906/omniparser-autogui-mcp](https://github.com/NON906/omniparser-autogui-mcp) - 🐍 Automatic operation of on-screen GUI.
 - [offorte/offorte-mcp-server](https://github.com/offorte/offorte-mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - The Offorte Proposal Software MCP server enables creation and sending of business proposals.
 - [olalonde/mcp-human](https://github.com/olalonde/mcp-human) 📇 ☁️ - When your LLM needs human assistance (through AWS Mechanical Turk)
+- [olgasafonova/miro-mcp-server](https://github.com/olgasafonova/miro-mcp-server) 🏎️ ☁️ 🏠 🍎 🪟 🐧 - Full-featured Miro whiteboard integration with 30+ tools. Create stickies, shapes, frames, connectors, mind maps, and diagrams. Supports bulk operations, search, and board management.
 - [orellazi/coda-mcp](https://github.com/orellazri/coda-mcp) 📇 ☁️ - MCP server for [Coda](https://coda.io/)
 - [osinmv/funciton-lookup-mcp](https://github.com/osinmv/function-lookup-mcp) 🐍 🏠 🍎 🐧 - MCP server for function signature lookups.
 - [pierrebrunelle/mcp-server-openai](https://github.com/pierrebrunelle/mcp-server-openai) 🐍 ☁️ - Query OpenAI models directly from Claude using MCP protocol


### PR DESCRIPTION
## Server Information

**Name:** miro-mcp-server

**Repository:** https://github.com/olgasafonova/miro-mcp-server

**Category:** Workplace & Productivity

## Description

Full-featured Miro whiteboard integration for AI assistants with 30+ tools:

- Create and manage boards, stickies, shapes, frames, cards, and text
- Build connectors and relationships between items
- Generate diagrams from Mermaid syntax (flowcharts, sequence, class diagrams)
- Create mind maps with automatic layout
- Bulk operations for efficient board manipulation
- Search across boards and items
- Tag management and board sharing
- Export boards as images

## Technical Details

- **Language:** Go
- **Transport:** stdio
- **Platforms:** macOS (Intel/ARM), Windows, Linux
- **License:** MIT
- **Installation:** Homebrew (`brew install olgasafonova/tap/miro-mcp-server`) or binary download

## Compatibility

Works with Claude Desktop, Claude Code CLI, Cursor, and any MCP-compatible client.

## Note

This is a separate, independent implementation from the existing Miro MCP servers (evalstate/mcp-miro and k-jarzyna/mcp-miro), offering different features and capabilities.