### PR TITLE
Add x402mail to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Integration with communication platforms for message management and channel oper
 - [userad/didlogic_mcp](https://github.com/UserAd/didlogic_mcp) 🐍 ☁️ - An MCP server for [DIDLogic](https://didlogic.com). Adds functionality to manage SIP endpoints, numbers and destinations.
 - [wyattjoh/imessage-mcp](https://github.com/wyattjoh/imessage-mcp) 📇 🏠 🍎 - A Model Context Protocol server for reading iMessage data from macOS.
 - [wyattjoh/jmap-mcp](https://github.com/wyattjoh/jmap-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that provides tools for interacting with JMAP (JSON Meta Application Protocol) email servers. Built with Deno and using the jmap-jam client library.
+- [x402mail](https://github.com/MuzsaiLajos/x402mail) 🐍 ☁️ - Email API with x402 micropayments. Send and receive emails with USDC on Base - no API keys, no accounts. [Website](https://x402mail.com)
 - [YCloud-Developers/ycloud-whatsapp-mcp-server](https://github.com/YCloud-Developers/ycloud-whatsapp-mcp-server) 📇 🏠 - MCP server for WhatsApp Business Platform by YCloud.
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) 📇 ☁️ - An MCP server to Manage Google Tasks
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.


### PR DESCRIPTION
Adds [x402mail](https://github.com/MuzsaiLajos/x402mail) — an email API with x402 micropayments.

- **Category:** Communication
- **Language:** Python 🐍
- **Scope:** Cloud ☁️
- **What it does:** Send and receive emails via MCP with USDC micropayments on Base. No API keys, no accounts — wallet is your identity.
- **Website:** https://x402mail.com