### PR TITLE
Add MCPList.site to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 ## Community
 
-* [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
+* [MCPList.site](https://mcplist.site) - Open directory of MCP servers with trust scores, security scanning, and user reviews
+* [r/mcp Reddit](https://www.reddit.com/r/mcp)
 
 ## Legend
 


### PR DESCRIPTION
## What is MCPList?

[MCPList.site](https://mcplist.site) is an open directory of MCP servers with:

- **Trust Scores** - Automated security scanning (prompt injection, tool poisoning, secrets exposure) with a calculated trust score for each server
- **User Reviews** - Community ratings and reviews for servers
- **260+ Servers** - Searchable and filterable catalog
- **Detailed Documentation** - Tool listings, installation commands, and compatibility info

## Why add it?

MCPList complements the awesome-list by providing a web-based discovery experience with security-focused trust scoring that helps users evaluate MCP servers before installing them.

The site is live at https://mcplist.site