### PR TITLE
Add WorkClear MCP server (Australian contractor licence verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Access to legal information, legislation, and legal databases. Enables AI models to search and analyze legal documents and regulatory information.
 
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
+- [mrmolt/workclear](https://github.com/mrmolt/workclear) 📇 ☁️ - Australian contractor licence verification across 7 states — 1.3M+ records from official government registers. Search, verify, and check licence status via WorkClear API.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
## WorkClear MCP Server

**npm:** [`@workclear/mcp-server`](https://www.npmjs.com/package/@workclear/mcp-server)
**Repository:** [mrmolt/workclear](https://github.com/mrmolt/workclear)
**Category:** Legal

### Description

WorkClear provides Australian contractor licence verification across 7 states and territories (QLD, NSW, VIC, WA, SA, ACT, NT) with 1.3M+ records sourced directly from official government registers.

### Tools

- `search_licences` — Search by name, licence number, or business across all states
- `verify_licence` — Verify a specific licence and get full details
- `get_state_coverage` — Check coverage and record counts

### Installation

```json
{
  "mcpServers": {
    "workclear": {
      "command": "npx",
      "args": ["-y", "@workclear/mcp-server"],
      "env": {
        "WORKCLEAR_API_KEY": "your-api-key"
      }
    }
  }
}
```

**Website:** https://workclear.com.au