### PR TITLE
feat: Add ClawPay MCP - Non-custodial x402 V2 payment layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) 📇 ☁️ - Bankless Onchain API to interact with smart contracts, query transaction and token information
 - [bolivian-peru/baozi-mcp](https://github.com/bolivian-peru/baozi-mcp) 📇 ☁️ - 68 tools for AI agents to interact with Solana prediction markets on [Baozi.bet](https://baozi.bet) — browse markets, place bets, claim winnings, create markets, and earn affiliate commissions.
 - [base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
+- [clawpay-mcp](https://www.npmjs.com/package/clawpay-mcp) 📇 ☁️ - Non-custodial x402 payment layer for AI agents. Agents sign transactions from their own wallet with on-chain spend limits — no custodial infrastructure, no API keys. Built on Base.
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information
 - [bitteprotocol/mcp](https://github.com/BitteProtocol/mcp) 📇 - Bitte Protocol integration to run AI Agents on several blockchains.
 - [bubilife1202/crossfin](https://github.com/bubilife1202/crossfin) 📇 ☁️ - Korean & global crypto exchange routing, arbitrage signals, and x402 USDC micropayments for AI agents. 16 tools, 9 exchanges, 11 bridge coins.


### PR DESCRIPTION
## ClawPay MCP

Adding ClawPay MCP to the **Finance & Fintech** section.

**Description:** Non-custodial x402 V2 payment layer for MCP servers. Agents sign locally — no custodial infrastructure. Session payments: pay once, all calls in the session are free.

**GitHub:** https://github.com/up2itnow0822/clawpay-mcp
**Glama:** https://glama.ai/mcp/servers/@up2itnow0822/clawpay-mcp

**Key features:**
- Non-custodial: agents hold their own keys, sign locally
- x402 V2 protocol (HTTP 402 payment required)
- Session payments: pay once per session, not per call
- USDC on Base, Arbitrum, Polygon, Etherlink
- No custodial infrastructure required