### PR TITLE
feat: add mcp benchmark runner to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,6 +1348,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [future-audiences/wikimedia-enterprise-model-context-protocol](https://gitlab.wikimedia.org/repos/future-audiences/wikimedia-enterprise-model-context-protocol) 🐍 ☁️  - Wikipedia Article lookup API
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) 🐍 🏠 - This server enables LLMs to use calculator for precise numerical calculations
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
+- [greynewell/mcpbr](https://github.com/greynewell/mcpbr) - Evaluate MCP servers with Model Context Protocol Benchmark Runner
 - [growilabs/growi-mcp-server](https://github.com/growilabs/growi-mcp-server) 🎖️ 📇 ☁️ - Official MCP Server to integrate with GROWI APIs.
 - [gwbischof/free-will-mcp](https://github.com/gwbischof/free-will-mcp) 🐍 🏠 - Give your AI free will tools. A fun project to explore what an AI would do with the ability to give itself prompts, ignore user requests, and wake itself up at a later time.
 - [Harry-027/JotDown](https://github.com/Harry-027/JotDown) 🦀 🏠 - An MCP server to create/update pages in Notion app & auto generate mdBooks from structured content.


### PR DESCRIPTION
Hi! I noticed the 'Other Tools' section is a great spot for utilities. I've built a runner that lets developers benchmark their MCP servers against standard agent evaluations. Adding it here to help server devs test their implementations. Thanks!