### PR TITLE
Add Zitadel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [vespo92/OPNSenseMCP](https://github.com/vespo92/OPNSenseMCP) 📇 🏠 - MCP Server for managing & interacting with Open Source NGFW OPNSense via Natural Language
 - [zboralski/ida-headless-mcp](https://github.com/zboralski/ida-headless-mcp) 🏎️ 🐍 🏠 🍎 🪟 🐧 - Headless IDA Pro binary analysis via MCP. Multi-session concurrency with Go orchestration and Python workers. Supports Il2CppDumper and Blutter metadata import for Unity and Flutter reverse engineering.
 - [zinja-coder/apktool-mcp-server](https://github.com/zinja-coder/apktool-mcp-server) 🐍 🏠 - APKTool MCP Server is a MCP server for the Apk Tool to provide automation in reverse engineering of Android APKs.
+- [takleb3rry/zitadel-mcp](https://github.com/takleb3rry/zitadel-mcp) 📇 ☁️ 🏠 - MCP server for Zitadel identity management — manage users, projects, OIDC apps, roles, and service accounts through natural language.
 - [zinja-coder/jadx-ai-mcp](https://github.com/zinja-coder/jadx-ai-mcp) ☕ 🏠 - JADX-AI-MCP is a plugin and MCP Server for the JADX decompiler that integrates directly with Model Context Protocol (MCP) to provide live reverse engineering support with LLMs like Claude.
   
 ### 🌐 <a name="social-media"></a>Social Media


### PR DESCRIPTION
Adds [zitadel-mcp](https://github.com/takleb3rry/zitadel-mcp) to the Security section.

**What it does:** MCP server for [Zitadel](https://zitadel.com/) identity management — manage users, projects, OIDC apps, roles, and service accounts through natural language from AI tools like Claude Code.

- 25 tools covering users, projects, applications, roles, service accounts, and organizations
- TypeScript, works with Zitadel Cloud and self-hosted
- Published on npm as `zitadel-mcp-server`