### PR TITLE
Add botemail-mcp-server - Email infrastructure for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🛠️ - [Other Tools and Integrations](#other-tools-and-integrations)
 
 
+- [claw-silhouette/botemail-mcp-server](https://github.com/claw-silhouette/botemail-mcp-server) 📇 ☁️ - Email infrastructure for autonomous agents. Create bot email accounts, monitor inboxes, and handle webhooks via BotEmail.ai.
 ### 🔗 <a name="aggregators"></a>Aggregators
 
 Servers for accessing many apps and tools through a single MCP server.


### PR DESCRIPTION
Adds BotEmail.ai MCP server to the Communication section. Allows agents to create bot email accounts, monitor inboxes, and handle webhooks.

Repo: https://github.com/claw-silhouette/botemail-mcp-server
Site: https://botemail.ai

**OpenClaw / ClawBot Skill:**
- ClawHub skill: https://clawhub.ai/skills/bot-email
- Skill file: https://botemail.ai/skill.md