### PR TITLE
Add qubitsok-mcp to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 Tools for conducting research, surveys, interviews, and data collection.
 
 - [Embassy-of-the-Free-Mind/sourcelibrary-v2](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/tree/main/mcp-server) 📇 ☁️ - Search and cite rare historical texts (alchemy, Hermeticism, Renaissance philosophy) with DOI-backed academic citations from [Source Library](https://sourcelibrary.org)
+- [navaro1/qubitsok-mcp](https://github.com/navaro1/qubitsok-mcp) ☁️ - Quantum computing jobs, papers & researchers — search 500+ job listings, daily arXiv papers, and 1,000+ researcher profiles via [qubitsok](https://qubitsok.com)
 - [ovlabs/mcp-server-originalvoices](https://github.com/ovlabs/mcp-server-originalvoices) 📇 ☁️ - Instantly understand what real users think and why by querying our network of 1:1 Digital Twins - each representing a real person. Give your AI agents authentic human context to ground outputs, improve creative, and make smarter decisions.
 - [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
 - [pminervini/deep-research-mcp](https://github.com/pminervini/deep-research-mcp) 🐍 ☁️ 🏠 - Deep research MCP server for OpenAI Responses API or Open Deep Research (smolagents), with web search and code interpreter support.


### PR DESCRIPTION
Add [qubitsok-mcp](https://github.com/navaro1/qubitsok-mcp) to the Research section.

A remote MCP server for quantum computing research — search 500+ quantum computing job listings, daily arXiv papers, and 1,000+ researcher profiles.

- **Category:** Research (🔬)
- **Type:** Cloud (☁️)  
- **Website:** [qubitsok.com](https://qubitsok.com)
- **License:** MIT