### PR TITLE
Add OpenEvidence MCP - medical evidence server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1710,3 +1710,7 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+
+## Healthcare / Medical
+
+- [OpenEvidence MCP](https://github.com/bakhtiersizhaev/openevidence-mcp) - Unofficial MCP server for OpenEvidence clinical platform. Browser-session auth via Playwright, no API key required. Tools: auth check, history, article fetch, ask with completion polling. Supports Codex CLI, Claude Desktop, Cursor, Cline, Continue.


### PR DESCRIPTION
## PR Title
Add OpenEvidence MCP - medical evidence server

## Section
Healthcare / Medical (or Science & Research, depending on repo structure)

## Entry to add

- **[OpenEvidence MCP](https://github.com/bakhtiersizhaev/openevidence-mcp)** - Unofficial MCP server for OpenEvidence clinical platform. Browser-session auth via Playwright, no API key required. Tools: auth check, history, article fetch, ask with completion polling. Supports Codex CLI, Claude Desktop, Cursor, Cline, Continue.

## Description for PR body
OpenEvidence is used by 40%+ of US physicians for clinical decision support. This MCP server bridges it to any MCP-compatible AI client using browser-session authentication (Playwright). Apache-2.0 licensed.
