### PR TITLE
Add Raysurfer Code Caching MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [qainsights/locust-mcp-server](https://github.com/QAInsights/locust-mcp-server) 🐍 🏠 - Locust MCP Server for performance testing
 - [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) 🏎️ 🏠 - Docker container management and operations through MCP
 - [r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server) 📇 🏠 🍎 - Xcode integration for project management, file operations, and build automation
+- [rayxc-org/raysurfer-code-caching-mcp](https://github.com/rayxc-org/raysurfer-code-caching-mcp) 📇 ☁️ – MCP server for LLM output caching and reuse. Caches and retrieves code from prior AI agent executions, delivering cached outputs up to 30x faster.
 - [ReAPI-com/mcp-openapi](https://github.com/ReAPI-com/mcp-openapi) 📇 🏠 - MCP server that lets LLMs know everything about your OpenAPI specifications to discover, explain and generate code/mock data
 - [reflagcom/mcp](https://github.com/reflagcom/javascript/tree/main/packages/cli#model-context-protocol) 🎖️ 📇 ☁️ - Flag features directly from chat in your IDE with [Reflag](https://reflag.com).
 - [Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server) 🎖️ 🐍 ☁️ 🍎 - MCP server for the incident management platform [Rootly](https://rootly.com/).


### PR DESCRIPTION
## Add Raysurfer Code Caching MCP Server

Adds [raysurfer-code-caching-mcp](https://github.com/rayxc-org/raysurfer-code-caching-mcp) to the Developer Tools section.

**Raysurfer** is an LLM output caching and reuse infrastructure. The MCP server caches and retrieves code from prior AI agent executions, delivering cached outputs up to 30x faster while eliminating redundant token generation through semantic matching.

- Added in alphabetical order within the Developer Tools section
- Follows existing format with TypeScript (📇) and Cloud (☁️) badges