### PR TITLE
Add CodeMode to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1686,6 +1686,7 @@ Interact with Git repositories and version control platforms. Enables repository
 > [!NOTE]
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 
+- [cnap-tech/codemode](https://github.com/cnap-tech/codemode) 📇 - Programmatic tool calling (Code Mode) for MCP. Turn any OpenAPI spec into two sandboxed tools (search + execute) instead of hundreds of hand-written tools.
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript


### PR DESCRIPTION
Adds [CodeMode](https://github.com/cnap-tech/codemode) to the Frameworks section.

## Why now

Cloudflare's [Agentic API design patterns](https://blog.cloudflare.com/agentic-design-patterns-for-api/) blog post and Anthropic's [tool use best practices](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/best-practices-and-common-patterns#programmatic-tool-calling-code-mode) both describe **programmatic tool calling (Code Mode)** as the recommended pattern for giving LLMs API access — two tools (search the spec + execute code) instead of one tool per endpoint. This library implements that pattern as a drop-in for any MCP server.

## What it does

Turn any OpenAPI spec into two sandboxed MCP tools (`search` + `execute`) instead of hundreds of hand-written tools.

- 📇 TypeScript, MIT licensed
- Published on npm as `@robinbraemer/codemode`
- Uses isolated-vm V8 sandboxes for secure code execution
- Works with any fetch-compatible handler (Hono, Express, standard fetch)