### PR TITLE
Add amekala/ads-mcp to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
+- [amekala/ads-mcp](https://github.com/amekala/ads-mcp) 📇 ☁️ - Remote MCP server connecting ChatGPT and Claude to Google, Meta, and TikTok Ads. Create Search/PMax campaigns, audit ROAS, and manage budget pacing through natural language.
 - [BlockRunAI/x-grow](https://github.com/BlockRunAI/x-grow) 📇 ☁️ - X/Twitter algorithm optimizer with post drafting, review scoring, and AI image generation for maximum engagement.
 - [gomarble-ai/facebook-ads-mcp-server](https://github.com/gomarble-ai/facebook-ads-mcp-server) 🐍 ☁️ - MCP server acting as an interface to the Facebook Ads, enabling programmatic access to Facebook Ads data and management features.
 - [gomarble-ai/google-ads-mcp-server](https://github.com/gomarble-ai/google-ads-mcp-server) 🐍 ☁️ - MCP server acting as an interface to the Google Ads, enabling programmatic access to Google Ads data and management features.


### PR DESCRIPTION
## Summary
Adds [Adspirer ads-mcp](https://github.com/amekala/ads-mcp) to the Marketing section.

## About ads-mcp
A remote MCP server that connects ChatGPT and Claude to advertising platforms for natural language campaign management.

**Key Features:**
- 🔗 Remote MCP endpoint at https://mcp.adspirer.com/
- 📊 Google Ads: Search campaigns, Performance Max campaigns
- 📱 TikTok Ads: Campaign creation and management
- 🎯 ROAS auditing and budget pacing
- 💬 Natural language interface for ad management

**Technical:**
- TypeScript implementation (📇)
- Cloud-hosted service (☁️)
- MCP Protocol compliant

Placement is alphabetical within the Marketing section (after AdsMCP, before BlockRunAI).