### PR TITLE
Add nordic-registry-mcp-server to Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1917,6 +1917,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [NON906/omniparser-autogui-mcp](https://github.com/NON906/omniparser-autogui-mcp) - 🐍 Automatic operation of on-screen GUI.
 - [offorte/offorte-mcp-server](https://github.com/offorte/offorte-mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - The Offorte Proposal Software MCP server enables creation and sending of business proposals.
 - [olalonde/mcp-human](https://github.com/olalonde/mcp-human) 📇 ☁️ - When your LLM needs human assistance (through AWS Mechanical Turk)
+- [olgasafonova/miro-mcp-server](https://github.com/olgasafonova/miro-mcp-server) 🏎️ ☁️ - Control Miro whiteboards. 88 tools for boards, diagrams, mindmaps, connectors, tags, frames, and export. OAuth2 + token auth.
 - [olgasafonova/productplan-mcp-server](https://github.com/olgasafonova/productplan-mcp-server) 🏎️ ☁️ - Query ProductPlan roadmaps. Access OKRs, ideas, launches, and timeline data.
 - [orellazi/coda-mcp](https://github.com/orellazri/coda-mcp) 📇 ☁️ - MCP server for [Coda](https://coda.io/)
 - [osinmv/funciton-lookup-mcp](https://github.com/osinmv/function-lookup-mcp) 🐍 🏠 🍎 🐧 - MCP server for function signature lookups.


### PR DESCRIPTION
Nordic Registry MCP Server provides access to official business registries across four Nordic countries (Norway, Denmark, Finland, Sweden).

23 tools covering:
- Company search and details across all four countries
- Board members, CEO, and auditor roles (Norway)
- Signature rights and prokura verification (Norway)
- Branch offices and production units
- Batch company lookups
- Annual report retrieval (Sweden)

Built with Go, uses free public APIs. Sweden requires free OAuth2 registration.

https://github.com/olgasafonova/nordic-registry-mcp-server