### PR TITLE
Add anybrowse - URL to LLM-ready Markdown via real Chrome browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [just-every/mcp-read-website-fast](https://github.com/just-every/mcp-read-website-fast) 📇 🏠 - Fast, token-efficient web content extraction for AI agents - converts websites to clean Markdown while preserving links. Features Mozilla Readability, smart caching, polite crawling with robots.txt support, and concurrent fetching.
 - [just-every/mcp-screenshot-website-fast](https://github.com/just-every/mcp-screenshot-website-fast) 📇 🏠 - Fast screenshot capture tool optimized for Claude Vision API. Automatically tiles full pages into 1072x1072 chunks for optimal AI processing with configurable viewports and wait strategies for dynamic content.
 - [kagisearch/kagimcp](https://github.com/kagisearch/kagimcp) ☁️ 📇 – Official Kagi Search MCP Server
+- [kc23go/anybrowse](https://github.com/kc23go/anybrowse) 📇 ☁️ - Convert any URL to LLM-ready Markdown via real Chrome browsers. 3 tools: scrape, crawl, search. Free via MCP, pay-per-use via x402. Remote MCP endpoint: `https://anybrowse.dev/mcp`
 - [kehvinbehvin/json-mcp-filter](https://github.com/kehvinbehvin/json-mcp-filter) ️🏠 📇 – Stop bloating your LLM context. Query & Extract only what you need from your JSON files.
 - [kimdonghwi94/Web-Analyzer-MCP](https://github.com/kimdonghwi94/web-analyzer-mcp) 🐍 🏠 🍎 🪟 🐧 - Extracts clean web content for RAG and provides Q&A about web pages.
 - [kshern/mcp-tavily](https://github.com/kshern/mcp-tavily.git) ☁️ 📇 – Tavily AI search API


### PR DESCRIPTION
## What is anybrowse?

[anybrowse](https://github.com/kc23go/anybrowse) converts any URL to clean, LLM-ready Markdown using real Chrome browsers. It exposes 3 MCP tools: `scrape` (single URL to Markdown), `crawl` (multi-page crawl), and `search` (web search).

## Key Features

- **Real Chrome rendering** — handles JavaScript-heavy sites, not simple HTTP fetch
- **3 MCP tools**: `scrape`, `crawl`, `search`
- **Remote MCP server** — no local install needed, endpoint: `https://anybrowse.dev/mcp` (streamable HTTP)
- **Free via MCP**, pay-per-use via x402 micropayments for API usage
- **TypeScript codebase**, cloud service

## Category

Added to **Search & Data Extraction** section — anybrowse provides web scraping, crawling, and search capabilities that convert web content into AI-consumable Markdown.

## Links

- Website: https://anybrowse.dev
- GitHub: https://github.com/kc23go/anybrowse

## Checklist

- [x] Entry follows existing format
- [x] Alphabetical order maintained (between `kagisearch/kagimcp` and `kehvinbehvin/json-mcp-filter`)
- [x] Description is concise and informative
- [x] Link points to public GitHub repository