### PR TITLE
Add OpZero - AI-powered web deployment MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [weibaohui/k8m](https://github.com/weibaohui/k8m) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations, featuring a management interface, logging, and nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [weibaohui/kom](https://github.com/weibaohui/kom) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations. It can be integrated as an SDK into your own project and includes nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye) 🏎️ ☁️/🏠 - MCP Server for kubernetes management, and analyze your cluster, application health
+- [opzero-sh/opzero](https://opzero.sh) 🎖️ 📇 ☁️ - Remote MCP bridge for AI-powered web deployment. Deploy HTML, React, and full-stack apps to Cloudflare, Netlify, or Vercel directly from AI agents with zero setup.
 
 ### 👨‍💻 <a name="code-execution"></a>Code Execution
 


### PR DESCRIPTION
## Summary

Adding **OpZero** to the Cloud Platforms section.

OpZero is a remote MCP server that enables AI agents to deploy HTML, React, and full-stack apps directly to Cloudflare, Netlify, or Vercel with zero setup.

- **URL**: https://opzero.sh
- **MCP Endpoint**: https://opzero.sh/mcp
- **Transport**: Streamable HTTP (remote server)

## Features

- Deploy web apps directly from AI conversations
- Supports Cloudflare Workers/Pages, Netlify, and Vercel
- Zero configuration required
- OAuth2 authentication with .well-known endpoints