### PR TITLE
Add vnsh-mcp - Ephemeral encrypted file sharing for AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.
+- [raullenchai/vnsh-mcp](https://github.com/raullenchai/vnsh/tree/main/mcp) 📇 ☁️ 🍎 🪟 🐧 - Ephemeral encrypted file sharing for AI. Client-side AES-256 encryption, 24h auto-vaporization. Read vnsh URLs and share large outputs securely.
 - [willianpinho/large-file-mcp](https://github.com/willianpinho/large-file-mcp) 📇 🏠 🍎 🪟 🐧 - Production-ready MCP server for intelligent handling of large files with smart chunking, navigation, streaming capabilities, regex search, and built-in LRU caching.
 - [Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal) 🐍 🏠 ☁️ - Access any storage with Apache OpenDAL™
 - [xxczaki/local-history-mcp](https://github.com/xxczaki/local-history/mcp) 📇 🏠 🍎 🪟 🐧  - MCP server for accessing VS Code/Cursor Local History


### PR DESCRIPTION
## New Server

**vnsh-mcp** - The Ephemeral Dropbox for AI

### What it does

vnsh-mcp enables Claude and other AI assistants to:
- **Read** encrypted vnsh URLs automatically
- **Share** large outputs (logs, diffs, code) via secure ephemeral links

### Key Features

- **Zero-Access Architecture**: Client-side AES-256-CBC encryption - server never sees your data
- **Auto-Vaporization**: Data auto-destructs after 24 hours
- **Cross-Platform**: Works on macOS, Windows, and Linux
- **npm Package**: `npx vnsh-mcp` - zero configuration required

### Use Case

When debugging or sharing context with AI that's too long for direct paste:
```bash
# CLI usage
git diff | vn
# Returns: https://vnsh.dev/v/abc123#k=...

# Paste link to Claude - vnsh-mcp reads it automatically
```

### Links

- **Repository**: https://github.com/raullenchai/vnsh
- **npm**: https://www.npmjs.com/package/vnsh-mcp
- **Website**: https://vnsh.dev