### PR TITLE
Add mcp-ragchat — RAG chat for any website via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 
+- [gogabrielordonez/mcp-ragchat](https://github.com/gogabrielordonez/mcp-ragchat) 📇 🏠 - Add RAG-powered AI chat to any website with one command. Local vector store, multi-provider LLM (OpenAI/Anthropic/Gemini), self-contained chat server and embeddable widget.
 - [poll-the-people/customgpt-mcp](https://github.com/Poll-The-People/customgpt-mcp) 🐍 🏠 ☁️ - An MCP server for accessing all of CustomGPT.ai's anti-hallucination RAG-as-a-service API endpoints.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.
 


### PR DESCRIPTION
## mcp-ragchat

**Repository:** https://github.com/gogabrielordonez/mcp-ragchat
**Category:** End to end RAG platforms
**Language:** TypeScript
**Scope:** Local

### Description

MCP server that adds RAG-powered AI chat to any website with one command from Claude Code.

- 5 tools: ragchat_setup, ragchat_test, ragchat_serve, ragchat_widget, ragchat_status
- Local JSON-based vector store with cosine similarity search — zero cloud dependency
- Multi-provider LLM support: OpenAI, Anthropic, Gemini
- Self-contained HTTP chat server + embeddable widget
- MIT License