### PR TITLE
Add AgentStore to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace
+- [AgentStore](https://github.com/techgangboss/agentstore) 📇 ☁️ 🏠 🍎 🪟 🐧 - Open-source marketplace for Claude Code plugins with gasless USDC payments via x402 protocol. Browse, install, and publish MCP-backed agents with CLI, web dashboard, and agent-friendly API.
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 📇 ☁️ 🏠 🍎 🪟 🐧 - Meta-MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized MCP interface, providing zero-configuration access to the entire AI coding ecosystem.
 - [blockrunai/blockrun-mcp](https://github.com/blockrunai/blockrun-mcp) 📇 ☁️ 🍎 🪟 🐧 - Access 30+ AI models (GPT-5, Claude, Gemini, Grok, DeepSeek) without API keys. Pay-per-use via x402 micropayments with USDC on Base.
 - [Data-Everything/mcp-server-templates](https://github.com/Data-Everything/mcp-server-templates) 📇 🏠 🍎 🪟 🐧 - One server. All tools. A unified MCP platform that connects many apps, tools, and services behind one powerful interface—ideal for local devs or production agents.


### PR DESCRIPTION
AgentStore is an open-source marketplace for Claude Code plugins with gasless USDC payments via the x402 protocol.

- **GitHub:** https://github.com/techgangboss/agentstore
- **Website:** https://agentstore.tools
- **API docs (agent-friendly):** `GET https://api.agentstore.dev/api`

Features:
- Browse, install, and publish MCP-backed agents via CLI, web dashboard, or HTTP API
- Gasless USDC payments (EIP-3009 transferWithAuthorization)
- Agent-first API — AI agents can register and publish with zero auth for free agents
- 80/20 revenue split (publisher/platform)
- TypeScript monorepo (Next.js API, React web, CLI, MCP gateway)