### PR TITLE
Add SuperLocalMemory V2 to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [unibaseio/membase-mcp](https://github.com/unibaseio/membase-mcp) 📇 ☁️ - Save and query your agent memory in distributed way by Membase
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
 - [varun29ankuS/shodh-memory](https://github.com/varun29ankuS/shodh-memory) 🦀 🏠 - Cognitive memory for AI agents with Hebbian learning, 3-tier architecture, and knowledge graphs. Single ~15MB binary, runs offline on edge devices.
-- [varun369/SuperLocalMemoryV2](https://github.com/varun369/SuperLocalMemoryV2) 🐍 🏠 🍎 🪟 🐧 - Universal local-first AI memory system with 10-layer architecture: SQLite + FTS5 full-text search, knowledge graph (Leiden clustering), pattern learning, agent trust scoring, and real-time event streaming. Works with 17+ AI tools (Claude, Cursor, Windsurf, ChatGPT, VS Code, Codex, Gemini CLI, JetBrains) via MCP. 100% free, zero cloud dependencies.
+- [varun369/SuperLocalMemoryV2](https://github.com/varun369/SuperLocalMemoryV2) 📇 🏠 🍎 🪟 🐧 - Universal local-first AI memory system with knowledge graphs, hybrid search, and pattern learning. Persistent memory across sessions for 17+ AI tools via MCP. Zero cloud dependencies, fully free.
 - [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 ☁️ 🏠 - Hindsight: Agent Memory That Works Like Human Memory - Built for AI Agents to manage Long Term Memory
 
 ### ⚖️ <a name="legal"></a>Legal


### PR DESCRIPTION
Adding [SuperLocalMemory V2](https://github.com/varun369/SuperLocalMemoryV2) to the **Knowledge & Memory** section.

- **What:** Local-first AI memory system with knowledge graphs, hybrid search, and pattern learning
- **MCP:** 6 tools, 4 resources, 2 prompts
- **Install:** `npm install -g superlocalmemory`
- **Compatibility:** 17+ AI tools (Claude, Cursor, Windsurf, VS Code, ChatGPT, etc.)
- **License:** MIT
- **Website:** https://superlocalmemory.com

Placed alphabetically between `varun29ankuS/shodh-memory` and `vectorize-io/hindsight`.