### PR TITLE
Add contentapi-mcp-server — Content Extraction for AI/RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [chasesaurabh/mcp-page-capture](https://github.com/chasesaurabh/mcp-page-capture) 📇 🏠 - MCP server that captures webpage screenshots, with viewport or full-page options and base64 PNG output.
 - [ConechoAI/openai-websearch-mcp](https://github.com/ConechoAI/openai-websearch-mcp/) 🐍 🏠 ☁️ - This is a Python-based MCP server that provides OpenAI `web_search` build-in tool.
 - [ConechoAI/openai-websearch-mcp](https://github.com/ConechoAI/openai-websearch-mcp/) 🐍 🏠 ☁️ - This is a Python-based MCP server that provides OpenAI `web_search` built-in tool.
+- [contentapi-mcp-server](https://www.npmjs.com/package/contentapi-mcp-server) 📇 ☁️ - Extract content from YouTube (transcripts, summaries, chapters), web pages, Twitter/X threads, and Reddit posts for AI agents and RAG pipelines via [ContentAPI](https://getcontentapi.com). Supports batch processing, structured data extraction, and website crawling.
 - [Crawleo/Crawleo-MCP](https://github.com/Crawleo/Crawleo-MCP) ☁️ 🐍 – Crawleo Search & Crawl API
 - [Crawleo/Crawleo-MCP](https://github.com/Crawleo/Crawleo-MCP) ☁️ 🐍 – Crawleo search & Crawling API
 - [czottmann/kagi-ken-mcp](https://github.com/czottmann/kagi-ken-mcp) 📇 ☁️ - Work with Kagi *without* API access (you'll need to be a customer, tho). Searches and summarizes. Uses Kagi session token for easy authentication.


### PR DESCRIPTION
## contentapi-mcp-server

**npm:** https://www.npmjs.com/package/contentapi-mcp-server
**API:** https://getcontentapi.com
**Docs:** https://getcontentapi.com/docs

### Description

MCP server for ContentAPI — a universal content extraction API. Enables AI assistants (Claude, Cursor, Windsurf) to:

- Extract YouTube transcripts (with AI/Whisper fallback for videos without captions)
- Extract clean content from web pages (handles JS-rendered pages)
- Read Twitter/X threads
- Read Reddit posts and comments
- Batch process multiple URLs
- Extract structured data using AI (schema-based)
- Crawl entire websites

### MCP Tools Provided
- `extract_web` — Extract content from web pages
- `extract_youtube_transcript` — Get video transcripts
- `extract_youtube_summary` — AI-generated video summaries
- `extract_batch` — Process multiple URLs at once
- `extract_structured` — Schema-based data extraction
- `crawl_website` — Crawl and extract entire sites
- `search_web` — Web search

### Install
```bash
npx contentapi-mcp-server
```

### Category
Added under **Search & Data Extraction** (alphabetically).

### Legend
- 📇 TypeScript
- ☁️ Cloud Service