### PR TITLE
Add Agenium MCP server — agent:// discovery bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
+- [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace
 - [askbudi/roundtable](https://github.com/askbudi/roundtable) 📇 ☁️ 🏠 🍎 🪟 🐧 - Meta-MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized MCP interface, providing zero-configuration access to the entire AI coding ecosystem.
 - [blockrunai/blockrun-mcp](https://github.com/blockrunai/blockrun-mcp) 📇 ☁️ 🍎 🪟 🐧 - Access 30+ AI models (GPT-5, Claude, Gemini, Grok, DeepSeek) without API keys. Pay-per-use via x402 micropayments with USDC on Base.


### PR DESCRIPTION
## New Server: Agenium MCP Server

**Category:** 🔗 Aggregators

**Description:** Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.

**Repository:** https://github.com/Aganium/agenium  
**npm:** [`@agenium/mcp-server`](https://www.npmjs.com/package/@agenium/mcp-server)  
**License:** MIT  
**Language:** TypeScript (📇)

### What it does
- Bridges MCP servers to the [agent:// protocol](https://agenium.net) network
- Adds DNS-like agent discovery — each agent gets a `agent://name` URI
- mTLS transport with trust scores for secure agent-to-agent communication
- Compatible with Claude Desktop, Cursor, and other MCP clients
- 56 tests passing (unit + integration + E2E)

### Quick Install
```bash
npx @agenium/mcp-server
```