### PR TITLE
Add hop SSH connection manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 ### 🖥️ <a name="command-line"></a>Command Line
 Run commands, capture output and otherwise interact with shells and command line tools.
 
+- [danmartuszewski/hop](https://github.com/danmartuszewski/hop) 🏎️ 🖥️ - Fast SSH connection manager with TUI dashboard and MCP server for discovering, searching, and executing commands on remote hosts.
+
 ### 💬 <a name="communication"></a>Communication
 
 Integration with communication platforms for message management and channel operations. Enables AI models to interact with team communication tools.


### PR DESCRIPTION
Adds [hop](https://github.com/danmartuszewski/hop) to the Command Line section.

Hop is a fast SSH connection manager built in Go, featuring a TUI dashboard and an MCP server for discovering, searching, and executing commands on remote hosts.