### PR TITLE
Add estat-mcp: Japanese government statistics (e-Stat) MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 
 Data Platforms for data integration, transformation and pipeline orchestration.
 
+- [ajtgjmdjp/estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) 🐍 ☁️ 🏠 - Access Japanese government statistics from [e-Stat](https://www.e-stat.go.jp/) (政府統計の総合窓口). Search, retrieve metadata, and fetch data from 3,000+ statistical tables covering population, GDP, CPI, labor, trade, and regional data with automatic pagination and Polars DataFrame export.
 - [alkemiai/alkemi-mcp](https://github.com/alkemi-ai/alkemi-mcp) 📇 ☁️ - MCP Server for natural language querying of Snowflake, Google BigQuery, and DataBricks Data Products through Alkemi.ai.
 - [avisangle/method-crm-mcp](https://github.com/avisangle/method-crm-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Production-ready MCP server for Method CRM API integration with 20 comprehensive tools for tables, files, users, events, and API key management. Features rate limiting, retry logic, and dual transport support (stdio/HTTP).
 - [aywengo/kafka-schema-reg-mcp](https://github.com/aywengo/kafka-schema-reg-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Comprehensive Kafka Schema Registry MCP server with 48 tools for multi-registry management, schema migration, and enterprise features.


### PR DESCRIPTION
## What is estat-mcp?

[estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) provides access to Japan's [e-Stat](https://www.e-stat.go.jp/) (政府統計の総合窓口), the official portal for Japanese government statistics.

**Key features:**
- Search 3,000+ statistical tables (population, GDP, CPI, labor, trade, regional data)
- Retrieve metadata to understand table structure (表章事項, 分類事項, 時間軸, 地域)
- Fetch statistical data with filtering and automatic pagination
- Polars DataFrame export
- Published on [PyPI](https://pypi.org/project/estat-mcp/)

**Category:** Data Platforms (alphabetical order before `alkemiai/alkemi-mcp`)

**Related:** Sister project of [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) (PR #1983) — together they cover company financials (EDINET) + macroeconomic statistics (e-Stat) for Japanese data.