### PR TITLE
Add coo-quack/calc-mcp to Other Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -582,6 +582,7 @@ Gitリポジトリおよびバージョン管理プラットフォームとの�
 - [bart6114/my-bear-mcp-server](https://github.com/bart6114/my-bear-mcp-server/) 📇 🏠 🍎 - BearのsqliteDBと直接統合してBear Note取得アプリのノートとタグを読み取り可能
 - [billster45/mcp-chatgpt-responses](https://github.com/billster45/mcp-chatgpt-responses) 🐍 ☁️ - ClaudeがChatGPTと通信してWeb検索機能を使用するためのMCPサーバー
 - [blurrah/mcp-graphql](https://github.com/blurrah/mcp-graphql) 📇 ☁️ - AIがGraphQLサーバーをクエリ可能にする
+- [coo-quack/calc-mcp](https://github.com/coo-quack/calc-mcp) 📇 🏠 - AIが苦手な21のツール — 正確な数学計算、暗号学的乱数生成、日付計算、ハッシュ、エンコーディング、単位変換など
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) 📇 🏠 - Claude Desktop（または任意のMCPクライアント）がMarkdownノート（Obsidianボルトなど）を含むディレクトリを読み取り・検索できるコネクター
 - [chrishayuk/mcp-cli](https://github.com/chrishayuk/mcp-cli) 🐍 🏠 - MCPサーバーテスト用のもう一つのCLIツール
 - [danhilse/notion_mcp](https://github.com/danhilse/notion_mcp) 🐍 ☁️ - NotionのAPIと統合してパーソナルToDoリストを管理

--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [blurrah/mcp-graphql](https://github.com/blurrah/mcp-graphql) 📇 ☁️ - Allows the AI to query GraphQL servers
 - [boldsign/boldsign-mcp](https://github.com/boldsign/boldsign-mcp) 📇 ☁️ - Search, request, and manage e-signature contracts effortlessly with [BoldSign](https://boldsign.com/).
 - [brianxiadong/ones-wiki-mcp-server](https://github.com/brianxiadong/ones-wiki-mcp-server) ☕ ☁️/🏠 - A Spring AI MCP-based service for retrieving ONES Waiki content and converting it to AI-friendly text format.
+- [coo-quack/calc-mcp](https://github.com/coo-quack/calc-mcp) 📇 🏠 - 21 tools for things AI is bad at — deterministic math, cryptographic randomness, date arithmetic, hashing, encoding, unit conversion, and more.
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) 📇 🏠 - This is a connector to allow Claude Desktop (or any MCP client) to read and search any directory containing Markdown notes (such as an Obsidian vault).
 - [caol64/wenyan-mcp](https://github.com/caol64/wenyan-mcp) 📇 🏠 🍎 🪟 🐧 - Wenyan MCP Server, which lets AI automatically format Markdown articles and publish them to WeChat GZH.
 - [chrishayuk/mcp-cli](https://github.com/chrishayuk/mcp-cli) 🐍 🏠 - Yet another CLI tool for testing MCP servers


### PR DESCRIPTION
## New Server

- **Name:** [@coo-quack/calc-mcp](https://github.com/coo-quack/calc-mcp)
- **Category:** Other Tools and Integrations
- **Language:** TypeScript (📇)
- **Scope:** Local (🏠)

### Description

21 tools for things AI is bad at — deterministic math, cryptographic randomness, date arithmetic, hashing, encoding, unit conversion, and more.

LLMs hallucinate calculations, can't generate true random numbers, and struggle with timezones. This MCP server provides accurate, deterministic results for these operations.

### Tools included

math, count, datetime, random (UUID v4/v7, ULID, passwords, shuffle), hash, base64, encode, date, regex, base conversion, diff, json_validate, cron_parse, luhn, ip, color, convert (72 units), char_info, jwt_decode, url_parse, semver

### Links

- npm: https://www.npmjs.com/package/@coo-quack/calc-mcp
- GitHub: https://github.com/coo-quack/calc-mcp
- Docker: https://github.com/coo-quack/calc-mcp/pkgs/container/calc-mcp
- [Glama](https://glama.ai/mcp/servers/@coo-quack/calc-mcp)

Added to both README.md and README-ja.md.