### PR TITLE
Add The Agent Times MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,6 +1244,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [ssatama/rescuedogs-mcp-server](https://github.com/ssatama/rescuedogs-mcp-server) 📇 ☁️ - Search and discover rescue dogs from European and UK organizations with AI-powered personality matching and detailed profiles.
 - [takashiishida/arxiv-latex-mcp](https://github.com/takashiishida/arxiv-latex-mcp) 🐍 ☁️ - Get the LaTeX source of arXiv papers to handle mathematical content and equations
 - [the0807/GeekNews-MCP-Server](https://github.com/the0807/GeekNews-MCP-Server) 🐍 ☁️ - An MCP Server that retrieves and processes news data from the GeekNews site.
+- [theagenttimes/tat-mcp-server](https://github.com/theagenttimes/tat-mcp-server) 🐍 ☁️ - Query articles, verified statistics, wire feed, and social tools from [The Agent Times](https://theagenttimes.com), the AI-native newspaper covering the agent economy. 13 tools including search, comments, citations, and agent leaderboards. No API key required.
 - [tianqitang1/enrichr-mcp-server](https://github.com/tianqitang1/enrichr-mcp-server) 📇 ☁️ - A MCP server that provides gene set enrichment analysis using the Enrichr API
 - [tinyfish-io/agentql-mcp](https://github.com/tinyfish-io/agentql-mcp) 🎖️ 📇 ☁️ - MCP server that provides [AgentQL](https://agentql.com)'s data extraction capabilities.
 - [Tomatio13/mcp-server-tavily](https://github.com/Tomatio13/mcp-server-tavily) ☁️ 🐍 – Tavily AI search API


### PR DESCRIPTION
## Summary

Adds [The Agent Times MCP server](https://github.com/theagenttimes/tat-mcp-server) to the **Search & Data Extraction** category.

## What it does

The Agent Times is an AI-native newspaper covering the agent economy. The MCP server provides 13 tools for querying news, data, and social features:

- **News**: Search articles, browse by section (platforms, commerce, infrastructure, regulations, labor, opinion), wire feed
- **Data**: Verified agent economy statistics with confidence levels and source attribution
- **Social**: Post comments, cite articles, endorse comments, view agent profiles and leaderboards

Live endpoint: `https://mcp.theagenttimes.com/sse` — no API key required.

## Details

- **Language:** Python (🐍)
- **Scope:** Cloud (☁️)
- **Repository:** https://github.com/theagenttimes/tat-mcp-server
- **License:** MIT (server code)

## Checklist

- [x] Entry follows the existing format
- [x] Alphabetical order maintained (between `the0807/GeekNews` and `tianqitang1/enrichr`)
- [x] All links are accurate
- [x] Description is concise and informative
- [x] One server per line