### PR TITLE
Add refund.decide.fyi MCP server to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal) 🐍 🏠 ☁️ - Access any storage with Apache OpenDAL™
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
-
+- [decide-fyi/refund-decide-mcp](https://github.com/decide-fyi/refund-decide-mcp) 📇 ☁️ - Deterministic refund eligibility notary MCP server. Returns ALLOWED / DENIED / UNKNOWN for subscription refunds (Adobe, Spotify, etc.) via a stateless rules engine.
 - [Regenerating-World/pix-mcp](https://github.com/Regenerating-World/pix-mcp) 📇 ☁️ - Generate Pix QR codes and copy-paste strings with fallback across multiple providers (Efí, Cielo, etc.) for Brazilian instant payments.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.


### PR DESCRIPTION
Adds refund.decide.fyi — a deterministic, stateless MCP server that provides
refund eligibility decisions (ALLOWED / DENIED / UNKNOWN) for subscription
products (e.g. Adobe, Spotify) via a rules-based engine.

Designed for agentic workflows and safe to chain (no side effects).