### PR TITLE
DC Hub - Data Center Intelligence 

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Provides access to customer profiles inside of customer data platforms
 - [OpenDataMCP/OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP) 🐍 ☁️ - Connect any Open Data to any LLM with Model Context Protocol.
 - [sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server) 📇 ☁️ - An MCP server to access and updates profiles on an Apache Unomi CDP server.
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
+- dchub-cloud/dchub-mcp 🐍 ☁️ - Data center industry intelligence MCP server providing facility search across 20,000+ data centers in 140+ countries, market analytics, M&A tracking, capacity pipeline data, and energy infrastructure insights.
 
 ### 🗄️ <a name="databases"></a>Databases
 


### PR DESCRIPTION
DC Hub is a data center industry intelligence platform (dchub.cloud) 
providing MCP access to 20,000+ facilities across 140+ countries.

Tools include facility search, market analytics, M&A deal tracking, 
capacity pipeline monitoring, and energy infrastructure data.

MCP endpoint: https://dchub.cloud/mcp