### PR TITLE
Add MCP Bash Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,6 +1579,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript
+- [MCP Bash Framework](https://github.com/yaniv-golan/mcp-bash-framework) 🏠 🍎 🐧 🪟 - Build MCP servers in pure Bash 3.2+. Full spec coverage, including MCP Apps. No runtimes beyond your shell and jq or gojq.
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 
 ## Tips and Tricks


### PR DESCRIPTION
Add **[MCP Bash Framework](https://github.com/yaniv-golan/mcp-bash-framework)** to the Frameworks section.

MCP Bash Framework enables building MCP servers in pure Bash 3.2+ with:
- Full MCP spec coverage (2025-11-25), including MCP Apps
- No runtimes beyond the shell and jq/gojq
- Tools, resources, prompts, elicitation, roots, progress, cancellation
- Runs on macOS, Linux, and Windows (Git Bash)