### PR TITLE
Add CMCP — Construction Project Management MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🤖 - [Coding Agents](#coding-agents)
 * 🖥️ - [Command Line](#command-line)
 * 💬 - [Communication](#communication)
+* 🏗️ - [Construction & AEC](#construction-and-aec)
 * 👤 - [Customer Data Platforms](#customer-data-platforms)
 * 🗄️ - [Databases](#databases)
 * 📊 - [Data Platforms](#data-platforms)
@@ -427,6 +428,13 @@ Integration with communication platforms for message management and channel oper
 - [YCloud-Developers/ycloud-whatsapp-mcp-server](https://github.com/YCloud-Developers/ycloud-whatsapp-mcp-server) 📇 🏠 - MCP server for WhatsApp Business Platform by YCloud.
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) 📇 ☁️ - An MCP server to Manage Google Tasks
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.
+
+
+### 🏗️ <a name="construction-and-aec"></a>Construction & AEC
+
+Construction project management, estimating, and AEC (Architecture, Engineering & Construction) industry tools.
+
+- [LordQueso/MCP-construction](https://github.com/LordQueso/MCP-construction) 📇 ☁️ - 50-tool construction project management server with estimates, RFIs, change orders, daily logs, budgets, schedules, safety tracking, subcontractor management, and AI-enhanced reporting. OAuth 2.1 + PKCE auth, multi-tenant, Stripe billing. Live hosted at cmcp.us.
 
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms


### PR DESCRIPTION
## New Server: CMCP — Construction AI MCP Server

**Repository:** https://github.com/LordQueso/MCP-construction
**Live:** https://cmcp.us
**Category:** Construction & AEC (new category)

### What it does
50-tool MCP server for construction project management covering the full project lifecycle:
- Estimates (CSI MasterFormat, version comparison, AI reports)
- RFIs (auto-numbering, AI-drafted responses)
- Change orders (impact analysis, approval workflow)
- Daily logs (weather, crew, AI weekly reports)
- Budgets (cost code tracking, EAC forecasting)
- Schedules (critical path, float calculation)
- Safety (OSHA compliance, bilingual toolbox talks)
- Subcontractors (bid comparison, AI scorecards)
- Documents (AIA G702/G703, lien waivers)

### Why a new category
This is the first construction/AEC industry MCP server. No existing category covers construction project management. Proposed: **🏗️ Construction & AEC** (alphabetically between Communication and Customer Data Platforms).

If maintainers prefer an existing category, happy to move it to 📐 Architecture & Design.

### Technical details
- OAuth 2.1 + PKCE (S256) authentication
- Multi-tenant with scope-based access control (28 scopes)
- Stripe metered billing
- MCP Streamable HTTP transport
- Production hosted with HTTPS