### PR TITLE
Add Apollo Intelligence Network MCP Server (26 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 
 Data Platforms for data integration, transformation and pipeline orchestration.
 
+- [bnmbnmai/mcp-proxy](https://github.com/bnmbnmai/mcp-proxy) 📇 ☁️ 🍎 🪟 🐧 - Apollo Intelligence Network — 26 tools for curated intelligence feeds, DeFi yields/protocol data, crypto prices, real-time X/Twitter search, NLP-powered pain point detection, web scraping via 190+ country residential proxies, and OSINT. Pay-per-use via x402 micropayments (USDC on Base).
 - [alkemiai/alkemi-mcp](https://github.com/alkemi-ai/alkemi-mcp) 📇 ☁️ - MCP Server for natural language querying of Snowflake, Google BigQuery, and DataBricks Data Products through Alkemi.ai.
 - [avisangle/method-crm-mcp](https://github.com/avisangle/method-crm-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Production-ready MCP server for Method CRM API integration with 20 comprehensive tools for tables, files, users, events, and API key management. Features rate limiting, retry logic, and dual transport support (stdio/HTTP).
 - [aywengo/kafka-schema-reg-mcp](https://github.com/aywengo/kafka-schema-reg-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Comprehensive Kafka Schema Registry MCP server with 48 tools for multi-registry management, schema migration, and enterprise features.
@@ -846,6 +847,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [ariadng/metatrader-mcp-server](https://github.com/ariadng/metatrader-mcp-server) 🐍 🏠 🪟 - Enable AI LLMs to execute trades using MetaTrader 5 platform
 - [armorwallet/armor-crypto-mcp](https://github.com/armorwallet/armor-crypto-mcp) 🐍 ☁️ - MCP to interface with multiple blockchains, staking, DeFi, swap, bridging, wallet management, DCA, Limit Orders, Coin Lookup, Tracking and more.
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) 📇 ☁️ - Bankless Onchain API to interact with smart contracts, query transaction and token information
+- [bnmbnmai/mcp-proxy](https://github.com/bnmbnmai/mcp-proxy) 📇 ☁️ 🍎 🪟 🐧 - Apollo Intelligence: DeFi yields (18K+ pools), protocol TVL rankings, live crypto prices, FX rates, and curated market intelligence. x402 micropayments (USDC on Base).
 - [base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information
 - [bitteprotocol/mcp](https://github.com/BitteProtocol/mcp) 📇 - Bitte Protocol integration to run AI Agents on several blockchains.


### PR DESCRIPTION
## Apollo Intelligence Network

**npm:** [`@apollo_ai/mcp-proxy`](https://www.npmjs.com/package/@apollo_ai/mcp-proxy)  
**GitHub:** [bnmbnmai/mcp-proxy](https://github.com/bnmbnmai/mcp-proxy)  
**Website:** [apolloai.team](https://apolloai.team)

### What it does
26 MCP tools for AI agents — intelligence feeds, DeFi data (18K+ yield pools, 7000+ protocols), crypto prices, real-time X/Twitter search, web scraping via 190+ country residential proxies, NLP-powered pain point detection, and OSINT (IP/domain intel).

### Why it's interesting
- **Pay-per-use via x402** (USDC on Base) — no API keys, no subscriptions
- Built for the agent-to-agent economy
- All data pre-computed and cached — zero latency
- Listed on [x402scan](https://www.x402scan.com)

### Categories
Added under:
- **Data Platforms** (primary — curated intelligence feeds, NLP analytics)
- **Finance & Fintech** (DeFi yields, crypto prices, FX rates)

### Quick start
```json
{
  "mcpServers": {
    "apollo": {
      "command": "npx",
      "args": ["@apollo_ai/mcp-proxy"]
    }
  }
}
```