### PR TITLE
Add ris-mcp-ts (Austrian Legal Information System)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Access to legal information, legislation, and legal databases. Enables AI models to search and analyze legal documents and regulatory information.
 
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
-- [philrox/ris-mcp-ts](https://github.com/philrox/ris-mcp-ts) 📇 ☁️ - Access Austrian federal laws, state laws, court decisions, and legal documents via the RIS (Rechtsinformationssystem) API with 12 specialized tools. [![philrox/ris-mcp-ts MCP server](https://glama.ai/mcp/servers/philrox/ris-mcp-ts/badges/score.svg)](https://glama.ai/mcp/servers/philrox/ris-mcp-ts)
+- [philrox/ris-mcp-ts](https://github.com/philrox/ris-mcp-ts) [![philrox/ris-mcp-ts MCP server](https://glama.ai/mcp/servers/philrox/ris-mcp-ts/badges/score.svg)](https://glama.ai/mcp/servers/philrox/ris-mcp-ts) 📇 ☁️ - Access Austrian federal laws, state laws, court decisions, and legal documents via the RIS (Rechtsinformationssystem) API with 12 specialized tools.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
## New Server

Adds [ris-mcp-ts](https://github.com/philrox/ris-mcp-ts) to the **Legal** category.

**What it does:** MCP Server for the Austrian Legal Information System (RIS - Rechtsinformationssystem). Provides 12 specialized tools for searching and retrieving Austrian federal laws, state laws, court decisions, law gazettes, government bills, and more via the official RIS API.

**Category:** ⚖️ Legal

- Published on npm: [`ris-mcp-ts`](https://www.npmjs.com/package/ris-mcp-ts)
- Listed on MCP Registry: `io.github.philrox/ris`
- MIT License
- 611+ tests, full CI/CD