### PR TITLE
Add Google Cloud Manager to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [weibaohui/k8m](https://github.com/weibaohui/k8m) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations, featuring a management interface, logging, and nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [weibaohui/kom](https://github.com/weibaohui/kom) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations. It can be integrated as an SDK into your own project and includes nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye) 🏎️ ☁️/🏠 - MCP Server for kubernetes management, and analyze your cluster, application health
+- [Google Cloud Manager](https://github.com/KishoreKu/mcp-server-gcp-manager) - Manage Cloud Run services and Secrets with self-healing capabilities.
 
 ### 👨‍💻 <a name="code-execution"></a>Code Execution
 


### PR DESCRIPTION
Added a new MCP server for Google Cloud Platform. It allows agents to manage Cloud Run and Secrets with self-healing capabilities (auto-enabling APIs). Thanks!