### PR TITLE
Add SpeedOf.Me Speed Test MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 - [grafana/mcp-grafana](https://github.com/grafana/mcp-grafana) 🎖️ 🐍 🏠 ☁️ - Search dashboards, investigate incidents and query datasources in your Grafana instance
 - [hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp) 🐍 🏠 - Enhance AI-generated code quality through intelligent, prompt-based analysis across 10 critical dimensions from complexity to security vulnerabilities
 - [inventer-dev/mcp-internet-speed-test](https://github.com/inventer-dev/mcp-internet-speed-test) 🐍 ☁️ - Internet speed testing with network performance metrics including download/upload speed, latency, jitter analysis, and CDN server detection with geographic mapping
+- [speedofme-dev/speedofme-mcp](https://www.npmjs.com/package/@speedofme/mcp) 📇 ☁️ 🍎 🪟 🐧 - Official SpeedOf.Me server for accurate internet speed tests via 129 global Fastly edge servers with analytics dashboard and local history
 - [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) - Seamlessly bring real-time production context—logs, metrics, and traces—into your local environment to auto-fix code faster
 - [metoro-io/metoro-mcp-server](https://github.com/metoro-io/metoro-mcp-server) 🎖️ 🏎️ ☁️ - Query and interact with kubernetes environments monitored by Metoro
 - [MindscapeHQ/server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun) 📇 ☁️ - Raygun API V3 integration for crash reporting and real user monitoring


### PR DESCRIPTION
Adds the official SpeedOf.Me MCP server to the Monitoring section.

## Server Details

- **npm**: [@speedofme/mcp](https://www.npmjs.com/package/@speedofme/mcp)
- **MCP Registry**: [me.speedof/speed-test](https://registry.modelcontextprotocol.io/v0.1/servers/me.speedof%2Fspeed-test/versions/1.0.11)

## Features

- Accurate internet speed tests (download, upload, latency, jitter)
- 129 global Fastly edge servers
- Local history storage
- Analytics dashboard
- Works as MCP server, CLI, and SDK