### PR TITLE
Update lightningfaucet entry to lightning-wallet-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,7 +929,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [kukapay/web3-jobs-mcp](https://github.com/kukapay/web3-jobs-mcp) 🐍 ☁️ -  An MCP server that provides AI agents with real-time access to curated Web3 jobs.
 - [kukapay/whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp) 🐍 ☁️ -  A mcp server for tracking cryptocurrency whale transactions.
 - [laukikk/alpaca-mcp](https://github.com/laukikk/alpaca-mcp) 🐍 ☁️ - An MCP Server for the Alpaca trading API to manage stock and crypto portfolios, place trades, and access market data.
-- [lightningfaucet/mcp-server](https://github.com/lightningfaucet/mcp-server) 📇 ☁️ - AI Agent Bitcoin wallet with L402 payments - operators fund agents, agents make autonomous Lightning Network payments.
+- [lightningfaucet/lightning-wallet-mcp](https://github.com/lightningfaucet/lightning-wallet-mcp) 📇 ☁️ - Give AI agents a Bitcoin wallet with Lightning Network payments, L402 protocol support, and multi-agent budget management.
 - [lnbits/LNbits-MCP-Server](https://github.com/lnbits/LNbits-MCP-Server) - Am MCP server for LNbits Lightning Network wallet integration.
 - [logotype/fixparser](https://gitlab.com/logotype/fixparser) 🎖 📇 ☁️ 🏠 📟  - FIX Protocol (send orders, market data, etc.) written in TypeScript.
 - [longportapp/openapi](https://github.com/longportapp/openapi/tree/main/mcp) - 🐍 ☁️ - LongPort OpenAPI provides real-time stock market data, provides AI access analysis and trading capabilities through MCP.


### PR DESCRIPTION
## Summary

- Updates the existing `lightningfaucet/mcp-server` entry to `lightningfaucet/lightning-wallet-mcp` in the Finance & Fintech section
- The npm package was renamed from `lightning-faucet-mcp` to `lightning-wallet-mcp` to better reflect its purpose
- Updated the description to be more concise and highlight key features (Lightning payments, L402 support, multi-agent budget management)

The new repo URL is live: https://github.com/lightningfaucet/lightning-wallet-mcp
The npm package is published: https://www.npmjs.com/package/lightning-wallet-mcp