### PR TITLE
Add BlockRun MCP - Access 30+ AI models without API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 📇 ☁️ 🏠 🍎 🪟 🐧 - Meta-MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized MCP interface, providing zero-configuration access to the entire AI coding ecosystem.
+- [blockrunai/blockrun-mcp](https://github.com/blockrunai/blockrun-mcp) 📇 ☁️ 🍎 🪟 🐧 - Access 30+ AI models (GPT-5, Claude, Gemini, Grok, DeepSeek) without API keys. Pay-per-use via x402 micropayments with USDC on Base.
 - [duaraghav8/MCPJungle](https://github.com/duaraghav8/MCPJungle) 🏎️ 🏠 - Self-hosted MCP Server registry for enterprise AI Agents
 - [glenngillen/mcpmcp-server](https://github.com/glenngillen/mcpmcp-server) ☁️ 📇 🍎 🪟 🐧 - A list of MCP servers so you can ask your client which servers you can use to improve your daily workflow.
 - [hamflx/imagen3-mcp](https://github.com/hamflx/imagen3-mcp) 📇 🏠 🪟 🍎 🐧 - A powerful image generation tool using Google's Imagen 3.0 API through MCP. Generate high-quality images from text prompts with advanced photography, artistic, and photorealistic controls.


### PR DESCRIPTION
## What is BlockRun MCP?

An MCP server that gives Claude Code access to 30+ AI models from OpenAI, Anthropic, Google, xAI, and DeepSeek - without requiring any API keys.

**Key Features:**
- **Zero API keys** - No accounts needed with providers
- **Pay-per-use** - USDC micropayments via x402 protocol on Base
- **30+ models** - GPT-5, Claude Opus, Gemini Pro, Grok 3, DeepSeek
- **Image generation** - DALL-E 3, Flux
- **Real-time Twitter/X search** via Grok

**Install:**
```bash
claude mcp add blockrun npx @blockrun/mcp
```

**Links:**
- npm: https://www.npmjs.com/package/@blockrun/mcp
- Website: https://blockrun.ai