### PR TITLE
Add elegoo-mcp-server - Elegoo 3D printer control via SDCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [0x1abin/matter-controller-mcp](https://github.com/0x1abin/matter-controller-mcp) 📇 📟 - An MCP server for Matter Controller, enabling AI agents to control and interact with Matter devices.
 - [adancurusul/embedded-debugger-mcp](https://github.com/adancurusul/embedded-debugger-mcp) 🦀 📟 - A Model Context Protocol server for embedded debugging with probe-rs - supports ARM Cortex-M, RISC-V debugging via J-Link, ST-Link, and more
 - [adancurusul/serial-mcp-server](https://github.com/adancurusul/serial-mcp-server) 🦀 📟 - A comprehensive MCP server for serial port communication
+- [skribascode/elegoo-mcp-server](https://github.com/skribascode/elegoo-mcp-server) 📇 🏠 - Control Elegoo 3D printers (Centauri Carbon) via SDCP. Monitor status, pause/resume prints, manage files, control lights. 100% local.
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.


### PR DESCRIPTION
Adds MCP server for controlling Elegoo 3D printers via SDCP protocol.

**Section:** 📟 Embedded System

**Features:**
- Multi-printer management
- Print control (start, pause, resume, stop)
- Status monitoring (temps, progress)
- Light control & camera stream
- File listing with thumbnails

**Links:**
- GitHub: https://github.com/skribascode/elegoo-mcp-server
- npm: https://www.npmjs.com/package/elegoo-mcp-server

100% local, no cloud dependencies.