### PR TITLE
Add Pare — 62 structured MCP tools for dev workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ConfigCat/mcp-server](https://github.com/configcat/mcp-server) 🎖️ 📇 ☁️ - MCP server for interacting with ConfigCat feature flag platform. Supports managing feature flags, configs, environments, products and organizations.
 - [cqfn/aibolit-mcp-server](https://github.com/cqfn/aibolit-mcp-server) ☕ - Helping Your AI Agent Identify Hotspots for Refactoring; Help AI Understand How to 'Make Code Better'
 - [currents-dev/currents-mcp](https://github.com/currents-dev/currents-mcp) 🎖️ 📇 ☁️ Enable AI Agents to fix Playwright test failures reported to [Currents](https://currents.dev).
+- [Dave-London/pare](https://github.com/Dave-London/pare) 📇 🏠 🍎 🪵 🐧 - 62 MCP tools wrapping git, npm, cargo, go, docker, python, lint, build, and test runners with structured, token-efficient JSON output optimized for AI agents
 - [Daghis/teamcity-mcp](https://github.com/Daghis/teamcity-mcp) 📇 ☁️ 🍎 🪟 🐧 - MCP server for JetBrains TeamCity with 87 tools for builds, tests, agents, and CI/CD pipeline management. Features dual-mode operation (dev/full) and runtime mode switching.
 - [dannote/figma-use](https://github.com/dannote/figma-use) 📇 🏠 - Full Figma control: create shapes, text, components, set styles, auto-layout, variables, export. 80+ tools.
 - [davidan90/time-node-mcp](https://github.com/davidan90/time-node-mcp) 📇 🏠 - Timezone-aware date and time operations with support for IANA timezones, timezone conversion, and Daylight Saving Time handling.


### PR DESCRIPTION
## What is Pare?

[Pare](https://github.com/Dave-London/pare) is a collection of **9 MCP servers** with **62 tools** that wrap popular developer CLI tools with structured, token-efficient, schema-validated JSON output.

**Supported tools:** git, npm, cargo, go, docker, python (pip/mypy/ruff/pytest/uv/black), build (tsc/esbuild/vite/webpack), lint (eslint/prettier/biome), and test runners (pytest/jest/vitest/mocha).

**Key feature:** Up to 95% fewer tokens than raw CLI output via MCP `structuredContent` + `outputSchema`. Every tool returns both human-readable text and typed JSON.

## Details

- **npm packages**: `@paretools/git`, `@paretools/test`, `@paretools/npm`, `@paretools/build`, `@paretools/lint`, `@paretools/python`, `@paretools/docker`, `@paretools/cargo`, `@paretools/go`
- **Language**: TypeScript
- **Scope**: Local
- **Platforms**: macOS, Windows, Linux
- **License**: MIT
- **Tests**: 1,334 tests across 80+ files
- **Listed on**: Official MCP Registry (`io.github.Dave-London/*`)

## Checklist

- [x] Entry is alphabetically sorted within the Developer Tools section
- [x] Follows the standard format with appropriate badges (📇 🏠 🍎 🪟 🐧)
- [x] Description is concise and accurate