### PR TITLE
Add arvo-mcp to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ Tools for accessing sports-related data, results, and statistics.
 - [willvelida/mcp-afl-server](https://github.com/willvelida/mcp-afl-server) ☁️ - MCP server that integrates with the Squiggle API to provide information on Australian Football League teams, ladder standings, results, tips, and power rankings.
 - [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server) 🏎️ ☁️ – Access structured sports data via the Cloudbet API. Query upcoming events, live odds, stake limits, and market info across soccer, basketball, tennis, esports, and more.
 - [labeveryday/nba_mcp_server](https://github.com/labeveryday/nba_mcp_server) 🐍 🏠 - Access live and historical NBA statistics including player stats, game scores, team data, and advanced analytics via Model Context Protocol
+- [khaoss85/arvo-mcp](https://github.com/khaoss85/arvo-mcp) 📇 ☁️ - AI workout coach MCP server for Arvo. Access training data, workout history, personal records, body progress, and 29 fitness tools through Claude Desktop.
 
 
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management


### PR DESCRIPTION
## Summary
Adding [arvo-mcp](https://github.com/khaoss85/arvo-mcp) to the Sports section.

## About arvo-mcp
- **Name:** arvo-mcp
- **Repository:** https://github.com/khaoss85/arvo-mcp
- **npm:** https://www.npmjs.com/package/arvo-mcp
- **Website:** https://arvo.guru

Official MCP server for Arvo - AI workout coach. Provides 29 fitness tools including:
- Workout history and training data access
- Personal records (PRs) tracking
- Body progress metrics
- Training split management
- Exercise library access

Built with TypeScript, cloud-hosted API.