### PR TITLE
Add ao-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,9 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [carsol/monarch-mcp-server](https://github.com/carsol/monarch-mcp-server) 🐍 ☁️ - MCP server providing read-only access to Monarch Money financial data, enabling AI assistants to analyze transactions, budgets, accounts, and cashflow data with MFA support.
 - [chargebee/mcp](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol) 🎖️ 📇 ☁️ - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com/).
 - [codex-data/codex-mcp](https://github.com/Codex-Data/codex-mcp) 🎖️ 📇 ☁️ - [Codex API](https://www.codex.io) integration for real-time enriched blockchain and market data on 60+ networks
+- [credentum/ao-mcp-server](https://github.com/credentum/ao-mcp-server) 📇 ☁️ - MCP      
+server for AO/Arweave - query processes, send messages, spawn processes, and execute Lua 
+code on the hyper-parallel computer. 
 - [coinpaprika/dexpaprika-mcp](https://github.com/coinpaprika/dexpaprika-mcp) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Coinpaprika's DexPaprika MCP server exposes high-performance [DexPaprika API](https://docs.dexpaprika.com) covering 20+ chains and 5M+ tokens with real time pricing, liquidity pool data & historical OHLCV data, providing AI agents standardized access to comprehensive market data through Model Context Protocol.
 - [doggybee/mcp-server-ccxt](https://github.com/doggybee/mcp-server-ccxt) 📇 ☁️ - An MCP server for accessing real-time crypto market data and trading via 20+ exchanges using the CCXT library. Supports spot, futures, OHLCV, balances, orders, and more.
 - [ferdousbhai/investor-agent](https://github.com/ferdousbhai/investor-agent) 🐍 ☁️ - Yahoo Finance integration to fetch stock market data including options recommendations


### PR DESCRIPTION
  Adds [ao-mcp-server](https://github.com/credentum/ao-mcp-server) - MCP server for        
  AO/Arweave.                                                                              
                                                                                           
  **What it does:**                                                                        
  - Query AO process state via dryrun (read-only, no wallet needed)                        
  - Send messages to AO processes                                                          
  - Spawn new AO processes                                                                 
  - Execute Lua code in processes                                                          
  - View process message history                                                           
                                                                                           
  **npm:** https://www.npmjs.com/package/ao-mcp-server                                     
                                                                                           
  **Tech:** TypeScript, Cloud Service (AO on Arweave)