### PR TITLE
Add Aganium MCP Bridge to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace
+- [Aganium/mcp-agenium-bridge](https://github.com/Aganium/mcp-agenium-bridge) 📇 ☁️ - Bidirectional bridge between MCP and the agent:// protocol. Expose MCP tools as named agents with DNS-based discovery and mTLS, or use remote agents as MCP tools in Claude/Cursor.
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 📇 ☁️ 🏠 🍎 🪟 🐧 - Meta-MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized MCP interface, providing zero-configuration access to the entire AI coding ecosystem.
 - [blockrunai/blockrun-mcp](https://github.com/blockrunai/blockrun-mcp) 📇 ☁️ 🍎 🪟 🐧 - Access 30+ AI models (GPT-5, Claude, Gemini, Grok, DeepSeek) without API keys. Pay-per-use via x402 micropayments with USDC on Base.
 - [Data-Everything/mcp-server-templates](https://github.com/Data-Everything/mcp-server-templates) 📇 🏠 🍎 🪟 🐧 - One server. All tools. A unified MCP platform that connects many apps, tools, and services behind one powerful interface—ideal for local devs or production agents.


### PR DESCRIPTION
## New Server: Aganium MCP Bridge

**Repository:** https://github.com/Aganium/mcp-agenium-bridge  
**Category:** Aggregators  
**Language:** TypeScript  
**Scope:** Cloud  

### Description

Bidirectional bridge between MCP (Model Context Protocol) and the agent:// protocol. Expose MCP tools as named agents with DNS-based discovery and mTLS, or use remote agents as MCP tools in Claude/Cursor.

### Key Features

- Bidirectional protocol translation (MCP to agent://)
- DNS-based agent discovery
- mTLS security
- npm: @agenium/mcp-server
- Live demo: https://demo.agenium.net