### PR TITLE
Add mcp-skill-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [janreges/ai-distiller-mcp](https://github.com/janreges/ai-distiller) 🏎️ 🏠 - Extracts essential code structure from large codebases into AI-digestible format, helping AI agents write code that correctly uses existing APIs on the first attempt.
 - [jasonjmcghee/claude-debugs-for-you](https://github.com/jasonjmcghee/claude-debugs-for-you) 📇 🏠 - An MCP Server and VS Code Extension which enables (language agnostic) automatic debugging via breakpoints and expression evaluation.
 - [jaspertvdm/mcp-server-tibet](https://github.com/jaspertvdm/mcp-server-tibet) 🐍 ☁️ 🏠 - TIBET provenance tracking for AI decisions. Cryptographic audit trails with ERIN/ERAAN/EROMHEEN/ERACHTER intent logging for compliance.
+- [jcc-ne/mcp-skill-server](https://github.com/jcc-ne/mcp-skill-server) [glama](https://glama.ai/mcp/servers/jcc-ne/mcp-skill-server) 🐍 🏠 🍎 🪟 🐧 - Build MCP skills with rapid local iteration — skip the deploy-test-redeploy cycle and ship securely when ready.
 - [jetbrains/mcpProxy](https://github.com/JetBrains/mcpProxy) 🎖️ 📇 🏠 - Connect to JetBrains IDE
 - [Jktfe/serveMyAPI](https://github.com/Jktfe/serveMyAPI) 📇 🏠 🍎 - A personal MCP (Model Context Protocol) server for securely storing and accessing API keys across projects using the macOS Keychain.
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.


### PR DESCRIPTION
Adding [mcp-skill-server](https://github.com/jcc-ne/mcp-skill-server) to the Developer Tools section.

A local MCP server for rapid skill development — iterate with your agent in real-time, skip the deploy-test-redeploy cycle, and ship securely when ready.

- **Category:** Developer Tools
- **Language:** Python
- **Scope:** Local
- **OS:** macOS, Windows, Linux