### PR TITLE
Add Polar MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 - [longevity-genie/synergy-age-mcp](https://github.com/longevity-genie/synergy-age-mcp) 🎖️ 🐍 🏠 ☁️ - MCP server for the SynergyAge database of synergistic and antagonistic genetic interactions in longevity.
 - [OHNLP/omop_mcp](https://github.com/OHNLP/omop_mcp) 🐍 🏠 ☁️ - Map clinical terminology to OMOP concepts using LLMs for healthcare data standardization and interoperability.
 - [the-momentum/apple-health-mcp-server](https://github.com/the-momentum/apple-health-mcp-server) 🐍 🏠 🍎 🪟 🐧 - An MCP server that provides access to exported data from Apple Health. Data analytics included.
+- [NelsonNew/polar-mcp-server](https://github.com/NelsonNew/polar-mcp-server) 📇 ☁️ 🏠 🍎 🪟 🐧 - MCP server for Polar AccessLink API to export data from Polar watches. 25 tools for workouts, sleep, recovery (HRV, ANS), heart rate, training load, and more. Hosted instance available.  
 - [the-momentum/fhir-mcp-server](https://github.com/the-momentum/fhir-mcp-server) 🐍 🏠 ☁️ - MCP Server that connects AI agents to FHIR servers. One example use case is querying patient history in natural language.
 - [wso2/fhir-mcp-server](https://github.com/wso2/fhir-mcp-server) 🐍 🏠 ☁️ - Model Context Protocol server for Fast Healthcare Interoperability Resources (FHIR) APIs. Provides seamless integration with FHIR servers, enabling AI assistants to search, retrieve, create, update, and analyze clinical healthcare data with SMART-on-FHIR authentication support.
 


### PR DESCRIPTION
Adds MCP server for Polar fitness watches (Pacer, Vantage, Grit X,  Ignite, etc.)                                                         
                                                                        
  Features:                                                             
  - 25 tools covering workouts, sleep, recovery, heart rate, training   
  load                                                                  
  - Cloud deployment (Cloudflare Workers) with OAuth                    
  - Local deployment option for Claude Desktop                          
  - Public hosted instance available                                    
                                                                        
  First MCP server for Polar/AccessLink API.