### PR TITLE
Add lightning-enable-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Latex MCP Server](https://github.com/Yeok-c/latex-mcp-server)** - MCP Server to compile latex, download/organize/read cited papers, run visualization scripts and add figures/tables to latex.
 - **[Lazy Toggl MCP](https://github.com/movstox/lazy-toggl-mcp)** - Simple unofficial MCP server to track time via Toggl API
 - **[libSQL by xexr](https://github.com/Xexr/mcp-libsql)** - MCP server for libSQL databases with comprehensive security and management tools. Supports file, local HTTP, and remote Turso databases with connection pooling, transaction support, and 6 specialized database tools.
+- **[Lightning Enable MCP](https://github.com/refined-element/lightning-enable-mcp)** - Add Bitcoin Lightning payments to any MCP-enabled agent. Pay invoices, check balances, access L402 paywalled APIs. Works with Strike, OpenNode, Coinos, and NWC wallets.
 - **[Linear](https://github.com/tacticlaunch/mcp-linear)** - Integrates with Linear project management systems.
 - **[llm-context](https://github.com/cyberchitta/llm-context.py)** - Share code context with LLMs via Model Context Protocol or clipboard.
 - **[LunchMoney](https://github.com/akutishevsky/lunchmoney-mcp)** - MCP server for LunchMoney personal finance and budgeting tool.


### PR DESCRIPTION
## Add Lightning Enable MCP Server

**Category:** Finance & Fintech

[lightning-enable-mcp](https://github.com/refined-element/lightning-enable-mcp) is an open-source MCP server that enables AI agents to make Bitcoin Lightning Network payments. MIT licensed, free to use.

### Features
- Pay Lightning invoices and get preimage proof of payment
- Auto-pay L402 (HTTP 402) challenges for seamless API access
- Check wallet balance and track payment history
- Budget controls for AI agent spending safety
- Create invoices to receive payments

### Supported Wallets
Strike, OpenNode, Nostr Wallet Connect (NWC), and LND

### Available As
- .NET global tool (`dotnet tool install -g LightningEnable.Mcp`)
- Python package (`pip install lightning-enable-mcp`)
- Docker (`docker pull refinedelement/lightning-enable-mcp`)

### Links
- GitHub: https://github.com/refined-element/lightning-enable-mcp
- Docs: https://docs.lightningenable.com
- NuGet: https://www.nuget.org/packages/LightningEnable.Mcp
- PyPI: https://pypi.org/project/lightning-enable-mcp