### PR TITLE
Add Intelligence Aeternum MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp) 🐍 - Add, Analyze, Search, and Generate Video Edits from your Video Jungle Collection
 - [cantian-ai/bazi-mcp](https://github.com/cantian-ai/bazi-mcp) 📇 🏠 ☁️ 🍎 🪟 - Provides comprehensive and accurate Bazi (Chinese Astrology) charting and analysis
 - [ConstantineB6/comfy-pilot](https://github.com/ConstantineB6/comfy-pilot) 🐍 🏠 - MCP server for ComfyUI that lets AI agents view, edit, and run node-based image generation workflows with an embedded terminal.
+- [codex-curator/intelligence-aeternum-mcp](https://github.com/codex-curator/intelligence-aeternum-mcp) 🐍 ☁️ - AI training dataset marketplace with 2M+ museum artworks across 7 institutions, 111-field Golden Codex enrichment, and x402 USDC micropayments on Base L2. 16 MCP tools for search, enrichment, and delivery.
 - [cswkim/discogs-mcp-server](https://github.com/cswkim/discogs-mcp-server) 📇 ☁️ - MCP server to interact with the Discogs API
 - [diivi/aseprite-mcp](https://github.com/diivi/aseprite-mcp) 🐍 🏠 - MCP server using the Aseprite API to create pixel art
 - [djalal/quran-mcp-server](https://github.com/djalal/quran-mcp-server) 📇 ☁️ MCP server to interact with Quran.com corpus via the official REST API v4.


### PR DESCRIPTION
## Add Intelligence Aeternum MCP Server

Adds [Intelligence Aeternum](https://github.com/codex-curator/intelligence-aeternum-mcp) to the **Art & Culture** section.

**What it is:** An AI training dataset marketplace providing access to 2M+ museum artworks across 7 institutions (Met, Rijksmuseum, Smithsonian, Art Institute of Chicago, Cleveland Museum, NGA, Paris Musées), with 111-field Golden Codex enrichment and x402 USDC micropayments on Base L2.

**16 MCP tools** for search, enrichment metadata retrieval, collection browsing, and batch delivery.

Python server, cloud-hosted.

- [GitHub Repository](https://github.com/codex-curator/intelligence-aeternum-mcp)
- [Live MCP Endpoint](https://data-portal-172867820131.us-west1.run.app/mcp)