### PR TITLE
Add Speech AI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,7 @@ Translation tools and services to enable AI assistants to translate content betw
 Tools for converting text-to-speech and vice-versa
 
 - [daisys-ai/daisys-mcp](https://github.com/daisys-ai/daisys-mcp) 🐍 🏠 🍎 🪟 🐧 - Generate high-quality text-to-speech and text-to-voice outputs using the [DAISYS](https://www.daisys.ai/) platform and make it able to play and store audio generated.
+- [fasuizu-br/speech-ai-plugin](https://github.com/fasuizu-br/speech-ai-plugin) 🐍 ☁️ 🍎 🪟 🐧 - Speech processing suite: pronunciation assessment (phoneme/word/sentence scoring 0-100), speech-to-text with word timestamps, and text-to-speech with 12 English voices. Cloud API with sub-300ms latency.
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration
 - [mberg/kokoro-tts-mcp](https://github.com/mberg/kokoro-tts-mcp) 🐍 🏠 - MCP Server that uses the open weight Kokoro TTS models to convert text-to-speech. Can convert text to MP3 on a local driver or auto-upload to an S3 bucket.
 - [transcribe-app/mcp-transcribe](https://github.com/transcribe-app/mcp-transcribe) 📇 🏠 - This service provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video file.


### PR DESCRIPTION
Adds [Speech AI](https://github.com/fasuizu-br/speech-ai-plugin) to the Text-to-Speech section.

**Category**: Text-to-Speech (also includes STT and pronunciation assessment)

**Features**:
- Pronunciation assessment — score at phoneme, word, and sentence levels (0-100)
- Speech-to-text — word-level timestamps and confidence scores
- Text-to-speech — 12 English voices (American + British)

**8 MCP tools**, cloud-hosted API, sub-300ms latency.