### PR TITLE
Add edinet-mcp to Finance & Fintech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [ajtgjmdjp/edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) 🐍 ☁️ - EDINET XBRL parsing and MCP server for Japanese public company financial data (BS/PL/CF) with automatic normalization across J-GAAP, IFRS, and US-GAAP.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
## New MCP Server: edinet-mcp

**Repository:** https://github.com/ajtgjmdjp/edinet-mcp
**PyPI:** https://pypi.org/project/edinet-mcp/
**License:** Apache-2.0

### What it does

edinet-mcp is an EDINET XBRL parsing library and MCP server for Japanese public company financial data. It provides programmatic access to Japan's EDINET financial disclosure system, normalizing XBRL filings across accounting standards (J-GAAP / IFRS / US-GAAP) into canonical Japanese labels.

### MCP Tools (7)

| Tool | Description |
|------|-------------|
| `search_companies` | Search 5,000+ Japanese companies by name, ticker, or EDINET code |
| `get_filings` | Retrieve financial filings within a date range |
| `get_financial_statements` | Parse normalized BS/PL/CF statements |
| `get_financial_metrics` | Calculate ROE, ROA, profit margins, etc. |
| `compare_financial_periods` | Year-over-year comparisons |
| `list_available_labels` | Discover available financial line items |
| `get_company_info` | Get detailed company metadata |

### Key Features

- 161 normalized XBRL mappings across J-GAAP, IFRS, and US-GAAP
- Fully async Python library with Polars/pandas DataFrame export
- Built on FastMCP
- 179 tests, CI passing

### Checklist

- [x] Entry added in alphabetical order within Finance & Fintech section
- [x] Format follows existing conventions (`[repo](url) 🐍 ☁️ - description`)
- [x] Links verified
- [x] Description is concise and informative