### PR TITLE
Add Maximum Sats MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [JamesANZ/prediction-market-mcp](https://github.com/JamesANZ/prediction-market-mcp) 📇 ☁️ - An MCP server that provides real-time prediction market data from multiple platforms including Polymarket, PredictIt, and Kalshi. Enables AI assistants to query current odds, prices, and market information through a unified interface.
 - [janswist/mcp-dexscreener](https://github.com/janswist/mcp-dexscreener) 📇 ☁️ - Real-time on-chain market prices using open and free Dexscreener API
 - [jjlabsio/korea-stock-mcp](https://github.com/jjlabsio/korea-stock-mcp) 📇 ☁️ - An MCP Server for Korean stock analysis using OPEN DART API and KRX API
+- [joelklabo/maximumsats-mcp](https://github.com/joelklabo/maximumsats-mcp) 📇 ☁️ - Bitcoin AI tools and Nostr Web of Trust scoring with native Lightning L402 micropayments. 12 tools: trust scores, Sybil detection, trust paths, network health, and AI text/image generation.
 - [kukapay/binance-alpha-mcp](https://github.com/kukapay/binance-alpha-mcp) 🐍 ☁️ - An MCP server for tracking Binance Alpha trades, helping AI agents optimize alpha point accumulation.
 - [kukapay/bitcoin-utxo-mcp](https://github.com/kukapay/bitcoin-utxo-mcp) 🐍 ☁️ - An MCP server that tracks Bitcoin's Unspent Transaction Outputs (UTXO) and block statistics.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) 🐍 ☁️ -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.


### PR DESCRIPTION
Adds [maximumsats-mcp](https://github.com/joelklabo/maximumsats-mcp) to the Finance & Fintech section.

**What it does:** MCP server with 12 tools for Bitcoin AI and Nostr Web of Trust scoring, with native Lightning L402 micropayments.

**Tools include:**
- `wot_score` — PageRank trust score for any Nostr pubkey
- `wot_sybil_check` — 5-signal Sybil detection
- `wot_trust_path` — hop-by-hop trust path between pubkeys
- `wot_network_health` — network metrics (51K+ nodes, Gini coefficient)
- `wot_follow_quality` — follow list quality analysis
- `wot_trust_circle` — mutual follows with cohesion metrics
- `wot_anomalies` — ghost follower and pattern detection
- `wot_predict_link` — link prediction (5 topology signals)
- `wot_compare_providers` — cross-provider NIP-85 consensus
- `wot_influence` — follow/unfollow ripple simulation
- `ask_bitcoin` — AI text generation (21 sats)
- `generate_image` — AI image generation (100 sats)

**Category:** Finance & Fintech (alphabetically placed)
**Icons:** 📇 ☁️ (TypeScript, Cloud)