### PR TITLE
Add musclesworked-mcp to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,6 +1332,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Tools for accessing sports-related data, results, and statistics.
 
 - [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server) 🏎️ ☁️ – Access structured sports data via the Cloudbet API. Query upcoming events, live odds, stake limits, and market info across soccer, basketball, tennis, esports, and more.
+- [csjoblom/musclesworked-mcp](https://github.com/csjoblom/musclesworked-mcp) 📇 ☁️ - Exercise-to-muscle mapping MCP server. Look up muscles worked by 856 exercises across 65 muscles and 14 muscle groups, analyze workouts for gaps, and find alternative exercises ranked by muscle overlap.
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp) 🐍 🏠 - MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.
 - [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp) 🐍 🏠 - Query TrainingPeaks workouts, analyze CTL/ATL/TSB fitness metrics, and compare power/pace PRs through Claude Desktop.
 - [khaoss85/arvo-mcp](https://github.com/khaoss85/arvo-mcp) 📇 ☁️ - AI workout coach MCP server for Arvo. Access training data, workout history, personal records, body progress, and 29 fitness tools through Claude Desktop.


### PR DESCRIPTION
Adds [musclesworked-mcp](https://github.com/csjoblom/musclesworked-mcp) to the Sports section.

## Server Details

- **Language**: TypeScript (📇)
- **Scope**: Cloud (☁️)
- **Description**: Exercise-to-muscle mapping MCP server with 856 exercises, 65 muscles, and 14 muscle groups. Provides primary/secondary/stabilizer activation data, workout gap analysis, and alternative exercise recommendations.

## Tools

| Tool | Description |
|------|-------------|
| `get_muscles_worked` | Get primary, secondary, and stabilizer muscles for an exercise |
| `find_exercises` | Find exercises targeting a specific muscle with optional filters |
| `analyze_workout` | Analyze a workout for coverage, gaps, and imbalances |
| `get_alternatives` | Find alternative exercises ranked by muscle overlap |
| `search_exercises` | Search exercises by name |
| `search_muscles` | Search muscles by name |

Website: https://musclesworked.com