### PR TITLE
Add TradeMemory Protocol to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402) ☁️ - Curated directory of x402 payment protocol resources, MCP servers, and tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM chains.
 - [zlinzzzz/finData-mcp-server](https://github.com/zlinzzzz/finData-mcp-server) 🐍 ☁️ - An MCP server for accessing professional financial data, supporting multiple data providers such as Tushare.
 - [zolo-ryan/MarketAuxMcpServer](https://github.com/Zolo-Ryan/MarketAuxMcpServer) 📇 ☁️ - MCP server for comprehensive market and financial news search with advanced filtering by symbols, industries, countries, and date ranges.
-- - [TradeMemory Protocol](https://github.com/mnemox-ai/tradememory-protocol) 🐍 🏠 - Structured 3-layer memory system (trades → patterns → strategy) for AI trading agents. Supports MT5, Binance, and Alpaca.
+- [mnemox-ai/tradememory-protocol](https://github.com/mnemox-ai/tradememory-protocol) [Glama](https://glama.ai/mcp/servers/mnemox-ai/tradememory-protocol) 🐍 🏠 - Structured 3-layer memory system (trades → patterns → strategy) for AI trading agents. Supports MT5, Binance, and Alpaca.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adding TradeMemory Protocol to the Finance section.

TradeMemory Protocol is a structured 3-layer memory system for AI trading agents built on MCP.

- L1: Raw trade recording
- L2: Pattern discovery via reflection
- L3: Strategy evolution
- Supports MT5, Binance, Alpaca
- 503 tests passing, MIT licensed
- Python / FastAPI / SQLite

GitHub: https://github.com/mnemox-ai/tradememory-protocol
[Glama](https://glama.ai/mcp/servers/mnemox-ai/tradememory-protocol)