### PR TITLE
Add @rentaunhumano/mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1542,6 +1542,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Rai220/think-mcp](https://github.com/Rai220/think-mcp) 🐍 🏠 - Enhances any agent's reasoning capabilities by integrating the think-tools, as described in [Anthropic's article](https://www.anthropic.com/engineering/claude-think-tool).
 - [reeeeemo/ancestry-mcp](https://github.com/reeeeemo/ancestry-mcp) 🐍 🏠 - Allows the AI to read .ged files and genetic data
 - [rember/rember-mcp](https://github.com/rember/rember-mcp) 📇 🏠 - Create spaced repetition flashcards in [Rember](https://rember.com) to remember anything you learn in your chats.
+- [@rentaunhumano/mcp-server](https://www.npmjs.com/package/@rentaunhumano/mcp-server) 📇 ☁️ 🍎 🪟 🐧 - Hire Spanish-speaking humans in Latin America for real-world tasks. 15 MCP tools for task creation, human discovery, geo-matching, payments (USDC/Solana), reviews, and disputes. Sandbox mode included.
 - [roychri/mcp-server-asana](https://github.com/roychri/mcp-server-asana) - 📇 ☁️ This Model Context Protocol server implementation of Asana allows you to talk to Asana API from MCP Client such as Anthropic's Claude Desktop Application, and many more.
 - [rusiaaman/wcgw](https://github.com/rusiaaman/wcgw/blob/main/src/wcgw/client/mcp_server/Readme.md) 🐍 🏠 - Autonomous shell execution, computer control and coding agent. (Mac)
 - [SecretiveShell/MCP-wolfram-alpha](https://github.com/SecretiveShell/MCP-wolfram-alpha) 🐍 ☁️ - An MCP server for querying wolfram alpha API.


### PR DESCRIPTION
## Summary

- Adds [@rentaunhumano/mcp-server](https://www.npmjs.com/package/@rentaunhumano/mcp-server) to the **Other Tools and Integrations** section
- Placed in alphabetical order (between `rember/rember-mcp` and `roychri/mcp-server-asana`)

## About the server

**RentaUnHumano** is an MCP server that lets AI agents hire Spanish-speaking humans in Latin America for real-world tasks — photography, deliveries, verification, inspections, and more.

- **15 MCP tools**: task creation, human discovery, geo-matching, reviews, messages, disputes, payments, batch operations
- **USDC/Solana payments**: automatic payouts to humans
- **Sandbox mode**: `sandbox_` API keys for risk-free testing with demo data
- **Live in production**: [rentaunhumano.com](https://rentaunhumano.com) with 46+ missions across 20 cities in Latin America
- **Published on npm**: `@rentaunhumano/mcp-server@1.1.0`
- **TypeScript** codebase, works on macOS/Windows/Linux

### Install

```bash
npx -y @rentaunhumano/mcp-server
```

### Context

As Peter Steinberger (OpenClaw, 160k+ GitHub stars) told Y Combinator: *"My bot needs to actually get some human work done so that the human then calls the restaurant because they don't have bots... or walks there to stand in line."* That's exactly what RentaUnHumano does — it's the meatspace layer for AI agents in the Spanish-speaking world.