### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,8 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
+- [Zyla-Labs/mcp-server](https://github.com/Zyla-Labs/mcp-server) 🐍 ☁️ - MCP server exposing a single `call_api` tool to access and call 7,500+ APIs from the Zyla API Hub. Supports stdio and SSE transport.
+
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds the Zyla API Hub MCP Server to the Aggregators category.

This MCP server exposes a single `call_api` tool that allows AI agents to programmatically access and call 7,500+ APIs available on the Zyla API Hub.

It supports both stdio and SSE transport, making it compatible with local and network-based MCP clients such as Claude Desktop, Cursor, and OpenAI Agents SDK.

Repository: https://github.com/Zyla-Labs/mcp-server