### PR TITLE
Add mineru-mcp to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,6 +1217,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [leehanchung/bing-search-mcp](https://github.com/leehanchung/bing-search-mcp) 📇 ☁️ - Web search capabilities using Microsoft Bing Search API
 - [lfnovo/content-core](https://github.com/lfnovo/content-core) 🐍 🏠 - Extract content from URLs, documents, videos, and audio files using intelligent auto-engine selection. Supports web pages, PDFs, Word docs, YouTube transcripts, and more with structured JSON responses.
 - [Linked-API/linkedapi-mcp](https://github.com/Linked-API/linkedapi-mcp) 🎖️ 📇 ☁️ - MCP server that lets AI assistants control LinkedIn accounts and retrieve real-time data.
+- [linxule/mineru-mcp](https://github.com/linxule/mineru-mcp) 📇 ☁️ - MCP server for MinerU document parsing API. Parse PDFs, images, DOCX, and PPTX with OCR (109 languages), batch processing (200 docs), page ranges, and local file upload. 73% token reduction with structured output.
 - [luminati-io/brightdata-mcp](https://github.com/luminati-io/brightdata-mcp) 📇 ☁️ - Discover, extract, and interact with the web - one interface powering automated access across the public internet.
 - [mikechao/brave-search-mcp](https://github.com/mikechao/brave-search-mcp) 📇 ☁️ - Web, Image, News, Video, and Local Point of Interest search capabilities using Brave's Search API
 - [modelcontextprotocol/server-fetch](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/fetch) 🐍 🏠 ☁️ - Efficient web content fetching and processing for AI consumption


### PR DESCRIPTION
Adds [mineru-mcp](https://github.com/linxule/mineru-mcp) to the Search & Data Extraction section.

**What it does:** MCP server for the [MinerU](https://mineru.net) document parsing API. Parse PDFs, images, DOCX, and PPTX with OCR support for 109 languages. Features batch processing (up to 200 docs), page range extraction, local file upload, and structured markdown output with 73% token reduction vs alternatives.

**6 tools:** `mineru_parse`, `mineru_status`, `mineru_batch`, `mineru_batch_status`, `mineru_upload_batch`, `mineru_download_results`

- Published on npm: `npx -y mineru-mcp`
- Listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io)