### PR TITLE
Add PraisonAI to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript
+- [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 
 ## Tips and Tricks
 


### PR DESCRIPTION
## Summary
Add PraisonAI MCP Server to the Frameworks section.

## About PraisonAI
- **GitHub**: https://github.com/MervinPraison/praisonai-mcp
- **Main Project**: https://github.com/MervinPraison/PraisonAI (10K+ stars, 2M+ PyPI downloads)
- **PyPI**: https://pypi.org/project/praisonai-mcp/

## Features
PraisonAI MCP Server provides 64+ built-in tools for MCP clients:

- 🤖 **Agent Tools**: run_agent, run_research, run_auto_agents
- 🔍 **Search Tools**: Tavily, Exa, DuckDuckGo, Wikipedia, arXiv
- 🧠 **Memory Tools**: memory_add, memory_search, auto_extract_memories
- 💻 **Code Tools**: run_python, run_shell, git_commit
- 📁 **File Tools**: read_file, write_file, list_directory

## Installation
```bash
uvx praisonai-mcp
```

## Configuration
```json
{
  "mcpServers": {
    "praisonai": {
      "command": "uvx",
      "args": ["praisonai-mcp"]
    }
  }
}
```