### PR TITLE
Add AgentPMT to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace
+- [AgentPMT](https://github.com/Apoth3osis-ai/agentpmt-mcp-public) 🐍 ☁️ 🍎 🪟 🐧 - Remote MCP server and tool marketplace for AI agents with budget-controlled USDC payments on Base blockchain. Discover, purchase, and use tools through a single Streamable HTTP endpoint.
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 📇 ☁️ 🏠 🍎 🪟 🐧 - Meta-MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized MCP interface, providing zero-configuration access to the entire AI coding ecosystem.
 - [blockrunai/blockrun-mcp](https://github.com/blockrunai/blockrun-mcp) 📇 ☁️ 🍎 🪟 🐧 - Access 30+ AI models (GPT-5, Claude, Gemini, Grok, DeepSeek) without API keys. Pay-per-use via x402 micropayments with USDC on Base.
 - [Data-Everything/mcp-server-templates](https://github.com/Data-Everything/mcp-server-templates) 📇 🏠 🍎 🪟 🐧 - One server. All tools. A unified MCP platform that connects many apps, tools, and services behind one powerful interface—ideal for local devs or production agents.


### PR DESCRIPTION
## Add AgentPMT to Aggregators

Adds [AgentPMT](https://github.com/Apoth3osis-ai/agentpmt-mcp-public) to the Aggregators section in alphabetical order.

### What is AgentPMT?

AgentPMT is a Web3 payment platform and tool marketplace for AI agents. It provides a remote MCP server where agents can discover, purchase, and use tools and services with budget-controlled USDC payments on the Base blockchain.

### Details

- **Type:** Remote MCP server (Streamable HTTP)
- **MCP Endpoint:** https://mcp.agentpmt.com/mcp
- **Language:** Python (FastAPI)
- **Category:** Aggregators - provides a single MCP server for accessing many tools and services
- **Repository:** https://github.com/Apoth3osis-ai/agentpmt-mcp-public
- **Website:** https://agentpmt.com

### Checklist

- [x] Entry placed in correct category (Aggregators)
- [x] Alphabetical order maintained
- [x] Format matches existing entries
- [x] Link points to valid GitHub repository
- [x] Description is concise and accurate