### PR TITLE
Add tilde - privacy-first AI identity MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [Smart-AI-Memory/empathy-framework](https://github.com/Smart-AI-Memory/empathy-framework) 🐍 🏠 - Five-level AI collaboration system with persistent memory and anticipatory capabilities. MCP-native integration for Claude and other LLMs with local-first architecture via MemDocs.
 - [TechDocsStudio/biel-mcp](https://github.com/TechDocsStudio/biel-mcp) 📇 ☁️ - Let AI tools like Cursor, VS Code, or Claude Desktop answer questions using your product docs. Biel.ai provides the RAG system and MCP server.
 - [topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp) 📇 🏠 - Memory manager for AI apps and Agents using various graph and vector stores and allowing ingestion from 30+ data sources
+- [topskychen/tilde](https://github.com/topskychen/tilde) 🐍 🏠 - Your AI agents' home directory — privacy-first MCP server for portable AI identity. Configure once, use everywhere. It supports profile management, skills, resume import, and team sync.
 - [unibaseio/membase-mcp](https://github.com/unibaseio/membase-mcp) 📇 ☁️ - Save and query your agent memory in distributed way by Membase
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
 - [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 ☁️ 🏠 - Hindsight: Agent Memory That Works Like Human Memory - Built for AI Agents to manage Long Term Memory


### PR DESCRIPTION
## Description
Adds **tilde** to the Knowledge & Memory section.

## What is tilde?
A privacy-first MCP server for managing AI agent identity and profiles:
- 🏠 **Local-first**: Your data stays on your machine
- ✏️ **Human-in-the-loop**: Agents propose updates, you approve
- 📋 **Structured profiles**: Identity, tech stack, skills, knowledge
- 📄 **Resume import**: Bootstrap from existing CV
- 👥 **Team sync**: Share coding standards

## Links
- Repository: https://github.com/topskychen/tilde
- PyPI: https://pypi.org/project/tilde-ai/
- MCP Registry: https://registry.modelcontextprotocol.io (search: io.github.topskychen/tilde)