### PR TITLE
Add saga-mcp to Product Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,7 +1227,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 Tools for product planning, customer feedback analysis, and prioritization.
 
 - [dkships/pm-copilot](https://github.com/dkships/pm-copilot) 📇 ☁️ - Triangulates HelpScout support tickets and ProductLift feature requests to generate prioritized product plans. Scores themes by convergence (same signal in both sources = 2x boost), scrubs PII, and accepts business metrics from other MCP servers via `kpi_context` for composable prioritization.
-- [spranab/saga-mcp](https://github.com/spranab/saga-mcp) 📇 🏠 🍎 🪟 🐧 - A Jira-like project tracker for AI agents with full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies with auto-block/unblock, threaded comments, reusable templates, activity logging, and a natural language dashboard. SQLite-backed, 31 tools.
+- [spranab/saga-mcp](https://github.com/spranab/saga-mcp) [glama](https://glama.ai/mcp/servers/@spranab/saga-mcp) 📇 🏠 🍎 🪟 🐧 - A Jira-like project tracker for AI agents with full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies with auto-block/unblock, threaded comments, reusable templates, activity logging, and a natural language dashboard. SQLite-backed, 31 tools.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## New Server

**Name:** [saga-mcp](https://github.com/spranab/saga-mcp)
**Category:** Product Management
**Language:** TypeScript (📇)
**Scope:** Local (🏠)
**Platforms:** macOS (🍎), Windows (🪟), Linux (🐧)

## Description

A Jira-like project tracker MCP server for AI agents. SQLite-backed with 31 tools covering the full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies with auto-block/unblock, threaded comments, reusable task templates with variable substitution, activity logging, and a natural language dashboard summary.

- **npm:** `npx saga-mcp`
- **Repository:** https://github.com/spranab/saga-mcp
- **License:** MIT