### PR TITLE
Add Godot MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ Integration with gaming related data, game engines, and services
 
 - [CoderGamester/mcp-unity](https://github.com/CoderGamester/mcp-unity) #️⃣ 🏠 - MCP Server for Unity3d Game Engine integration for game development
 - [Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp) 📇 🏠 - A MCP server for interacting with the Godot game engine, providing tools for editing, running, debugging, and managing scenes in Godot projects.
+- [tomyud1/godot-mcp](https://github.com/tomyud1/godot-mcp) 📇 🏠 - MCP server for Godot with 32 tools for scene management, scripting, asset generation, and project visualization. Zero-setup via npx.
 - [ddsky/gamebrain-api-clients](https://github.com/ddsky/gamebrain-api-clients) ☁️ - Search and discover hundreds of thousands of video games on any platform through the [GameBrain API](https://gamebrain.co/api).
 - [hkaanengin/opendota-mcp-server](https://github.com/hkaanengin/opendota-mcp-server) 🐍 🏠 ☁️ - MCP server providing AI assistants with access to Dota 2 statistics via OpenDota API. 20+ tools for player stats, hero data, and match    analysis with natural language support.
 - [IvanMurzak/Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) #️⃣ 🏠 🍎 🪟 🐧 - MCP Server for Unity Editor and for a game made with Unity


### PR DESCRIPTION
Adding [godot-mcp](https://github.com/tomyud1/godot-mcp) — an MCP server for Godot game engine development with 32 tools for scene management, scripting, asset generation, and project visualization. Available on npm as `godot-mcp-server` with zero-setup via `npx`.