### PR TITLE
Add domain-search-mcp to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [imprvhub/mcp-claude-hackernews](https://github.com/imprvhub/mcp-claude-hackernews) 📇 🏠 ☁️ - An integration that allows Claude Desktop to interact with Hacker News using the Model Context Protocol (MCP).
 - [imprvhub/mcp-rss-aggregator](https://github.com/imprvhub/mcp-rss-aggregator) 📇 ☁️ 🏠 - Model Context Protocol Server for aggregating RSS feeds in Claude Desktop.
 - [boikot-xyz/boikot](https://github.com/boikot-xyz/boikot) 🦀☁️ - Model Context Protocol Server for looking up company ethics information. Learn about the ethical and unethical actions of major companies.
+- [dorukardahan/domain-search-mcp](https://github.com/dorukardahan/domain-search-mcp) 📇 ☁️ - Fast domain availability aggregator with pricing. Checks Porkbun, Namecheap, GoDaddy, RDAP & WHOIS. Includes bulk search, registrar comparison, AI-powered suggestions, and social media handle checking.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
## New MCP Server Submission

**Repository:** https://github.com/dorukardahan/domain-search-mcp

**Category:** 🔎 Search & Data Extraction

**Description:** Fast domain availability aggregator with pricing. Checks Porkbun, Namecheap, GoDaddy, RDAP & WHOIS. Includes bulk search, registrar comparison, AI-powered suggestions, and social media handle checking.

### Features

- **7 Tools:** search_domain, bulk_search, compare_registrars, suggest_domains, suggest_domains_smart, tld_info, check_socials
- **Multi-source:** Aggregates Porkbun, Namecheap, GoDaddy MCP, RDAP, WHOIS
- **Zero-config:** Works without API keys via GoDaddy MCP + RDAP + WHOIS fallback
- **TypeScript:** Full type safety with Zod validation

### Installation

```bash
npm install domain-search-mcp
```

Or via Claude Desktop config:
```json
{
  "mcpServers": {
    "domain-search": {
      "command": "npx",
      "args": ["-y", "domain-search-mcp"]
    }
  }
}
```

**npm:** https://www.npmjs.com/package/domain-search-mcp