### PR TITLE
Add imessage-mcp to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Integration with communication platforms for message management and channel oper
 - [AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp) ☁️ - A Nostr MCP server that allows to interact with Nostr, enabling posting notes, and more.
 - [adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit) 🐍 ☁️ - Interact with Twitter search and timeline
 - [agentmail-toolkit/mcp](https://github.com/agentmail-to/agentmail-toolkit/tree/main/mcp) 🐍 💬 - An MCP server to create inboxes on the fly to send, receive, and take actions on email. We aren't AI agents for email, but email for AI Agents.
+- [anipotts/imessage-mcp](https://github.com/anipotts/imessage-mcp) 📇 🏠 🍎 - 25 read-only tools for searching, analyzing, and exploring your entire iMessage history on macOS. Includes conversation analytics, Spotify Wrapped-style year reviews, streak tracking, read receipts, reactions, and more.
 - [areweai/tsgram-mcp](https://github.com/areweai/tsgram-mcp) - TSgram: Telegram + Claude with local workspace access on your phone in typescript. Read, write, and vibe code on the go!
 - [arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks) 📇 ☁️ - An MCP server to interface with the Google Tasks API
 - [Cactusinhand/mcp_server_notify](https://github.com/Cactusinhand/mcp_server_notify) 🐍 🏠 - A MCP server that send desktop notifications with sound effect when agent tasks are completed.


### PR DESCRIPTION
## Summary

- Adds [anipotts/imessage-mcp](https://github.com/anipotts/imessage-mcp) to the Communication section in alphabetical order
- TypeScript MCP server with 25 read-only tools for searching, analyzing, and exploring iMessage history on macOS
- Features include conversation analytics, Spotify Wrapped-style year reviews, streak tracking, read receipts, reactions, and more

## Checklist

- [x] Entry added to the correct category (Communication)
- [x] Alphabetical order maintained
- [x] Format matches existing entries
- [x] Correct badges used (📇 TypeScript, 🏠 Local, 🍎 macOS)
- [x] Link is valid and points to the correct repository