### PR TITLE
Add wake - Terminal session recorder for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 ### 🖥️ <a name="command-line"></a>Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [joemckenney/wake](https://github.com/joemckenney/wake) 🦀 🏠 🍎 🐧 - Terminal session recorder that captures commands and outputs to SQLite. Includes local LLM summarization (Qwen2.5-0.5B) and tiered retrieval tools for efficient context usage with Claude Code.
+
 ### 💬 <a name="communication"></a>Communication
 
 Integration with communication platforms for message management and channel operations. Enables AI models to interact with team communication tools.


### PR DESCRIPTION
## Summary

Adding [wake](https://github.com/joemckenney/wake) to the Command Line section.

## What is Wake?

Wake records your terminal sessions—commands, outputs, git context—so AI assistants can see what you've been doing. No more copy-pasting logs and error messages into chat.

**The workflow:**
1. Start a recorded session with `wake shell`
2. Do your work (builds, deploys, debugging, etc.)
3. Ask Claude about what happened—it can see your terminal history

## Key Features

- **PTY-based capture** — Spawns your shell in a pseudo-terminal, recording all I/O
- **Shell hooks** — zsh/bash hooks notify wake when commands start/end
- **Local LLM summarization** — Auto-summarizes command outputs using Qwen2.5-0.5B (~468MB, runs on CPU)
- **Tiered retrieval** — `wake_list_commands` returns metadata + summaries, `wake_get_output` fetches full output on demand
- **Privacy-first** — Everything stored locally in SQLite, all inference runs on-device

## Setup

```sh
# Install
curl -sSf https://raw.githubusercontent.com/joemckenney/wake/main/install.sh | sh

# Add shell hooks
echo 'eval "$(wake init zsh)"' >> ~/.zshrc   # or ~/.bashrc for bash

# Add MCP server to Claude Code
claude mcp add wake-mcp -- wake-mcp
```

## MCP Tools

| Tool | Purpose |
|------|---------|
| `wake_status` | Current session info |
| `wake_list_commands` | List commands with metadata and summaries |
| `wake_get_output` | Fetch full output for specific command IDs |
| `wake_search` | Search command history |
| `wake_dump` | Export session as markdown |
| `wake_annotate` | Add notes to session |