### PR TITLE
Add Bear Notes MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [teamwork/mcp](https://github.com/teamwork/mcp) 🎖️ 🏎️ ☁️ 🍎 🪟 🐧 - Project and resource management platform that keeps your client projects on track, makes managing resources a breeze, and keeps your profits on point.
 - [tubasasakunn/context-apps-mcp](https://github.com/tubasasakunn/context-apps-mcp) 📇 🏠 🍎 🪟 🐧 - AI-powered productivity suite connecting Todo, Idea, Journal, and Timer apps with Claude via Model Context Protocol.
 - [vakharwalad23/google-mcp](https://github.com/vakharwalad23/google-mcp) 📇 ☁️ - Collection of Google-native tools (Gmail, Calendar, Drive, Tasks) for MCP with OAuth management, automated token refresh, and auto re-authentication capabilities.
+- [vasylenko/claude-desktop-extension-bear-notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) 📇 🏠 🍎 - Search, read, create, and update Bear Notes directly from Claude. Local-only with complete privacy.
 - [khaoss85/mcp-orchestro](https://github.com/khaoss85/mcp-orchestro) 📇 ☁️ 🍎 🪟 🐧 - Trello for Claude Code: AI-powered task management with 60 MCP tools, visual Kanban board, and intelligent orchestration for product teams and developers.
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations


### PR DESCRIPTION
## Summary

Adding [Bear Notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) MCP server to the Workplace & Productivity section.

**Key features:**
- Full CRUD operations for Bear Notes (macOS)
- Search notes by text, tags, and date ranges
- Read note content including OCR from images/PDFs
- Create notes with markdown and tags
- Add text and files to existing notes
- Tag management and organization
- Local-only architecture with complete privacy

**Why Workplace & Productivity?**
Unlike existing Bear entries (akseyh and bart6114) which are read-only, this implementation provides complete note management capabilities, making it a full productivity tool rather than just an integration.

**Format:** `📇 🏠 🍎` (TypeScript, Local, macOS)