### PR TITLE
Add Maximum Sats AI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [JamesANZ/prediction-market-mcp](https://github.com/JamesANZ/prediction-market-mcp) 📇 ☁️ - An MCP server that provides real-time prediction market data from multiple platforms including Polymarket, PredictIt, and Kalshi. Enables AI assistants to query current odds, prices, and market information through a unified interface.
 - [janswist/mcp-dexscreener](https://github.com/janswist/mcp-dexscreener) 📇 ☁️ - Real-time on-chain market prices using open and free Dexscreener API
 - [jjlabsio/korea-stock-mcp](https://github.com/jjlabsio/korea-stock-mcp) 📇 ☁️ - An MCP Server for Korean stock analysis using OPEN DART API and KRX API
+- [joelklabo/maximumsats-mcp](https://github.com/joelklabo/maximumsats-mcp) 📇 ☁️ - Bitcoin & Lightning Network AI tools with Web of Trust scoring. Ask questions about Bitcoin, get network stats, and look up Nostr trust scores.
 - [kukapay/binance-alpha-mcp](https://github.com/kukapay/binance-alpha-mcp) 🐍 ☁️ - An MCP server for tracking Binance Alpha trades, helping AI agents optimize alpha point accumulation.
 - [kukapay/bitcoin-utxo-mcp](https://github.com/kukapay/bitcoin-utxo-mcp) 🐍 ☁️ - An MCP server that tracks Bitcoin's Unspent Transaction Outputs (UTXO) and block statistics.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) 🐍 ☁️ -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.


### PR DESCRIPTION
Adds [maximumsats-mcp](https://github.com/joelklabo/maximumsats-mcp) to the Finance & Fintech section.

**Maximum Sats AI** — Bitcoin & Lightning Network AI tools with Web of Trust scoring for Nostr.

### Tools provided (5)

- `ask_bitcoin` — Ask questions about Bitcoin (1 free query per IP per 24h, then L402 payment)
- `bitcoin_stats` — Get current Bitcoin network statistics
- `wot_score` — Look up a Nostr pubkey's Web of Trust score (PageRank over kind:3 follow graph)
- `wot_top` — Get the top-ranked Nostr pubkeys by WoT score
- `retry_with_payment` — Retry a request with L402 Lightning payment

### Install

```
npx -y github:joelklabo/maximumsats-mcp
```

- TypeScript / Node.js
- Cloud service (talks to remote API)
- Alphabetical order maintained in Finance & Fintech section