### PR TITLE
Add Cloud Latitude Labs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [aliyun/alibaba-cloud-ops-mcp-server](https://github.com/aliyun/alibaba-cloud-ops-mcp-server) 🎖️ 🐍 ☁️ - A MCP server that enables AI assistants to operation resources on Alibaba Cloud, supporting ECS, Cloud Monitor, OOS and widely used cloud products.
 - [awslabs/mcp](https://github.com/awslabs/mcp) 🎖️ ☁️ - AWS MCP servers for seamless integration with AWS services and resources.
 - [bright8192/esxi-mcp-server](https://github.com/bright8192/esxi-mcp-server) 🐍 ☁️ - A VMware ESXi/vCenter management server based on MCP (Model Control Protocol), providing simple REST API interfaces for virtual machine management.
+- [cloud-latitude/mcp-server](https://cloudlatitude.io) 📇 ☁️ - Cloud Latitude Labs MCP server with 6 tools for agent-native infrastructure, AI cost optimization, architecture reports, and Google Cloud Next 2026 raffle integration. Google Cloud Partner.
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1
 - [cyclops-ui/mcp-cyclops](https://github.com/cyclops-ui/mcp-cyclops) 🎖️ 🏎️ ☁️ - An MCP server that allows AI agents to manage Kubernetes resources through Cyclops abstraction
 - [elementfm/mcp](https://gitlab.com/elementfm/mcp) 🎖️ 🐍 📇 🏠 ☁️ - Open source podcast hosting platform


### PR DESCRIPTION
## New MCP Server

**Name:** Cloud Latitude Labs MCP Server  
**Category:** Cloud Platforms  
**Organization:** Cloud Latitude (Google Cloud Partner)  
**Website:** https://cloudlatitude.io  
**Agent Card:** https://cloudlatitude.io/.well-known/agent.json

### Description

Cloud Latitude Labs provides 6 MCP tools for enterprise AI teams:
- `get_raffle_info` — Google Cloud Next 2026 raffle details
- `get_booking_link` — Cloud Intel Brief booking
- `get_architecture_report` — 5-layer agentic stack report
- `explore_labs` — Browse Labs products and agent skills
- `get_protocols` — Supported protocol info (A2A, MCP, AG-UI, MCP-UI)
- `share_with_agent` — Agent-referred sharing with 5x raffle multiplier

### Protocols Supported
A2A, MCP, AG-UI, MCP-UI (live) + GenUI, ACP (coming soon)