### PR TITLE
Add Artefact Revenue Intelligence MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Integration with communication platforms for message management and channel oper
 
 Provides access to customer profiles inside of customer data platforms
 
-- [alexboissAV/artefact-mcp-server](https://github.com/alexboissAV/artefact-mcp-server) 🐍 ☁️ 🏠 - Revenue intelligence MCP server with RFM analysis (11-segment classification), 14.5-point ICP scoring, and pipeline health scoring. Embeds [Artefact Formula](https://artefactventures.com) methodology. HubSpot integration.
+- [alexboissAV/artefact-mcp-server](https://github.com/alexboissAV/artefact-mcp-server) 🐍 ☁️ 🏠 - Revenue intelligence MCP server with RFM analysis, 14.5-point ICP scoring, and pipeline health scoring. HubSpot integration.
 - [antv/mcp-server-chart](https://github.com/antvis/mcp-server-chart) 🎖️ 📇 ☁️ - A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - [hustcc/mcp-echarts](https://github.com/hustcc/mcp-echarts) 📇 🏠 - Generate visual charts using [Apache ECharts](https://echarts.apache.org) with AI MCP dynamically.
 - [hustcc/mcp-mermaid](https://github.com/hustcc/mcp-mermaid) 📇 🏠 - Generate [mermaid](https://mermaid.js.org/) diagram and chart with AI MCP dynamically.


### PR DESCRIPTION
## Server Details

- **Name:** Artefact Revenue Intelligence MCP Server
- **Repository:** https://github.com/alexboissAV/artefact-mcp-server
- **Language:** Python
- **Category:** Customer Data Platforms

## What It Does

Revenue intelligence MCP server with:
- **RFM Analysis** — 11-segment customer classification (Champions through Lost)
- **ICP Scoring** — 14.5-point model across Firmographic (5pts), Behavioral (5pts), and Strategic (4.5pts) dimensions
- **Pipeline Health** — 0-100 health score with velocity metrics, conversion rates, and at-risk deal detection

Embeds the Artefact Formula methodology from real B2B consulting engagements. HubSpot integration with built-in sample data for testing.

## Why It's Different

Every existing HubSpot/CRM MCP server is a data connector (CRUD operations). This is the first MCP server purpose-built for revenue intelligence with scoring models embedded.

## Links

- [PyPI](https://pypi.org/project/artefact-mcp/)
- [GitHub](https://github.com/alexboissAV/artefact-mcp-server)