### PR TITLE
Add CryptoMinute MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [XeroAPI/xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server) 📇 ☁️ – An MCP server that integrates with Xero's API, allowing for standardized access to Xero's accounting and business features.
 - [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402) ☁️ - Curated directory of x402 payment protocol resources, MCP servers, and tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM chains.
 - [zlinzzzz/finData-mcp-server](https://github.com/zlinzzzz/finData-mcp-server) 🐍 ☁️ - An MCP server for accessing professional financial data, supporting multiple data providers such as Tushare.
+- [zkoranges/crypto_minute](https://github.com/zkoranges/crypto_minute/tree/main/cmd/mcp) 🏎️ ☁️ - AI-powered crypto news intelligence MCP with 8 tools: news search, narrative analytics, AI-clustered stories, Reddit sentiment, YouTube engagement, historical prices, token metadata, and Telegram flash posts. Aggregates 50+ sources with significance scoring and sentiment analysis.
 - [zolo-ryan/MarketAuxMcpServer](https://github.com/Zolo-Ryan/MarketAuxMcpServer) 📇 ☁️ - MCP server for comprehensive market and financial news search with advanced filtering by symbols, industries, countries, and date ranges.
 
 ### 🎮 <a name="gaming"></a>Gaming


### PR DESCRIPTION
## Summary

Adding [CryptoMinute](https://github.com/zkoranges/crypto_minute/tree/main/cmd/mcp) to the Finance & Fintech section.

CryptoMinute is an AI-powered crypto news intelligence MCP server built in Go with 8 tools:

- **crypto-news-search** — Full-text news search across 50+ sources with significance scoring
- **crypto-analytics** — Narrative analytics and mindshare tracking per token
- **crypto-stories** — AI-clustered story narratives with sentiment aggregation
- **crypto-reddit-monitor** — Reddit sentiment analysis from crypto subreddits
- **crypto-youtube-insights** — YouTube engagement metrics from crypto channels
- **crypto-prices** — Historical price data from CoinGecko
- **crypto-tokens** — Token metadata and listings
- **crypto-flash-posts** — Telegram flash posts for breaking news

Aggregates 50+ RSS sources with AI significance scoring and sentiment analysis.

## Checklist

- [x] Alphabetically sorted in Finance & Fintech section
- [x] Follows existing format: `[owner/repo](url) emoji emoji - description`
- [x] Uses 🏎️ (Go) and ☁️ (Cloud Service) badges