### PR TITLE
Add AIP Identity MCP Server to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,8 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔒 <a name="security"></a>Security
 
+- [AIP Identity MCP Server](https://github.com/The-Nexus-Guard/aip/tree/main/mcp-server) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Cryptographic agent identity for MCP. Ed25519 keypairs, DID-based verification, trust scoring via vouch chains, E2E encrypted messaging, and artifact signing. Gives AI agents provable identity. ([PyPI](https://pypi.org/project/aip-mcp-server/))
+
 - [13bm/GhidraMCP](https://github.com/13bm/GhidraMCP) 🐍 ☕ 🏠 - MCP server for integrating Ghidra with AI assistants. This plugin enables binary analysis, providing tools for function inspection, decompilation, memory exploration, and import/export analysis via the Model Context Protocol.
 - [82ch/MCP-Dandan](https://github.com/82ch/MCP-Dandan) 🐍 📇 🏠 🍎 🪟 🐧 - Real-time security framework for MCP servers that detects and blocks malicious AI agent behavior by analyzing tool call patterns and intent across multiple threat detection engines.
 - [adeptus-innovatio/solvitor-mcp](https://github.com/Adeptus-Innovatio/solvitor-mcp) 🦀 🏠 - Solvitor MCP server provides tools to access reverse engineering tools that help developers extract IDL files from closed-source Solana smart contracts and decompile them.


### PR DESCRIPTION
## New MCP Server: AIP Identity

**Category:** Security

**What it does:** Cryptographic agent identity for MCP clients. Provides Ed25519 keypairs, DID-based identity verification, trust scoring via vouch chains, E2E encrypted messaging, and artifact signing.

**8 MCP tools:** register, verify, vouch, trust-score, message, sign, lookup, whoami

**Links:**
- [GitHub](https://github.com/The-Nexus-Guard/aip/tree/main/mcp-server)
- [PyPI](https://pypi.org/project/aip-mcp-server/)
- [Live Service](https://aip-service.fly.dev/docs)

**Install:** `pip install aip-mcp-server`

The MCP ecosystem currently has no standard way for agents to prove their identity. This server adds that capability.