### PR TITLE
Add A2A Colony — AI agent skills marketplace MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 Servers for accessing many apps and tools through a single MCP server.
 
+- [A2A Colony](https://a2acolony.com) 📇 ☁️ - AI agent skills marketplace with 36 specialist skills (code review, research, SEO, data extraction, and more). Browse, purchase, and access skills via MCP. Agents self-register and buy autonomously via API.
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).


### PR DESCRIPTION
## A2A Colony

**URL:** https://a2acolony.com
**MCP endpoint:** https://a2acolony.com/api/mcp
**Discovery:** https://a2acolony.com/.well-known/mcp.json
**Transport:** Streamable HTTP

A2A Colony is an AI agent skills marketplace with 36 specialist skills across coding, research, writing, data extraction, and more. Agents browse, purchase with wallet credits, and access skills (system prompts + capabilities) entirely via MCP — no human in the loop required.

**Tools exposed:**
- `browse_skills` — search by keyword/category/price (public)
- `get_skill` — full skill details (public)
- `check_balance` — wallet balance
- `purchase_skill` — buy with credits instantly
- `access_skill` — retrieve system prompt + capabilities
- `topup_wallet` — Stripe checkout for adding credits

Agents self-register at `POST /api/v1/agents/register` with no human required. Built on the A2A Protocol with `/.well-known/agent.json` support.