### PR TITLE
Add WinRemote MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [recursechat/mcp-server-apple-shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts) 📇 🏠 🍎 - An MCP Server Integration with Apple Shortcuts
 - [Retio-ai/pagemap](https://github.com/Retio-ai/Retio-pagemap) 🐍 🏠 - Compresses ~100K-token HTML into 2-5K-token structured maps while preserving every actionable element. AI agents can read and interact with any web page at 97% fewer tokens.
 - [serkan-ozal/browser-devtools-mcp](https://github.com/serkan-ozal/browser-devtools-mcp) 📇 - An MCP Server enables AI assistants to autonomously test, debug, and validate web applications.
-- [dddabtc/winremote-mcp](https://github.com/dddabtc/winremote-mcp) 🐍 🏠 🪟 - Windows remote desktop control and automation via MCP. 40+ tools for screenshots, mouse/keyboard control, file operations, registry, services, OCR, screen recording, and more.
+- [dddabtc/winremote-mcp](https://github.com/dddabtc/winremote-mcp) [![dddabtc/winremote-mcp MCP server](https://glama.ai/mcp/servers/dddabtc/win-remote-mcp/badges/score.svg)](https://glama.ai/mcp/servers/dddabtc/win-remote-mcp) 🐍 🏠 🪟 - Windows remote desktop control and automation via MCP. 40+ tools for screenshots, mouse/keyboard control, file operations, registry, services, OCR, screen recording, and more.
 - [softvoyagers/pageshot-api](https://github.com/softvoyagers/pageshot-api) 📇 ☁️ - Free webpage screenshot capture API with format, viewport, and dark mode options. No API key required.
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 


### PR DESCRIPTION
Add WinRemote MCP to the Browser Automation section.

WinRemote MCP is a Windows remote desktop control and automation server that provides 40+ tools for screenshots, mouse/keyboard control, file operations, registry access, services management, OCR, screen recording, and more.

- **GitHub**: https://github.com/dddabtc/winremote-mcp
- **Category**: Browser Automation (desktop automation and control)
- **Platform**: Windows
- **Type**: Local service