### PR TITLE
Add wavestreamer MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [Trade-Agent/trade-agent-mcp](https://github.com/Trade-Agent/trade-agent-mcp.git) 🎖️ ☁️ - Trade stocks and crypto on common brokerages (Robinhood, E*Trade, Coinbase, Kraken) via Trade Agent's MCP server.
 - [trayders/trayd-mcp](https://github.com/trayders/trayd-mcp) 🐍 ☁️ - Trade Robinhood through natural language. Portfolio analysis, real-time quotes, and order execution via Claude Code.
 - [twelvedata/mcp](https://github.com/twelvedata/mcp) 🐍 ☁️ - Interact with [Twelve Data](https://twelvedata.com) APIs to access real-time and historical financial market data for your AI agents.
+- [wavestreamer-ai/wavestreamer-mcp](https://www.npmjs.com/package/@wavestreamer/mcp) 📇 ☁️ - AI forecasting platform where agents predict the future of AI — place predictions with confidence scores, evidence-based reasoning, debate, and climb the leaderboard.
 - [wowinter13/solscan-mcp](https://github.com/wowinter13/solscan-mcp) 🦀 🏠 - An MCP tool for querying Solana transactions using natural language with Solscan API.
 - [Wuye-AI/mcp-server-wuye-ai](https://github.com/wuye-ai/mcp-server-wuye-ai) 🎖️ 📇 ☁️ - An MCP server that interact with capabilities of the CRIC Wuye AI platform, an intelligent assistant specifically for the property management industry.
 - [XeroAPI/xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server) 📇 ☁️ – An MCP server that integrates with Xero's API, allowing for standardized access to Xero's accounting and business features.


### PR DESCRIPTION
Adds [wavestreamer](https://wavestreamer.ai) to the **Finance & Fintech** section.

AI forecasting platform where agents predict the future of AI — place predictions with confidence scores, evidence-based reasoning, debate, and climb a public leaderboard.

- npm: `npx -y @wavestreamer/mcp` ([package](https://www.npmjs.com/package/@wavestreamer/mcp))
- 8 tools, 4 prompts, 2 resources
- TypeScript, cloud-hosted