### PR TITLE
Add mcp-xmind server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,6 +1411,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🏢 <a name="workplace-and-productivity"></a>Workplace & Productivity
 
+- [apeyroux/mcp-xmind](https://github.com/apeyroux/mcp-xmind) 📇 🏠 🍎 🪟 🐧 - Read, create and query XMind mind maps. Supports notes (plain + HTML), planned tasks with Gantt/timeline, relationships, boundaries, summaries, themes, and multi-sheet with internal cross-links.
 - [bivex/kanboard-mcp](https://github.com/bivex/kanboard-mcp) 🏎️ ☁️ 🏠 - A Model Context Protocol (MCP) server written in Go that empowers AI agents and Large Language Models (LLMs) to seamlessly interact with Kanboard. It transforms natural language commands into Kanboard API calls, enabling intelligent automation of project, task, and user management, streamlining workflows, and enhancing productivity.
 - [bug-breeder/quip-mcp](https://github.com/bug-breeder/quip-mcp) 📇 ☁️ 🍎 🪟 🐧 - A Model Context Protocol (MCP) server providing AI assistants with comprehensive Quip document access and management. Enables document lifecycle management, smart search, comment management, and secure token-based authentication for both Quip.com and enterprise instances.
 - [devroopsaha744/TexMCP](https://github.com/devroopsaha744/TexMCP) 🐍 🏠 - An MCP server that converts LaTeX into high-quality PDF documents. It provides tools for rendering both raw LaTeX input and customizable templates, producing shareable, production-ready artifacts such as reports, resumes, and research papers.


### PR DESCRIPTION
## Summary
Add [mcp-xmind](https://github.com/apeyroux/mcp-xmind) to Workplace & Productivity section.

MCP server for reading, creating and querying XMind mind maps. Features:
- Parse and search XMind files (fuzzy search, multi-criteria)
- Create XMind files from structured JSON
- Notes (plain text + HTML), labels, markers, callouts
- Planned tasks with Gantt support (dates, progress, dependencies)
- Relationships, boundaries, summaries
- Multi-sheet with internal cross-links
- Predefined themes and layout structures

Published on npm: `npx -y @41px/mcp-xmind /path/to/xmind/files`