### PR TITLE
Add company-gi MCP server (Gibraltar company tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Access to legal information, legislation, and legal databases. Enables AI models to search and analyze legal documents and regulatory information.
 
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
+- [GraemeFulton/company-gibraltar](https://github.com/GraemeFulton/company-gibraltar) 📇 ☁️ - Gibraltar company tools: corporate tax calculations, compliance deadlines, and pre-filled PDF form generation (annual return, office change, company formation) for Companies House.
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
 
 ### 🗺️ <a name="location-services"></a>Location Services

--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Access to legal information, legislation, and legal databases. Enables AI models to search and analyze legal documents and regulatory information.
 
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
-- [GraemeFulton/company-gibraltar](https://github.com/GraemeFulton/company-gibraltar) 📇 ☁️ - Gibraltar company tools: corporate tax calculations, compliance deadlines, and pre-filled PDF form generation (annual return, office change, company formation) for Companies House.
+- [Company-Gibraltar/company-gi-mcp](https://github.com/Company-Gibraltar/company-gi-mcp) 📇 ☁️ - Gibraltar company tools: corporate tax calculations, compliance deadlines, and pre-filled PDF form generation (annual return, office change, company formation) for Companies House.
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
 
 ### 🗺️ <a name="location-services"></a>Location Services

--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 Access to legal information, legislation, and legal databases. Enables AI models to search and analyze legal documents and regulatory information.
 
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
-- [Company-Gibraltar/company-gi-mcp](https://github.com/Company-Gibraltar/company-gi-mcp) 📇 ☁️ - Gibraltar company tools: corporate tax calculations, compliance deadlines, and pre-filled PDF form generation (annual return, office change, company formation) for Companies House.
+- [Company-Gibraltar/company-gibraltar-mcp](https://github.com/Company-Gibraltar/company-gibraltar-mcp) 📇 ☁️ - Gibraltar company tools: corporate tax calculations, compliance deadlines, and pre-filled PDF form generation (annual return, office change, company formation) for Companies House.
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
 
 ### 🗺️ <a name="location-services"></a>Location Services


### PR DESCRIPTION
Adds [company-gibraltar](https://github.com/Company-Gibraltar/company-gibraltar-mcp) to the Legal section.

**What it does:** 6 tools for Gibraltar company management via MCP:
- Calculate corporate tax Payments on Account
- Calculate all compliance deadlines for a given year
- Generate pre-filled annual return (FAR01) form
- Generate registered office change forms (FREG01 + board resolution)
- Generate full company formation pack (5 FINC forms)
- Generate eGov account application forms

**Category:** Legal (company formation, compliance, tax)
**Language:** TypeScript
**Scope:** Cloud - calls REST API at company.gi

npm: https://www.npmjs.com/package/company-gibraltar-mcp
Repo: https://github.com/Company-Gibraltar/company-gibraltar-mcp
Docs: https://company.gi/developers
Playground: https://company.gi/developers/playground