### PR TITLE
Add Japan finance MCP servers (edinet-mcp, estat-mcp, tdnet-disclosure-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 
 Data Platforms for data integration, transformation and pipeline orchestration.
 
-- [ajtgjmdjp/boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) 🐍 ☁️ - Access Bank of Japan statistics (CGPI, TANKAN, Flow of Funds, Balance of Payments, BIS). 16 datasets with automatic Shift_JIS handling. No API key required.
+- [ajtgjmdjp/tdnet-disclosure-mcp](https://github.com/ajtgjmdjp/tdnet-disclosure-mcp) 🐍 ☁️ - Access Japanese timely disclosures (TDNet) for 4,000+ listed companies. Retrieve earnings, dividends, forecast revisions, buybacks, and other filings with automatic category classification. No API key required.
 - [ajtgjmdjp/estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) 🐍 ☁️ 🏠 - Access Japanese government statistics from [e-Stat](https://www.e-stat.go.jp/). Search and fetch data from 3,000+ statistical tables covering population, GDP, CPI, labor, trade, and regional data.
 - [alkemiai/alkemi-mcp](https://github.com/alkemi-ai/alkemi-mcp) 📇 ☁️ - MCP Server for natural language querying of Snowflake, Google BigQuery, and DataBricks Data Products through Alkemi.ai.
 - [avisangle/method-crm-mcp](https://github.com/avisangle/method-crm-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Production-ready MCP server for Method CRM API integration with 20 comprehensive tools for tables, files, users, events, and API key management. Features rate limiting, retry logic, and dual transport support (stdio/HTTP).


### PR DESCRIPTION
## Japan Finance Data Stack — 3 MCP servers for Japanese financial data

Adds three MCP servers covering different aspects of Japanese financial data:

### 1. [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) [<img alt="Glama" src="https://glama.ai/mcp/servers/@ajtgjmdjp/edinet-mcp/badge" height="20">](https://glama.ai/mcp/servers/@ajtgjmdjp/edinet-mcp) — Finance & Fintech
Access Japan's [EDINET](https://disclosure.edinet-fsa.go.jp/) financial disclosure system. Search 5,000+ listed companies, retrieve normalized XBRL financial statements (BS/PL/CF) across J-GAAP/IFRS/US-GAAP, and calculate financial metrics. Published on [PyPI](https://pypi.org/project/edinet-mcp/).

### 2. [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) [<img alt="Glama" src="https://glama.ai/mcp/servers/@ajtgjmdjp/estat-mcp/badge" height="20">](https://glama.ai/mcp/servers/@ajtgjmdjp/estat-mcp) — Data Platforms
Access Japanese government statistics from [e-Stat](https://www.e-stat.go.jp/) (政府統計の総合窓口). Search and fetch data from 3,000+ statistical tables covering population, GDP, CPI, labor, trade, and regional data. Published on [PyPI](https://pypi.org/project/estat-mcp/).

### 3. [tdnet-disclosure-mcp](https://github.com/ajtgjmdjp/tdnet-disclosure-mcp) [<img alt="Glama" src="https://glama.ai/mcp/servers/@ajtgjmdjp/tdnet-disclosure-mcp/badge" height="20">](https://glama.ai/mcp/servers/@ajtgjmdjp/tdnet-disclosure-mcp) — Data Platforms
Access Japanese timely disclosures (TDNet) for 4,000+ listed companies. Retrieve earnings, dividends, forecast revisions, buybacks, and other filings with automatic category classification. No API key required. Published on [PyPI](https://pypi.org/project/tdnet-disclosure-mcp/).

All three are Apache-2.0 licensed Python packages with CI, type checking, and tests.