### PR TITLE
Add ue5-mcp to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,7 @@ Integration with gaming related data, game engines, and services
 - [IvanMurzak/Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) #️⃣ 🏠 🍎 🪟 🐧 - MCP Server for Unity Editor and for a game made with Unity
 - [jiayao/mcp-chess](https://github.com/jiayao/mcp-chess) 🐍 🏠 - A MCP server playing chess against LLMs.
 - [kkjdaniel/bgg-mcp](https://github.com/kkjdaniel/bgg-mcp) 🏎️ ☁️ - An MCP server that enables interaction with board game related data via the BoardGameGeek API (XML API2).
+- [mirno-ehf/ue5-mcp](https://github.com/mirno-ehf/ue5-mcp) 📇 🌊 🏠 🪟 - Read and modify Unreal Engine 5 Blueprint assets with AI coding assistants.
 - [opgginc/opgg-mcp](https://github.com/opgginc/opgg-mcp) 📇 ☁️ - Access real-time gaming data across popular titles like League of Legends, TFT, and Valorant, offering champion analytics, esports schedules, meta compositions, and character statistics.
 - [pab1ito/chess-mcp](https://github.com/pab1it0/chess-mcp) 🐍 ☁️ - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 - [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.


### PR DESCRIPTION
Adds [ue5-mcp](https://github.com/mirno-ehf/ue5-mcp) — an MCP server that lets AI coding assistants read and modify Unreal Engine 5 Blueprint assets.

- TypeScript + C++ UE5 editor plugin
- Works with any UE5 5.4+ project
- Two modes: editor subsystem (zero overhead) or standalone commandlet