### PR TITLE
Add OpenEvidence MCP - medical evidence server

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 ### <a name="bio"></a>Biology, Medicine and Bioinformatics
 
 - [cafferychen777/ChatSpatial](https://github.com/cafferychen777/ChatSpatial) 🐍 🏠 - MCP server for spatial transcriptomics analysis with 60+ integrated methods covering cell annotation, deconvolution, spatial statistics, and visualization.
+- [bakhtiersizhaev/openevidence-mcp](https://github.com/bakhtiersizhaev/openevidence-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Unofficial MCP server for OpenEvidence clinical platform with browser-session auth via Playwright (no API key), plus tools for auth checks, history, article fetch, and evidence Q&A workflows.
 - [dnaerys/onekgpd-mcp](https://github.com/dnaerys/onekgpd-mcp) ☕ ☁️ 🍎 🪟 🐧- real-time access to 1000 Genomes Project dataset
 - [genomoncology/biomcp](https://github.com/genomoncology/biomcp) 🐍 ☁️ - Biomedical research MCP server providing access to PubMed, ClinicalTrials.gov, and MyVariant.info.
 - [hlydecker/ucsc-genome-mcp](https://github.com/hlydecker/ucsc-genome-mcp) 🐍 ☁️ - MCP server to interact with the UCSC Genome Browser API, letting you find genomes, chromosomes, and more.


### PR DESCRIPTION
## Summary
Adds OpenEvidence MCP under Biology, Medicine and Bioinformatics.

- **OpenEvidence MCP** — Unofficial MCP server for OpenEvidence clinical platform.
- Browser-session auth via Playwright (no API key required).
- Tooling: auth check, history, article fetch, ask with completion polling.
- Supports Codex CLI, Claude Desktop/Code, Cursor, Cline, Continue.

## Notes
OpenEvidence is used by a large physician base for clinical decision support; this server bridges it to MCP-compatible AI clients. Apache-2.0 licensed.