### PR TITLE
Add langfuse-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.
 
+- [avivsinai/langfuse-mcp](https://github.com/avivsinai/langfuse-mcp) 🐍 ☁️ - Query Langfuse traces, debug exceptions, analyze sessions, and manage prompts. Full observability toolkit for LLM applications.
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Leverage AI-driven observability, security, and automation to analyze anomalies, logs, traces, events, metrics.
 - [edgedelta/edgedelta-mcp-server](https://github.com/edgedelta/edgedelta-mcp-server) 🎖️ 🏎️ ☁️ – Interact with Edge Delta anomalies, query logs / patterns / events, and pinpoint root causes and optimize your pipelines.
 - [getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp) 🐍 ☁️ - Sentry.io integration for error tracking and performance monitoring


### PR DESCRIPTION
Adds [langfuse-mcp](https://github.com/avivsinai/langfuse-mcp) to the Monitoring section.

**What it does:** MCP server for Langfuse observability — query traces, debug exceptions, analyze sessions, and manage prompts.

**Why it's useful:**
- 25 tools across traces, observations, sessions, exceptions, prompts, datasets
- Selective tool loading to reduce token overhead
- Read-only mode for safer access
- Full observability toolkit (the official Langfuse MCP only covers prompt management)

**Stats:** 38 GitHub stars, 2K+ monthly PyPI downloads