### PR TITLE
Add AgentPay to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [JamesANZ/prediction-market-mcp](https://github.com/JamesANZ/prediction-market-mcp) 📇 ☁️ - An MCP server that provides real-time prediction market data from multiple platforms including Polymarket, PredictIt, and Kalshi. Enables AI assistants to query current odds, prices, and market information through a unified interface.
 - [janswist/mcp-dexscreener](https://github.com/janswist/mcp-dexscreener) 📇 ☁️ - Real-time on-chain market prices using open and free Dexscreener API
 - [jjlabsio/korea-stock-mcp](https://github.com/jjlabsio/korea-stock-mcp) 📇 ☁️ - An MCP Server for Korean stock analysis using OPEN DART API and KRX API
+- [kar69-96/useagentpay](https://github.com/kar69-96/useagentpay) 📇 🏠 - Local-first payments for AI agents with human approval, encrypted credentials, and budget controls.
 - [kukapay/binance-alpha-mcp](https://github.com/kukapay/binance-alpha-mcp) 🐍 ☁️ - An MCP server for tracking Binance Alpha trades, helping AI agents optimize alpha point accumulation.
 - [kukapay/bitcoin-utxo-mcp](https://github.com/kukapay/bitcoin-utxo-mcp) 🐍 ☁️ - An MCP server that tracks Bitcoin's Unspent Transaction Outputs (UTXO) and block statistics.
 - [kukapay/blockbeats-mcp](https://github.com/kukapay/blockbeats-mcp) 🐍 ☁️ -  An MCP server that delivers blockchain news and in-depth articles from BlockBeats for AI agents.


### PR DESCRIPTION
## Summary
- Adds [AgentPay](https://github.com/kar69-96/useagentpay) to the **Finance & Fintech** section
- AgentPay is a local-first MCP server for AI agent payments with human approval, encrypted credentials, and budget controls

## Details
- TypeScript codebase (📇), local service (🏠)
- Entry placed in alphabetical order within the Finance & Fintech section