### PR TITLE
Add Forge MCP Server (GPU kernel optimization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [phuongrealmax/code-guardian](https://github.com/phuongrealmax/code-guardian) 📇 🏠 - AI-powered code refactor engine with 80+ MCP tools for code analysis, hotspot detection, complexity metrics, persistent memory, and automated refactoring plans.
 - [pramod/kaggle](https://github.com/KrishnaPramodParupudi/kaggle-mcp-server) 🐍 - This Kaggle MCP Server makes Kaggle more accessible by letting you browse competitions, leaderboards, models, datasets, and kernels directly within MCP, streamlining discovery for data scientists and developers.
 - [reading-plus-ai/mcp-server-data-exploration](https://github.com/reading-plus-ai/mcp-server-data-exploration) 🐍 ☁️ - Enables autonomous data exploration on .csv-based datasets, providing intelligent insights with minimal effort.
+- [RightNow-AI/forge-mcp-server](https://github.com/RightNow-AI/forge-mcp-server) 📇 ☁️ - GPU kernel optimization using 32 parallel swarm agents. Turns PyTorch into fast CUDA/Triton kernels on real datacenter GPUs (B200, H200, H100, A100) with up to 14x speedup over torch.compile.
 - [subelsky/bundler_mcp](https://github.com/subelsky/bundler_mcp) 💎 🏠 - Enables agents to query local information about dependencies in a Ruby project's `Gemfile`.
 - [zcaceres/markdownify-mcp](https://github.com/zcaceres/markdownify-mcp) 📇 🏠 - An MCP server to convert almost any file or web content into Markdown
 


### PR DESCRIPTION
## New Server

**Name:** [RightNow-AI/forge-mcp-server](https://github.com/RightNow-AI/forge-mcp-server)

**Category:** Data Science Tools

**Description:** GPU kernel optimization using 32 parallel swarm agents. Turns PyTorch into fast CUDA/Triton kernels on real datacenter GPUs (B200, H200, H100, A100) with up to 14x speedup over torch.compile.

**Language:** TypeScript
**Scope:** Cloud

**npm:** [@rightnow/forge-mcp-server](https://www.npmjs.com/package/@rightnow/forge-mcp-server)

- Alphabetically ordered within the Data Science Tools section
- Follows existing format and style conventions