### PR TITLE
Add DigitalCore - Service Management MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,6 +1348,7 @@ Tools for managing customer support, IT service management, and helpdesk operati
 
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
+- [DigitalCore](https://github.com/DigitalCoreApp/digitalcore-mcp-free) - Service management toolkit with 29 expert playbooks, KPI metrics, and instant service health scoring for MSPs and IT service providers.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.
 - [nguyenvanduocit/jira-mcp](https://github.com/nguyenvanduocit/jira-mcp) 🏎️ ☁️ - A Go-based MCP connector for Jira that enables AI assistants like Claude to interact with Atlassian Jira. This tool provides a seamless interface for AI models to perform common Jira operations including issue management, sprint planning, and workflow transitions.


### PR DESCRIPTION
## New Server: DigitalCore MCP Free

**Repository:** https://github.com/DigitalCoreApp/digitalcore-mcp-free
**Endpoint:** https://mcpfree.digitalcore.app/mcp

### Description
Free service management toolkit for MCP-enabled AI assistants. Provides instant access to 29 expert playbooks, KPI metrics, and service health scoring.

### Tools (6 total)
- `list_playbooks` - List 29 service management playbooks
- `get_playbook` - Get detailed playbook content
- `explain_metric` - KPI formulas and benchmarks
- `run_service_reality_check` - Instant service health scoring
- `submit_email` - Get Service Economics Guide
- `submit_feedback` - Rate tool responses

### Target Users
- MSPs (Managed Service Providers)
- MSSPs (Managed Security Service Providers)
- IT Service Providers
- Service Management Professionals

### Protocol
- MCP 2024-11-05 Streamable HTTP Transport
- No API key required (free tier)