### PR TITLE
Add Berckan/bugherd-mcp to Support & Service Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,7 @@ Tools for accessing sports-related data, results, and statistics.
 Tools for managing customer support, IT service management, and helpdesk operations.
 
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.


### PR DESCRIPTION
Adds BugHerd MCP server to Support & Service Management category.

- **Name:** [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp)
- **Language:** TypeScript 📇
- **Scope:** Cloud ☁️
- **Description:** MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.

---

Note: This is a resubmission of #1670, which was closed due to unintended formatting changes. This PR contains only the single line addition.