### PR TITLE
Add kubefwd - Kubernetes bulk port forwarding MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [strowk/mcp-k8s-go](https://github.com/strowk/mcp-k8s-go) 🏎️ ☁️/🏠 - Kubernetes cluster operations through MCP
 - [thunderboltsid/mcp-nutanix](https://github.com/thunderboltsid/mcp-nutanix) 🏎️ 🏠/☁️ - Go-based MCP Server for interfacing with Nutanix Prism Central resources.
 - [trilogy-group/aws-pricing-mcp](https://github.com/trilogy-group/aws-pricing-mcp) 🏎️ ☁️/🏠 - Get up-to-date EC2 pricing information with one call. Fast. Powered by a pre-parsed AWS pricing catalogue.
+- [txn2/kubefwd](https://github.com/txn2/kubefwd) 🏎️ 🏠 - Kubernetes bulk port forwarding with service discovery, /etc/hosts management, traffic monitoring, and pod log streaming
 - [VmLia/books-mcp-server](https://github.com/VmLia/books-mcp-server) 📇 ☁️ - This is an MCP server used for querying books, and it can be applied in common MCP clients, such as Cherry Studio.
 - [weibaohui/k8m](https://github.com/weibaohui/k8m) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations, featuring a management interface, logging, and nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [weibaohui/kom](https://github.com/weibaohui/kom) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations. It can be integrated as an SDK into your own project and includes nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.


### PR DESCRIPTION
**What is kubefwd?**

 kubefwd is a command-line utility for bulk Kubernetes port forwarding. Each service gets a unique loopback IP (127.x.x.x), eliminating port conflicts and enabling local development with services accessible by name.

  **MCP Capabilities:**
  - 28 tools for discovery, forwarding, debugging, and monitoring
  - 8 queryable resources (`kubefwd://services`, `kubefwd://metrics`, etc.)
  - 10 AI-optimized prompt templates
  - Supports Claude, ChatGPT, Cursor, Windsurf, VS Code Copilot, Gemini, Cline

  **Example interactions:**
  - "Connect me to PostgreSQL in staging" - AI discovers and forwards the service
  - "What services are in the dev namespace?" - AI lists available services
  - "Why is my connection failing?" - AI diagnoses and reconnects

  **Documentation:** https://kubefwd.com/mcp-integration/