### PR TITLE
Add Stats Compass MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [jjsantos01/jupyter-notebook-mcp](https://github.com/jjsantos01/jupyter-notebook-mcp) 🐍 🏠 - connects Jupyter Notebook to Claude AI, allowing Claude to directly interact with and control Jupyter Notebooks.
 - [kdqed/zaturn](https://github.com/kdqed/zaturn) 🐍 🏠 🪟 🐧 🍎 - Link multiple data sources (SQL, CSV, Parquet, etc.) and ask AI to analyze the data for insights and visualizations.
 - [mckinsey/vizro-mcp](https://github.com/mckinsey/vizro/tree/main/vizro-mcp) 🎖️ 🐍 🏠 - Tools and templates to create validated and maintainable data charts and dashboards.
+- [oogunbiyi21/stats-compass-mcp](https://github.com/oogunbiyi21/stats-compass-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - 50+ pandas-powered data analysis tools for loading, cleaning, transforming, visualizing, and ML workflows. Supports local, remote HTTP, and cloud deployments.
 - [optuna/optuna-mcp](https://github.com/optuna/optuna-mcp) 🎖️ 🐍 🏠 🐧 🍎 - Official MCP server enabling seamless orchestration of hyperparameter search and other optimization tasks with [Optuna](https://optuna.org/).
 - [phisanti/MCPR](https://github.com/phisanti/MCPR) 🏠 🍎 🪟 🐧 - Model Context Protocol for R: enables AI agents to participate in interactive live R sessions.
 - [phuongrealmax/code-guardian](https://github.com/phuongrealmax/code-guardian) 📇 🏠 - AI-powered code refactor engine with 80+ MCP tools for code analysis, hotspot detection, complexity metrics, persistent memory, and automated refactoring plans.


### PR DESCRIPTION
## Stats Compass MCP

**Website:** https://statscompass.io  
**GitHub:** https://github.com/oogunbiyi21/stats-compass-mcp  
**PyPI:** https://pypi.org/project/stats-compass-mcp/

### What is Stats Compass MCP?

Stats Compass MCP turns your LLM into a data analyst with 50+ pandas-powered tools via MCP. It enables AI agents to:

- **Data Loading** - Load CSV/Excel files, sample datasets, manage multiple DataFrames
- **Cleaning** - Drop nulls, impute, dedupe, handle outliers
- **Transforms** - Filter, groupby, pivot, encode, add columns
- **EDA** - Describe, correlations, hypothesis tests, data quality reports
- **Visualization** - Histograms, scatter plots, bar charts, ROC curves, confusion matrices
- **ML Workflows** - Classification, regression, time series forecasting (ARIMA)

### Available As

✅ Local MCP Server (stdio transport)  
✅ Remote HTTP Server (Streamable HTTP transport)  
✅ CLI tool (`stats-compass-mcp install --client claude`)

### Category

Added to **Data Science Tools** section - tools for data exploration, analysis, and enhancing data science workflows.