### PR TITLE
Add Speech AI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ Translation tools and services to enable AI assistants to translate content betw
 Tools for converting text-to-speech and vice-versa
 
 - [daisys-ai/daisys-mcp](https://github.com/daisys-ai/daisys-mcp) 🐍 🏠 🍎 🪟 🐧 - Generate high-quality text-to-speech and text-to-voice outputs using the [DAISYS](https://www.daisys.ai/) platform and make it able to play and store audio generated.
+- [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples) 🐍 ☁️ - Production speech AI server with pronunciation scoring, speech-to-text, and text-to-speech. 10 tools, 7 resources, 3 prompts for language learning and speech assessment workflows.
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration
 - [mberg/kokoro-tts-mcp](https://github.com/mberg/kokoro-tts-mcp) 🐍 🏠 - MCP Server that uses the open weight Kokoro TTS models to convert text-to-speech. Can convert text to MP3 on a local driver or auto-upload to an S3 bucket.
 - [transcribe-app/mcp-transcribe](https://github.com/transcribe-app/mcp-transcribe) 📇 🏠 - This service provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video file.


### PR DESCRIPTION
Adds [Speech AI](https://github.com/fasuizu-br/speech-ai-examples) to the Text-to-Speech category.

**Speech AI** is a production remote MCP server for speech processing:
- **Pronunciation Assessment** — phoneme-level scoring with confidence metrics
- **Speech-to-Text** — audio transcription
- **Text-to-Speech** — speech synthesis with multiple voices

10 tools, 7 resources, 3 prompts. Hosted on Azure Container Apps.

**MCP endpoint:** `https://pronunciation-mcp.thankfulfield-a7857897.eastus.azurecontainerapps.io/mcp`

Listed on MCP Registry, Smithery (score 85/100), MCPize, and Apify.