### PR TITLE
Add SnapRender screenshot MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [Retio-ai/pagemap](https://github.com/Retio-ai/Retio-pagemap) 🐍 🏠 - Compresses ~100K-token HTML into 2-5K-token structured maps while preserving every actionable element. AI agents can read and interact with any web page at 97% fewer tokens.
 - [serkan-ozal/browser-devtools-mcp](https://github.com/serkan-ozal/browser-devtools-mcp) 📇 - An MCP Server enables AI assistants to autonomously test, debug, and validate web applications.
 - [softvoyagers/pageshot-api](https://github.com/softvoyagers/pageshot-api) 📇 ☁️ - Free webpage screenshot capture API with format, viewport, and dark mode options. No API key required.
-- [User0856/snaprender-mcp](https://github.com/User0856/snaprender-integrations/tree/main/mcp-server) 📇 ☁️ - Screenshot API for AI agents — capture any website as PNG, JPEG, WebP, or PDF with device emulation, dark mode, ad blocking, and cookie banner removal. Free tier included.
+- [User0856/snaprender-mcp](https://github.com/User0856/snaprender-integrations/tree/main/mcp-server) [glama](https://glama.ai/mcp/servers/@User0856/snaprender-mcp) 📇 ☁️ - Screenshot API for AI agents — capture any website as PNG, JPEG, WebP, or PDF with device emulation, dark mode, ad blocking, and cookie banner removal. Free tier included.
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms


### PR DESCRIPTION
Adds [SnapRender](https://snap-render.com) to the Browser Automation section.

**What it does:** Screenshot API for AI agents — capture any website as PNG, JPEG, WebP, or PDF via MCP tools.

**Key features:**
- Device emulation (iPhone, iPad, Pixel, MacBook)
- Dark mode, ad blocking, cookie banner removal
- Full-page capture, custom viewports
- Hosted MCP endpoint (Streamable HTTP) + local npx install
- Free tier: 50 screenshots/month

**Links:**
- npm: [`snaprender-mcp`](https://www.npmjs.com/package/snaprender-mcp)
- Hosted MCP: `https://app.snap-render.com/mcp`
- Smithery: [snaprender](https://smithery.ai/server/snaprender/snaprender)
- Glama: [snaprender-mcp](https://glama.ai/mcp/servers/@User0856/snaprender-mcp)