### PR TITLE
Add Fan Token Intel MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,6 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information
 - [bitteprotocol/mcp](https://github.com/BitteProtocol/mcp) 📇 - Bitte Protocol integration to run AI Agents on several blockchains.
-- [BrunoPessoa22/chiliz-marketing-intel](https://github.com/BrunoPessoa22/chiliz-marketing-intel) 🐍 ☁️ - 67+ tools for fan token intelligence on Chiliz Chain: whale flows, signal scores, sports calendar, backtesting, DEX trading, social sentiment. SSE transport with Bearer auth.
 - [carsol/monarch-mcp-server](https://github.com/carsol/monarch-mcp-server) 🐍 ☁️ - MCP server providing read-only access to Monarch Money financial data, enabling AI assistants to analyze transactions, budgets, accounts, and cashflow data with MFA support.
 - [chargebee/mcp](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol) 🎖️ 📇 ☁️ - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com/).
 - [codex-data/codex-mcp](https://github.com/Codex-Data/codex-mcp) 🎖️ 📇 ☁️ - [Codex API](https://www.codex.io) integration for real-time enriched blockchain and market data on 60+ networks


### PR DESCRIPTION
## What
Adding [Fan Token Intel MCP](https://github.com/BrunoPessoa22/chiliz-marketing-intel) to the Finance & Fintech section.

## Description
67+ tools for fan token intelligence on Chiliz Chain. Covers whale flow tracking, composite signal scoring, sports match-price correlation (847+ matchdays analyzed), backtesting engine, on-chain DEX trading via Kayen, cross-venue arbitrage detection (11 CEXs + DEX), governance staking, LP yield farming, social sentiment analysis, and an AI agent marketplace.

SSE transport with Bearer auth. Python server built on the MCP SDK.

## Checklist
- [x] Entry added alphabetically
- [x] Follows existing format (owner/repo, badges, description)
- [x] Repository is public
- [x] MCP server is deployed and functional