### PR TITLE
Add Servicialo - open protocol for professional service delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,6 +1650,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [roychri/mcp-server-asana](https://github.com/roychri/mcp-server-asana) - 📇 ☁️ This Model Context Protocol server implementation of Asana allows you to talk to Asana API from MCP Client such as Anthropic's Claude Desktop Application, and many more.
 - [rusiaaman/wcgw](https://github.com/rusiaaman/wcgw/blob/main/src/wcgw/client/mcp_server/Readme.md) 🐍 🏠 - Autonomous shell execution, computer control and coding agent. (Mac)
 - [SecretiveShell/MCP-wolfram-alpha](https://github.com/SecretiveShell/MCP-wolfram-alpha) 🐍 ☁️ - An MCP server for querying wolfram alpha API.
+- [servicialo/mcp-server](https://github.com/servicialo/mcp-server) 📇 ☁️ - Open protocol for professional service delivery. Enables AI agents to discover, schedule, verify and settle professional services (healthcare, legal, home services) through a standardized 8-dimension model and 9-state lifecycle. First implementation: healthcare clinics in Chile.
 - [Seym0n/tiktok-mcp](https://github.com/Seym0n/tiktok-mcp) 📇 ☁️ - Interact with TikTok videos
 - [Shopify/dev-mcp](https://github.com/Shopify/dev-mcp) 📇 ☁️ - Model Context Protocol (MCP) server that interacts with Shopify Dev.
 - [simonpainter/netbox-mcp](https://github.com/simonpainter/netbox-mcp) 🐍 ☁️ - MCP server for interacting with NetBox API.


### PR DESCRIPTION
## Add Servicialo — open protocol for professional service delivery

**Entry added to:** Support & Service Management section

### What is Servicialo?

[Servicialo](https://github.com/servicialo/mcp-server) is an open protocol (v0.8) for AI-agent coordination of professional services. It provides:

- **23 MCP tools** across 6 phases: discovery, understanding, commitment, lifecycle, delivery, settlement
- **HTTP profile** with OpenAPI 3.1 spec for non-MCP integrations
- **Python SDK** for server-side implementations
- **npm package:** `npx -y @servicialo/mcp-server` (v0.7.0)

### Links

- GitHub: https://github.com/servicialo/mcp-server
- npm: https://www.npmjs.com/package/@servicialo/mcp-server
- Python SDK: https://github.com/servicialo/python-sdk
- Website: https://servicialo.com
- Protocol spec: https://github.com/servicialo/mcp-server/blob/main/PROTOCOL.md