### PR TITLE
Add Milofax/xert-mcp to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,7 @@ Tools for accessing sports-related data, results, and statistics.
 
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp) 🐍 🏠 - MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.
 - [mikechao/balldontlie-mcp](https://github.com/mikechao/balldontlie-mcp) 📇 - MCP server that integrates balldontlie api to provide information about players, teams and games for the NBA, NFL and MLB
+- [Milofax/xert-mcp](https://github.com/Milofax/xert-mcp) 📇 ☁️ - MCP server for XERT cycling analytics — access fitness signature (FTP, HIE, PP), training status, workouts, activities with XSS metrics, and MPA analysis.
 - [r-huijts/firstcycling-mcp](https://github.com/r-huijts/firstcycling-mcp) 📇 ☁️ - Access cycling race data, results, and statistics through natural language. Features include retrieving start lists, race results, and rider information from firstcycling.com.
 - [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs
 - [RobSpectre/mvf1](https://github.com/RobSpectre/mvf1) 🐍 ☁️ - MCP server that controls [MultiViewer](https://multiviewer.app), an app for watching motorsports like Formula 1, World Endurance Championship, IndyCar and others.


### PR DESCRIPTION
## Description

Adds [xert-mcp](https://github.com/Milofax/xert-mcp) to the Sports section.

## About xert-mcp

A TypeScript MCP server for [XERT](https://www.xertonline.com/) cycling analytics platform.

### Features

- **Fitness Signature** - Get current FTP, LTP, HIE, and Peak Power
- **Training Status** - Check freshness, training load, and form stars
- **Workout of the Day** - AI-powered workout recommendations
- **Workouts** - List, view details, and export (ZWO/ERG)
- **Activities** - Browse activities with XSS metrics and MPA data
- **FIT Upload** - Upload FIT files for analysis

### Available Tools

| Tool | Description |
|------|-------------|
| `xert-get-training-info` | Fitness signature, training status, load, WOTD |
| `xert-list-workouts` | List saved workouts |
| `xert-get-workout` | Workout details with intervals |
| `xert-download-workout` | Export as ZWO/ERG |
| `xert-list-activities` | Activities in time range |
| `xert-get-activity` | Activity with XSS metrics |
| `xert-upload-fit` | Upload FIT file |

## Checklist

- [x] TypeScript implementation (📇)
- [x] Cloud service (☁️) - connects to XERT API
- [x] README with installation instructions
- [x] MIT License