### PR TITLE
Add Soul Spec MCP — AI agent persona manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [softvoyagers/pagedrop-api](https://github.com/softvoyagers/pagedrop-api) 📇 ☁️ - Free instant HTML hosting API with paste, file upload, and ZIP deploy support. No API key required.
 - [softvoyagers/pdfspark-api](https://github.com/softvoyagers/pdfspark-api) 📇 ☁️ - Free HTML/URL to PDF conversion API powered by Playwright. No API key required.
 - [softvoyagers/qrmint-api](https://github.com/softvoyagers/qrmint-api) 📇 ☁️ - Free styled QR code generator API with custom colors, logos, frames, and batch generation. No API key required.
+- [soul-spec-mcp](https://github.com/clawsouls/soul-spec-mcp) 📇 ☁️ - Browse, install, and apply AI agent personas via [Soul Spec](https://clawsouls.ai/spec). Search 80+ personas, preview as CLAUDE.md, and switch identity instantly with `apply_persona`.
 - [spacecode-ai/SpaceBridge-MCP](https://github.com/spacecode-ai/SpaceBridge-MCP) 🐍 🏠 🍎 🐧 - Bring structure and preserve context in vibe coding by automatically tracking issues.
 - [srijanshukla18/xray](https://github.com/srijanshukla18/xray) 🐍 🏠 - Progressive code-intelligence MCP server: map project structure, fuzzy-find symbols, and assess change-impact across Python, JS/TS, and Go (powered by `ast-grep`).
 - [st3v3nmw/sourcerer-mcp](https://github.com/st3v3nmw/sourcerer-mcp) 🏎️ ☁️ - MCP for semantic code search & navigation that reduces token waste


### PR DESCRIPTION
## Soul Spec MCP

**Repository**: https://github.com/clawsouls/soul-spec-mcp
**npm**: https://www.npmjs.com/package/soul-spec-mcp
**Language**: TypeScript

Browse, install, and apply AI agent personas via [Soul Spec](https://clawsouls.ai/spec). Connects any MCP client to the ClawSouls registry with 80+ personas.

### Tools
- `search_souls` — Search by keyword, category, or tag
- `get_soul` — Detailed info about a specific soul
- `apply_persona` — **Switch persona instantly in current session**
- `install_soul` — Download + convert to CLAUDE.md
- `preview_soul` — Preview CLAUDE.md without saving
- `list_categories` — Browse persona categories

### Setup
```json
{
  "mcpServers": {
    "soul-spec": {
      "command": "npx",
      "args": ["-y", "soul-spec-mcp"]
    }
  }
}
```

Works with Claude Desktop, Cowork, Code, Cursor, Windsurf, Continue, Cline, Zed, and any MCP-compatible client.