### PR TITLE
Add Frihet ERP MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) 📇 ☁️ - Bankless Onchain API to interact with smart contracts, query transaction and token information
 - [base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information
+- [berthelius/frihet-mcp](https://github.com/berthelius/frihet-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - First AI-native MCP server for a Spanish ERP. Manage invoices, expenses, clients, products, quotes and webhooks through any AI assistant.
 - [bitteprotocol/mcp](https://github.com/BitteProtocol/mcp) 📇 - Bitte Protocol integration to run AI Agents on several blockchains.
 - [carsol/monarch-mcp-server](https://github.com/carsol/monarch-mcp-server) 🐍 ☁️ - MCP server providing read-only access to Monarch Money financial data, enabling AI assistants to analyze transactions, budgets, accounts, and cashflow data with MFA support.
 - [chargebee/mcp](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol) 🎖️ 📇 ☁️ - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com/).


### PR DESCRIPTION
Adds [Frihet ERP MCP Server](https://github.com/berthelius/frihet-mcp) to the **Finance & Fintech** section.

## What is Frihet?

The first official MCP server for a Spanish ERP. 31 tools for managing invoices, expenses, clients, products, quotes, and webhooks — all through natural language.

- **npm:** [@frihet/mcp-server](https://www.npmjs.com/package/@frihet/mcp-server)
- **License:** MIT
- **Transport:** stdio
- **Language:** TypeScript
- **Platforms:** macOS, Windows, Linux, Cloud

No other Spanish ERP has an official MCP server.