### PR TITLE
Add sigrok-mcp-server to Embedded System category

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [adancurusul/embedded-debugger-mcp](https://github.com/adancurusul/embedded-debugger-mcp) 🦀 📟 - A Model Context Protocol server for embedded debugging with probe-rs - supports ARM Cortex-M, RISC-V debugging via J-Link, ST-Link, and more
 - [adancurusul/serial-mcp-server](https://github.com/adancurusul/serial-mcp-server) 🦀 📟 - A comprehensive MCP server for serial port communication
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
+- [KenosInc/sigrok-mcp-server](https://github.com/KenosInc/sigrok-mcp-server) 🏎️ 📟 🏠 - An MCP server wrapping sigrok-cli for signal analysis — scan logic analyzers, capture data, decode protocols (UART, SPI, I2C, etc.), and query serial instruments via SCPI.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.


### PR DESCRIPTION
Add [sigrok-mcp-server](https://github.com/KenosInc/sigrok-mcp-server) to the Embedded System category.

An MCP server wrapping sigrok-cli for signal analysis — scan logic analyzers, capture data, decode protocols (UART, SPI, I2C, etc.), and query serial instruments via SCPI.

- **Language:** Go
- **Category:** Embedded System (📟)
- **Type:** Local (🏠)
- **Docker image:** `ghcr.io/kenosinc/sigrok-mcp-server`
- **License:** MIT