### PR TITLE
Add asc-mcp — App Store Connect API MCP server (208 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [yWorks/mcp-typescribe](https://github.com/yWorks/mcp-typescribe) 📇 🏠 - MCP server that provides Typescript API information efficiently to the agent to enable it to work with untrained APIs
 - [zaizaizhao/mcp-swagger-server](https://github.com/zaizaizhao/mcp-swagger-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server that converts OpenAPI/Swagger specifications to MCP format, enabling AI assistants to interact with REST APIs through standardized protocol.
 - [zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp) 📇 🏠 - An MCP server to flexibly fetch JSON, text, and HTML data
+- [zelentsov-dev/asc-mcp](https://github.com/zelentsov-dev/asc-mcp) 🏠 🍎 - App Store Connect API server with 208 tools for managing apps, builds, TestFlight, subscriptions, reviews, and more — directly from any MCP client.
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples


### PR DESCRIPTION
## New Server: asc-mcp

**Repository:** https://github.com/zelentsov-dev/asc-mcp
**Category:** Developer Tools
**Language:** Swift
**Badges:** 🏠 🍎

### Description

A Swift-based MCP server that bridges any MCP-compatible client with the App Store Connect API. It exposes **208 tools** across 25 workers, enabling full iOS/macOS release workflow automation through natural language:

- Multi-account management
- Full release pipeline (versions, builds, submit, phased rollout)
- TestFlight automation (beta groups, testers, builds)
- In-app purchases & subscriptions (CRUD, localizations, prices, offer codes)
- Customer reviews & responses
- Provisioning (bundle IDs, devices, certificates, profiles)
- Marketing (screenshots, custom product pages, A/B testing)
- Analytics & performance metrics

### Checklist

- [x] Server has a README with setup instructions
- [x] Server is publicly available on GitHub
- [x] Entry is in alphabetical order within the category