### PR TITLE
Add PageBolt MCP server — screenshots, PDFs, OG images, narrated video recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [browsermcp/mcp](https://github.com/browsermcp/mcp) 📇 🏠 - Automate your local Chrome browser
 - [brutalzinn/simple-mcp-selenium](https://github.com/brutalzinn/simple-mcp-selenium) 📇 🏠 - An MCP Selenium Server for controlling browsers using natural language in Cursor IDE. Perfect for testing, automation, and multi-user scenarios.
 - [co-browser/browser-use-mcp-server](https://github.com/co-browser/browser-use-mcp-server) 🐍 - browser-use packaged as an MCP server with SSE transport. includes a dockerfile to run chromium in docker + a vnc server.
+- [Custodia-Admin/pagebolt-mcp](https://github.com/Custodia-Admin/pagebolt-mcp) 📇 ☁️ - MCP server for screenshots, PDFs, OG images, and narrated video recording from Claude Desktop, Cursor, and Windsurf.
 - [eat-pray-ai/yutu](https://github.com/eat-pray-ai/yutu) 🏎️ 🏠 🍎 🐧 🪟 - A fully functional MCP server and CLI for YouTube to automate YouTube operation
 - [executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright) 📇 - An MCP server using Playwright for browser automation and webscrapping
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).


### PR DESCRIPTION
Adds [pagebolt-mcp](https://github.com/Custodia-Admin/pagebolt-mcp) to the Browser Automation section.

**Entry:**
```
- [Custodia-Admin/pagebolt-mcp](https://github.com/Custodia-Admin/pagebolt-mcp) 📇 ☁️ - MCP server for screenshots, PDFs, OG images, and narrated video recording from Claude Desktop, Cursor, and Windsurf.
```

`pagebolt-mcp` is the official MCP server for [PageBolt](https://pagebolt.dev). It exposes 8 tools to AI coding assistants: `take_screenshot`, `generate_pdf`, `create_og_image`, `inspect_page`, `run_sequence`, `record_video`, `list_devices`, and `check_usage`. Available on npm as `pagebolt-mcp`.

Placed alphabetically between `co-browser` and `eat-pray-ai`.