### PR TITLE
Add Godot MCP Pro to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,7 @@ Integration with gaming related data, game engines, and services
 - [sonirico/mcp-stockfish](https://github.com/sonirico/mcp-stockfish) - 🏎️ 🏠 🍎 🪟 🐧️ MCP server connecting AI systems to Stockfish chess engine.
 - [stefan-xyz/mcp-server-runescape](https://github.com/stefan-xyz/mcp-server-runescape) 📇 - An MCP server with tools for interacting with RuneScape (RS) and Old School RuneScape (OSRS) data, including item prices, player hiscores, and more.
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
+- [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adds [Godot MCP Pro](https://github.com/youichi-uda/godot-mcp-pro) — a premium MCP server for the Godot game engine with 84 tools across 14 categories (scene, node, script, editor, input simulation, runtime analysis, animation, tilemap, theme, shader, profiling, batch operations, and export). Website: https://godot-mcp.abyo.net/