### PR TITLE
Add Scrapi MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [angheljf/nyt](https://github.com/angheljf/nyt) 📇 ☁️ - Search articles using the NYTimes API
 - [apify/mcp-server-rag-web-browser](https://github.com/apify/mcp-server-rag-web-browser) 📇 ☁️ - An MCP server for Apify's open-source RAG Web Browser Actor to perform web searches, scrape URLs, and return content in Markdown.
 - [Bigsy/Clojars-MCP-Server](https://github.com/Bigsy/Clojars-MCP-Server) 📇 ☁️ - Clojars MCP Server for upto date dependency information of Clojure libraries
+- [bamchi/scrapi-mcp-server](https://github.com/bamchi/scrapi-mcp-server) 📇 ☁️ - Web scraping for AI agents. Bypass anti-bot systems and get clean, LLM-ready Markdown via MCP. Supports both stdio and Streamable HTTP transports.
 - [blazickjp/arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server) ☁️ 🐍 - Search ArXiv research papers
 - [boikot-xyz/boikot](https://github.com/boikot-xyz/boikot) 🦀☁️ - Model Context Protocol Server for looking up company ethics information. Learn about the ethical and unethical actions of major companies.
 - [brave/brave-search-mcp-server](https://github.com/brave/brave-search-mcp-server) 📇 ☁️ - Web search capabilities using Brave's Search API


### PR DESCRIPTION
## Summary

Add [Scrapi MCP Server](https://github.com/bamchi/scrapi-mcp-server) to the **Search & Data Extraction** category.

**Scrapi** is a web scraping MCP server that bypasses anti-bot systems and returns clean, LLM-ready Markdown content. Built on 8+ years of production scraping infrastructure.

- **Language:** TypeScript (📇)
- **Scope:** Cloud Service (☁️)
- **npm:** [@scrapi.ai/mcp-server](https://www.npmjs.com/package/@scrapi.ai/mcp-server)
- **Transport:** Both stdio and Streamable HTTP
- **Tools:** `scrape_url`, `scrape_urls`, `get_usage`, `get_billing`, `scraper_server_status`
- **License:** MIT