### PR TITLE
Add reclaim-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) 🐍 ☁️ 🍎 🪟 🐧 - Comprehensive Google Workspace MCP server with full support for Google Calendar, Drive, Gmail, and Docs, Forms, Chats, Slides and Sheets over stdio, Streamable HTTP and SSE transports.
 - [teamwork/mcp](https://github.com/teamwork/mcp) 🎖️ 🏎️ ☁️ 🍎 🪟 🐧 - Project and resource management platform that keeps your client projects on track, makes managing resources a breeze, and keeps your profits on point.
 - [tubasasakunn/context-apps-mcp](https://github.com/tubasasakunn/context-apps-mcp) 📇 🏠 🍎 🪟 🐧 - AI-powered productivity suite connecting Todo, Idea, Journal, and Timer apps with Claude via Model Context Protocol.
+- [universalamateur/reclaim-mcp-server](https://github.com/universalamateur/reclaim-mcp-server) 🐍 ☁️ - Reclaim.ai calendar integration with 40 tools for tasks, habits, focus time, scheduling links, and productivity analytics.
 - [vakharwalad23/google-mcp](https://github.com/vakharwalad23/google-mcp) 📇 ☁️ - Collection of Google-native tools (Gmail, Calendar, Drive, Tasks) for MCP with OAuth management, automated token refresh, and auto re-authentication capabilities.
 - [khaoss85/mcp-orchestro](https://github.com/khaoss85/mcp-orchestro) 📇 ☁️ 🍎 🪟 🐧 - Trello for Claude Code: AI-powered task management with 60 MCP tools, visual Kanban board, and intelligent orchestration for product teams and developers.
 


### PR DESCRIPTION
## Server Information

- **Name:** reclaim-mcp-server
- **Repository:** https://github.com/universalamateur/reclaim-mcp-server
- **Category:** Workplace & Productivity
- **Language:** Python 🐍
- **Hosting:** Cloud ☁️ (PyPI, Docker Hub)

## Description

Unofficial MCP server for [Reclaim.ai](https://reclaim.ai) - AI-powered calendar, tasks, habits, and focus time management. Provides 40 tools for:

- Task management (create, update, prioritize, start/stop)
- Habit tracking (create, log completions)
- Calendar events (list, create, update)
- Focus time sessions
- Scheduling links
- Productivity analytics

## Installation

```bash
pip install reclaim-mcp-server
# or
uvx reclaim-mcp-server
```

## Links

- [PyPI](https://pypi.org/project/reclaim-mcp-server/)
- [Docker Hub](https://hub.docker.com/r/universalamateur/reclaim-mcp-server)
- [Smithery](https://smithery.ai/server/universalamateur/reclaim-mcp-server)
- [Glama](https://glama.ai/mcp/servers/@universalamateur/reclaim-mcp-server)

## Checklist

- [x] Server is published and accessible
- [x] README includes installation instructions
- [x] Entry placed alphabetically in correct category
- [x] Correct badges used (🐍 ☁️)