### PR TITLE
Add Solderable MCP server for electronic component search

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.
+- [solderable/mcp](https://solderable.dev/mcp) 📇 ☁️ - Search electronic components across LCSC's database and query datasheets with natural language. Get specifications, pricing, availability, and AI-powered part selection.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 


### PR DESCRIPTION
## What is Solderable MCP?

[Solderable](https://solderable.dev) provides an MCP server (`@solderable/mcp` on npm) that gives AI assistants access to electronic component search and datasheet querying tools.

### Tools exposed:
- **component_search** — Batch search for electronic components across the LCSC database with AI-powered part selection reasoning. Up to 10 parallel queries.
- **datasheet_query** — Natural language questions against component datasheets using LCSC part numbers.

### Installation:
```json
{
  "mcpServers": {
    "solderable": {
      "command": "npx",
      "args": ["-y", "@solderable/mcp"]
    }
  }
}
```

### Category
Added under **Embedded System** as it provides tooling for electronic component research used in embedded and hardware design workflows.

### Links
- Website: https://solderable.dev/mcp
- npm: https://www.npmjs.com/package/@solderable/mcp