### PR TITLE
Add VoiceLayer — Voice I/O layer for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ Tools for converting text-to-speech and vice-versa
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration
 - [mberg/kokoro-tts-mcp](https://github.com/mberg/kokoro-tts-mcp) 🐍 🏠 - MCP Server that uses the open weight Kokoro TTS models to convert text-to-speech. Can convert text to MP3 on a local driver or auto-upload to an S3 bucket.
 - [transcribe-app/mcp-transcribe](https://github.com/transcribe-app/mcp-transcribe) 📇 🏠 - This service provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video file.
+- [EtanHey/voicelayer](https://github.com/EtanHey/voicelayer) 📇 🏠 🍎 🐧 - Voice I/O layer for Claude Code with 5 modes (announce, brief, consult, converse, think). Local TTS via edge-tts, local STT via whisper.cpp, lockfile-based session booking, user-controlled stop signal. 75 tests.
 - [ybouhjira/claude-code-tts](https://github.com/ybouhjira/claude-code-tts) 🏎️ ☁️ 🍎 🪟 🐧 - MCP server plugin for Claude Code that converts text to speech using OpenAI's TTS API. Features 6 voices, worker pool architecture, mutex-protected playback, and cross-platform support.
 
 ### 🚆 <a name="travel-and-transportation"></a>Travel & Transportation


### PR DESCRIPTION
## New Server: VoiceLayer

**Repository:** [EtanHey/voicelayer](https://github.com/EtanHey/voicelayer)
**Category:** Text-to-Speech
**Language:** TypeScript (Bun)
**Scope:** Local
**Platforms:** macOS, Linux

### Description

Voice I/O layer for Claude Code via MCP. Provides 5 voice modes:
- **announce** — fire-and-forget TTS (status updates)
- **brief** — one-way explanation (reading back decisions)
- **consult** — speak checkpoint, user may respond
- **converse** — full voice Q&A with local STT transcription
- **think** — silent markdown log (no audio)

Built with edge-tts (neural TTS), whisper.cpp (local STT), and lockfile-based session booking to prevent mic conflicts between Claude Code sessions.

**Key stats:** 7 MCP tools, 75 tests, MIT license, [documentation site](https://etanhey.github.io/voicelayer/)

### Checklist
- [x] Server exists and is functional
- [x] Added in alphabetical order within category
- [x] Follows existing format with badges
- [x] Concise description