### PR TITLE
Add korean-keyword-mcp (Korean keyword niche analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,6 +1170,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 - [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
 - [tomba-io/tomba-mcp-server](https://github.com/tomba-io/tomba-mcp-server) 📇 ☁️ - Email discovery, verification, and enrichment tools. Find email addresses, verify deliverability, enrich contact data, discover authors and LinkedIn profiles, validate phone numbers, and analyze technology stacks.
+- [Whitening-Sinabro/korean-keyword-mcp](https://github.com/Whitening-Sinabro/korean-keyword-mcp) 📇 ☁️ 🍎 🪟 🐧 - Korean keyword niche analysis using Naver SearchAd API. 7 tools: niche scoring (0-100 + A-F grade), keyword expansion with Quick/Full scores, batch comparison, trending keyword discovery, search volume, blog competition, and 12-month trend analysis.
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
## Add korean-keyword-mcp

**Category**: Marketing

**Repository**: https://github.com/Whitening-Sinabro/korean-keyword-mcp

**npm**: https://www.npmjs.com/package/korean-keyword-mcp

### Description

Korean keyword niche analysis MCP server using Naver SearchAd, DataLab, and Blog Search APIs. The only MCP server that exposes Naver SearchAd API data (CPC competition index, click rates) for keyword research.

### 7 Tools

| Tool | Description |
|------|-------------|
| `keyword_expand` | Seed → 50+ related keywords with Quick Score + Full Score |
| `niche_score` | Single keyword 0-100 score + A-F grade |
| `search_volume` | Naver SearchAd monthly volume (PC/mobile, competition) |
| `trend` | 12-month DataLab trend |
| `blog_competition` | Blog competition analysis |
| `batch_analyze` | Batch analysis for up to 10 keywords |
| `trending_discover` | Filter rising-trend keywords from related |

### Entry Added

```
- [Whitening-Sinabro/korean-keyword-mcp](https://github.com/Whitening-Sinabro/korean-keyword-mcp) 📇 ☁️ 🍎 🪟 🐧 - Korean keyword niche analysis using Naver SearchAd API. 7 tools: niche scoring (0-100 + A-F grade), keyword expansion with Quick/Full scores, batch comparison, trending keyword discovery, search volume, blog competition, and 12-month trend analysis.
```