### PR TITLE
Add yuvalsuede/memory-mcp to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
 - [varun29ankuS/shodh-memory](https://github.com/varun29ankuS/shodh-memory) 🦀 🏠 - Cognitive memory for AI agents with Hebbian learning, 3-tier architecture, and knowledge graphs. Single ~15MB binary, runs offline on edge devices.
 - [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 ☁️ 🏠 - Hindsight: Agent Memory That Works Like Human Memory - Built for AI Agents to manage Long Term Memory
+- [yuvalsuede/memory-mcp](https://github.com/yuvalsuede/memory-mcp) 📇 🏠 🍎 🪟 🐧 - Persistent memory + git snapshots for Claude Code. Silent auto-capture via hooks, two-tier memory (CLAUDE.md + searchable store), LLM-powered extraction, and instant rollback.
 
 ### ⚖️ <a name="legal"></a>Legal
 


### PR DESCRIPTION
## New MCP Server: memory-mcp

**Category:** Knowledge & Memory

**Description:** Persistent memory for Claude Code CLI. Uses Claude Code hooks (Stop, PreCompact, SessionEnd) for silent auto-capture — no commands needed. Haiku extracts memories from transcripts, deduplicates via Jaccard similarity, manages confidence decay, and syncs a compact summary to CLAUDE.md. Mid-session deep recall via MCP search tools.

**Links:**
- GitHub: https://github.com/yuvalsuede/memory-mcp
- npm: https://www.npmjs.com/package/claude-code-memory

**Features:**
- Zero-config silent capture via Claude Code hooks
- Two-tier memory: CLAUDE.md (auto-read) + searchable store
- Jaccard dedup, confidence decay, LLM-powered consolidation
- MCP tools: memory_search, memory_ask (RAG), memory_related
- CLI: `npx claude-code-memory setup`