### PR TITLE
Add VibeCodingInc/vibe-mcp to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Integration with communication platforms for message management and channel oper
 - [saseq/discord-mcp](https://github.com/SaseQ/discord-mcp) ☕ 📇 🏠 💬 - A MCP server for the Discord integration. Enable your AI assistants to seamlessly interact with Discord. Enhance your Discord experience with powerful automation capabilities.
 - [teddyzxcv/ntfy-mcp](https://github.com/teddyzxcv/ntfy-mcp) - The MCP server that keeps you informed by sending the notification on phone using ntfy
 - [userad/didlogic_mcp](https://github.com/UserAd/didlogic_mcp) 🐍 ☁️ - An MCP server for [DIDLogic](https://didlogic.com). Adds functionality to manage SIP endpoints, numbers and destinations.
+- [VibeCodingInc/vibe-mcp](https://github.com/VibeCodingInc/vibe-mcp) 📇 ☁️ 🏠 - Social layer for AI coding — DMs, presence, discovery, and multiplayer games between developers. Works with Claude Code, Cursor, VS Code, Windsurf, and any MCP client.
 - [YCloud-Developers/ycloud-whatsapp-mcp-server](https://github.com/YCloud-Developers/ycloud-whatsapp-mcp-server) 📇 🏠 - MCP server for WhatsApp Business Platform by YCloud.
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) 📇 ☁️ - An MCP server to Manage Google Tasks
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.


### PR DESCRIPTION
## Summary

Adds [/vibe](https://github.com/VibeCodingInc/vibe-mcp) to the Communication section.

/vibe is a social MCP server that brings DMs, real-time presence, discovery, and multiplayer games to AI coding environments. It connects developers across Claude Code, Cursor, VS Code, Windsurf, and any MCP-compatible client through a shared social network at [slashvibe.dev](https://slashvibe.dev).

- **npm package:** `slashvibe-mcp`
- **68 tools** across messaging, discovery, creative sharing, memory, games, and cross-platform bridges
- **MIT licensed**
- **TypeScript/JavaScript** codebase with SQLite local persistence + Postgres cloud sync

Placed alphabetically in the Communication section (between `teddyzxcv/ntfy-mcp` and `YCloud-Developers`).