### PR TITLE
Add Quackback - open-source feedback platform with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Provides access to customer profiles inside of customer data platforms
 - [hustcc/mcp-mermaid](https://github.com/hustcc/mcp-mermaid) 📇 🏠 - Generate [mermaid](https://mermaid.js.org/) diagram and chart with AI MCP dynamically.
 - [iaptic/mcp-server-iaptic](https://github.com/iaptic/mcp-server-iaptic) 🎖️ 📇 ☁️ - Connect with [iaptic](https://www.iaptic.com) to ask about your Customer Purchases, Transaction data and App Revenue statistics.
 - [OpenDataMCP/OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP) 🐍 ☁️ - Connect any Open Data to any LLM with Model Context Protocol.
+- [QuackbackIO/quackback](https://github.com/QuackbackIO/quackback) 📇 ☁️ - Open-source customer feedback platform with built-in MCP server. Agents can search feedback, triage posts, update statuses, create and comment on posts, vote, manage roadmaps, merge duplicates, and publish changelogs.
 - [sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server) 📇 ☁️ - An MCP server to access and updates profiles on an Apache Unomi CDP server.
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
 


### PR DESCRIPTION
## Quackback

[Quackback](https://github.com/QuackbackIO/quackback) is an open-source customer feedback platform with a built-in MCP server.

**Category:** Customer Data Platforms

**What agents can do:**

- Search across all feedback posts and changelogs
- Triage posts: update status, assign owners, add tags, write responses
- Create new posts and changelog entries
- Comment and vote on behalf of your team
- Manage roadmap items
- Merge and unmerge duplicate posts

Every agent action is attributed and auditable. Works with Claude, Cursor, Windsurf, and any MCP-compatible client.

**Transport:** Streamable HTTP (`/api/mcp`)
**Language:** TypeScript
**License:** AGPL-3.0