### PR TITLE
Add AgentPay to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [AgentPay](https://github.com/kar69-96/useagentpay) 📇 ☁️ - Let your agent purchase approved items within a budget, giving you back your time. Fully encrypted and local.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
Adds [AgentPay](https://github.com/kar69-96/useagentpay) to the Finance & Fintech section.

AgentPay is an MCP server that lets AI agents purchase items on any website with human-approved, cryptographically signed mandates. Credentials are encrypted locally and never leave the user's machine.

- **npm:** `@useagentpay/mcp-server`
- **Install:** `npx @useagentpay/mcp-server`
- **8 tools, 3 resources, 3 prompts**
- TypeScript, MIT licensed