### PR TITLE
Add mcp-bench-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 
 - [betterhyq/mermaid-grammer-inspector-mcp](https://github.com/betterhyq/mermaid_grammer_inspector_mcp) 📇 🏠 🍎 🪟 🐧 - A Model Context Protocol (MCP) server for validating Mermaid diagram syntax and providing comprehensive grammar checking capabilities
 - [GittyBurstein/mermaid-mcp-server](https://github.com/GittyBurstein/mermaid-mcp-server) 🐍 ☁️ - MCP server that turns local projects or GitHub repositories into Mermaid diagrams and renders them via Kroki.
+- [K1ta141k/mcp-bench-router](https://github.com/K1ta141k/mcp-bench-router) 📇 ☁️ - Routes design tasks to designarena.ai's top-ranked model via OpenRouter, with dynamic model selection across 14 design categories including websites, games, 3D scenes, and UI components.
 - [Narasimhaponnada/mermaid-mcp](https://github.com/Narasimhaponnada/mermaid-mcp) 📇 ☁️ 🍎 🪟 🐧 - AI-powered Mermaid diagram generation with 22+ diagram types including flowcharts, sequence diagrams, class diagrams, ER diagrams, architecture diagrams, state machines, and more. Features 50+ pre-built templates, advanced layout engines, SVG/PNG/PDF exports, and seamless integration with GitHub Copilot, Claude, and any MCP-compatible client. Install via NPM: `npm install -g @narasimhaponnada/mermaid-mcp-server`
 
 ### <a name="bio"></a>Biology, Medicine and Bioinformatics


### PR DESCRIPTION
Adds mcp-bench-router to Architecture & Design — routes design tasks to designarena.ai's top-ranked model via OpenRouter across 14 design categories.