### PR TITLE
Add dTelecom STT MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,6 +1368,7 @@ Translation tools and services to enable AI assistants to translate content betw
 Tools for converting text-to-speech and vice-versa
 
 - [daisys-ai/daisys-mcp](https://github.com/daisys-ai/daisys-mcp) 🐍 🏠 🍎 🪟 🐧 - Generate high-quality text-to-speech and text-to-voice outputs using the [DAISYS](https://www.daisys.ai/) platform and make it able to play and store audio generated.
+- [dTelecom/stt-mcp](https://github.com/dTelecom/stt-mcp) 📇 ☁️ 🍎 🪟 🐧 - Real-time speech-to-text with production-grade audio pipeline. Transcribe audio files using dual-engine architecture (Parakeet-TDT + Whisper). Pay per use with USDC via x402 — no API keys needed.
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration
 - [mberg/kokoro-tts-mcp](https://github.com/mberg/kokoro-tts-mcp) 🐍 🏠 - MCP Server that uses the open weight Kokoro TTS models to convert text-to-speech. Can convert text to MP3 on a local driver or auto-upload to an S3 bucket.
 - [transcribe-app/mcp-transcribe](https://github.com/transcribe-app/mcp-transcribe) 📇 🏠 - This service provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video file.


### PR DESCRIPTION
Adds [dTelecom STT](https://github.com/dTelecom/stt-mcp) to the Text-to-Speech section.

**What it does:** Real-time speech-to-text MCP server with production-grade audio pipeline (VAD, noise reduction, speech validation, dual-engine transcription, hallucination filtering). Pay per use with USDC via x402 — no API keys needed.

**Tools:**
- `transcribe_file` — transcribe WAV audio files
- `stt_pricing` — get current pricing info
- `stt_health` — check service health

**npm:** `@dtelecom/stt-mcp`
**Service:** https://x402stt.dtelecom.org