### PR TITLE
Add Agent Casino MCP servers (dice + affiliate) to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,12 +1039,12 @@ Integration with gaming related data, game engines, and services
 - [opgginc/opgg-mcp](https://github.com/opgginc/opgg-mcp) 📇 ☁️ - Access real-time gaming data across popular titles like League of Legends, TFT, and Valorant, offering champion analytics, esports schedules, meta compositions, and character statistics.
 - [pab1ito/chess-mcp](https://github.com/pab1it0/chess-mcp) 🐍 ☁️ - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 - [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.
+- [rollhub-dev/rollhub-affiliate-mcp](https://github.com/rollhub-dev/rollhub-affiliate-mcp) 📇 ☁️ - Earn crypto commissions promoting [Agent Casino](https://agent.rollhub.com). Autonomous affiliate marketing MCP server for AI agents with real-time commission tracking.
+- [rollhub-dev/rollhub-dice-mcp](https://github.com/rollhub-dev/rollhub-dice-mcp) 📇 ☁️ - Provably fair dice and coinflip gambling API for AI agents via [Agent Casino](https://agent.rollhub.com). 99% RTP, real crypto, zero-trust verification, 70+ chains.
 - [sonirico/mcp-stockfish](https://github.com/sonirico/mcp-stockfish) - 🏎️ 🏠 🍎 🪟 🐧️ MCP server connecting AI systems to Stockfish chess engine.
 - [stefan-xyz/mcp-server-runescape](https://github.com/stefan-xyz/mcp-server-runescape) 📇 - An MCP server with tools for interacting with RuneScape (RS) and Old School RuneScape (OSRS) data, including item prices, player hiscores, and more.
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
-- [rollhub-dev/rollhub-dice-mcp](https://github.com/rollhub-dev/rollhub-dice-mcp) 📇 ☁️ - Provably fair dice and coinflip gambling API for AI agents via [Agent Casino](https://agent.rollhub.com). 99% RTP, real crypto, zero-trust verification, 70+ chains.
-- [rollhub-dev/rollhub-affiliate-mcp](https://github.com/rollhub-dev/rollhub-affiliate-mcp) 📇 ☁️ - Earn crypto commissions promoting [Agent Casino](https://agent.rollhub.com). Autonomous affiliate marketing MCP server for AI agents with real-time commission tracking.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
## Adding Agent Casino MCP Servers

Adding two MCP servers to the Gaming section:

### rollhub-dice-mcp
Provably fair dice and coinflip gambling API for AI agents. 99% RTP, real crypto, zero-trust verification, 70+ chains.
- npm: https://npmjs.com/package/rollhub-dice-mcp
- Website: https://agent.rollhub.com

### rollhub-affiliate-mcp 
Earn crypto commissions promoting Agent Casino. Autonomous affiliate marketing MCP server for AI agents.
- npm: https://npmjs.com/package/rollhub-affiliate-mcp
- Website: https://agent.rollhub.com

Both servers are published on npm and follow the MCP specification.