### PR TITLE
Add Retio-ai/pagemap MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [PhungXuanAnh/selenium-mcp-server](https://github.com/PhungXuanAnh/selenium-mcp-server) 🐍 🏠 🍎 🪟 🐧 - A Model Context Protocol server providing web automation capabilities through Selenium WebDriver
 - [pskill9/web-search](https://github.com/pskill9/web-search) 📇 🏠 - An MCP server that enables free web searching using Google search results, with no API keys required.
 - [recursechat/mcp-server-apple-shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts) 📇 🏠 🍎 - An MCP Server Integration with Apple Shortcuts
+- [Retio-ai/pagemap](https://github.com/Retio-ai/Retio-pagemap) 🐍 🏠 - Compresses ~100K-token HTML into 2-5K-token structured maps while preserving every actionable element. AI agents can read and interact with any web page at 97% fewer tokens.
 - [serkan-ozal/browser-devtools-mcp](https://github.com/serkan-ozal/browser-devtools-mcp) 📇 - An MCP Server enables AI assistants to autonomously test, debug, and validate web applications.
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 


### PR DESCRIPTION
## New Server: PageMap

**Repository:** [Retio-ai/Retio-pagemap](https://github.com/Retio-ai/Retio-pagemap)
**Category:** Browser Automation
**Language:** Python 🐍
**Scope:** Local 🏠

### Description

PageMap is an MCP server that compresses ~100K-token HTML into 2-5K-token structured maps while preserving every actionable element. AI agents can read and interact with any web page at 97% fewer tokens.

### Key Features

- **3 MCP Tools:** `get_page_map`, `execute_action`, `get_page_state`
- **97% token reduction** — 2-5K tokens per page vs 50-540K for raw accessibility snapshots
- **Full interaction** — click, type, select on elements by ref number (not read-only)
- **Benchmarked:** 95.2% task success across 66 tasks on 9 e-commerce sites
- **Published on PyPI:** `pip install retio-pagemap`
- **MIT License**

### Checklist

- [x] Server linked to its repository
- [x] Brief description included
- [x] Categorized under Browser Automation
- [x] Alphabetical order maintained