### PR TITLE
Add Dwellsmith (home management) and Groupthink (meeting participation) MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Integration with communication platforms for message management and channel oper
 - [jaipandya/producthunt-mcp-server](https://github.com/jaipandya/producthunt-mcp-server) 🐍 🏠 - MCP server for Product Hunt. Interact with trending posts, comments, collections, users, and more.
 - [jaspertvdm/mcp-server-rabel](https://github.com/jaspertvdm/mcp-server-rabel) 🐍 ☁️ 🏠 - AI-to-AI messaging via I-Poll protocol and AInternet. Enables agents to communicate using .aint domains, semantic messaging, and trust-based routing.
 - [joinly-ai/joinly](https://github.com/joinly-ai/joinly) 🐍☁️ - MCP server to interact with browser-based meeting platforms (Zoom, Teams, Google Meet). Enables AI agents to send bots to online meetings, gather live transcripts, speak text, and send messages in the meeting chat.
+- [groupthinkai/mcp-meeting-server](https://github.com/groupthinkai/mcp-meeting-server) 📇 ☁️ 🍎 🪟 🐧 - Join Google Meet, Zoom, or Teams meetings as a named AI participant. Listen to transcripts, speak via TTS, send chat messages, and save per-agent meeting notes.
 - [jtalk22/slack-mcp-server](https://github.com/jtalk22/slack-mcp-server) 📇 ☁️ 🏠 🍎 🪟 🐧 - Your complete Slack context for Claude—DMs, channels, threads, search. No OAuth apps, no admin approval. `--setup` and done, 11 tools, auto-refresh.
 - [keturiosakys/bluesky-context-server](https://github.com/keturiosakys/bluesky-context-server) 📇 ☁️ - Bluesky instance integration for querying and interaction
 - [khan2a/telephony-mcp-server](https://github.com/khan2a/telephony-mcp-server) 🐍 💬 - MCP Telephony server for automating voice calls with Speech-to-Text and Speech Recognition to summarize call conversations. Send and receive SMS, detect voicemail, and integrate with Vonage APIs for advanced telephony workflows.
@@ -990,6 +991,7 @@ Integration with gaming related data, game engines, and services
 Control smart home devices, home network equipment, and automation systems.
 
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
+- [project-dwellsmith/mcp-server](https://github.com/project-dwellsmith/mcp-server) 📇 ☁️ 🏠 🍎 🪟 🐧 - Manage household tasks, relationships, helpers, and home maintenance through natural language. The human layer of home management — tasks, contacts, and coordination rather than device control.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds two MCP servers:

**Dwellsmith** (Home Automation) — Household management through natural language: tasks, relationships/contacts, helpers, home maintenance. Unique in the home automation category as it manages the human/coordination layer rather than device control.

**Groupthink** (Communication) — AI agents join meetings as named speaking participants. Supports Google Meet, Zoom, and Teams. Includes transcript access, TTS speech, chat messaging, and per-agent notes.

Both are open source, TypeScript/Node.js, and work with Claude Desktop and Claude Code.