### PR TITLE
Add Ablefy Connector - Digital product management via Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,6 +873,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [JamesANZ/prediction-market-mcp](https://github.com/JamesANZ/prediction-market-mcp) 📇 ☁️ - An MCP server that provides real-time prediction market data from multiple platforms including Polymarket, PredictIt, and Kalshi. Enables AI assistants to query current odds, prices, and market information through a unified interface.
 - [janswist/mcp-dexscreener](https://github.com/janswist/mcp-dexscreener) 📇 ☁️ - Real-time on-chain market prices using open and free Dexscreener API
 - [jjlabsio/korea-stock-mcp](https://github.com/jjlabsio/korea-stock-mcp) 📇 ☁️ - An MCP Server for Korean stock analysis using OPEN DART API and KRX API
+- [johovgit/ablefy-connector](https://github.com/johovgit/ablefy-connector) 📇 ☁️ 🍎 🪟 - Manage Ablefy digital products, orders, payments, voices, funnels, webhooks, and affiliate programs through Claude Desktop (44 tools)
 - [kukapay/binance-alpha-mcp](https://github.com/kukapay/binance-alpha-mcp) 🐍 ☁️ - An MCP server for tracking Binance Alpha trades, helping AI agents optimize alpha point accumulation.
 - [kukapay/bitcoin-utxo-mcp](https://github.com/kukapay/bitcoin-utxo-mcp) 🐍 ☁️ - An MCP server that tracks Bitcoin's Unspent Transaction Outputs (UTXO) and block statistics.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) 🐍 ☁️ -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.


### PR DESCRIPTION
## New Server Submission

**Server Name:** Ablefy Connector  
**Repository:** https://github.com/johovgit/ablefy-connector  
**Category:** Finance & Fintech

### Description
MCP connector enabling Claude Desktop to interact with the Ablefy API for managing digital products and e-commerce operations.

### Features
- 44 tools covering all Ablefy API endpoints
- One-click installation via .mcpb bundle
- Supports macOS and Windows
- Requires Claude Desktop 0.10.0+