### PR TITLE
Add productplan-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1342,6 +1342,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [NON906/omniparser-autogui-mcp](https://github.com/NON906/omniparser-autogui-mcp) - 🐍 Automatic operation of on-screen GUI.
 - [offorte/offorte-mcp-server](https://github.com/offorte/offorte-mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - The Offorte Proposal Software MCP server enables creation and sending of business proposals.
 - [olalonde/mcp-human](https://github.com/olalonde/mcp-human) 📇 ☁️ - When your LLM needs human assistance (through AWS Mechanical Turk)
+- [olgasafonova/productplan-mcp-server](https://github.com/olgasafonova/productplan-mcp-server) 🏎️ ☁️ - Query ProductPlan roadmaps. Access OKRs, ideas, launches, and timeline data.
 - [orellazi/coda-mcp](https://github.com/orellazri/coda-mcp) 📇 ☁️ - MCP server for [Coda](https://coda.io/)
 - [osinmv/funciton-lookup-mcp](https://github.com/osinmv/function-lookup-mcp) 🐍 🏠 🍎 🐧 - MCP server for function signature lookups.
 - [pierrebrunelle/mcp-server-openai](https://github.com/pierrebrunelle/mcp-server-openai) 🐍 ☁️ - Query OpenAI models directly from Claude using MCP protocol


### PR DESCRIPTION
Adds [productplan-mcp-server](https://github.com/olgasafonova/productplan-mcp-server) - Query ProductPlan roadmaps via MCP. Access OKRs, ideas, launches, and timeline data.

**Category:** Workplace & Productivity

**Features:**
- 15 tools for ProductPlan API access
- Query roadmaps, ideas, OKRs, launches
- Single Go binary, no dependencies
- Works with Claude Code, Cursor, VS Code