### PR TITLE
Add ForgeCraft MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [janreges/ai-distiller-mcp](https://github.com/janreges/ai-distiller) 🏎️ 🏠 - Extracts essential code structure from large codebases into AI-digestible format, helping AI agents write code that correctly uses existing APIs on the first attempt.
 - [jasonjmcghee/claude-debugs-for-you](https://github.com/jasonjmcghee/claude-debugs-for-you) 📇 🏠 - An MCP Server and VS Code Extension which enables (language agnostic) automatic debugging via breakpoints and expression evaluation.
 - [jaspertvdm/mcp-server-tibet](https://github.com/jaspertvdm/mcp-server-tibet) 🐍 ☁️ 🏠 - TIBET provenance tracking for AI decisions. Cryptographic audit trails with ERIN/ERAAN/EROMHEEN/ERACHTER intent logging for compliance.
+- [jghiringhelli/forgecraft-mcp](https://github.com/jghiringhelli/forgecraft-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server that generates production-grade engineering standards (SOLID, testing, architecture, CI/CD) for AI coding assistants. Supports 24 project tags with YAML-driven templates for scaffolding, auditing, and code review across any stack.
 - [jetbrains/mcpProxy](https://github.com/JetBrains/mcpProxy) 🎖️ 📇 🏠 - Connect to JetBrains IDE
 - [Jktfe/serveMyAPI](https://github.com/Jktfe/serveMyAPI) 📇 🏠 🍎 - A personal MCP (Model Context Protocol) server for securely storing and accessing API keys across projects using the macOS Keychain.
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.


### PR DESCRIPTION
Adds [ForgeCraft](https://github.com/jghiringhelli/forgecraft-mcp) to the **Developer Tools** section.

**ForgeCraft** is an MCP server that generates production-grade engineering standards (SOLID, testing, architecture, CI/CD) for AI coding assistants. It supports 24 project tags with YAML-driven templates for scaffolding, auditing, and code review across any stack.

- **Language**: TypeScript
- **Scope**: Local
- **OS**: macOS, Windows, Linux
- **npm**: forgecraft-mcp
- **MCP Registry**: Published
- **Install**: npx forgecraft-mcp