### PR TITLE
Add ESPN MCP Server to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1435,6 +1435,7 @@ Tools for accessing sports-related data, results, and statistics.
 
 - [cloudbet/sports-mcp-server](https://github.com/cloudbet/sports-mcp-server) 🏎️ ☁️ – Access structured sports data via the Cloudbet API. Query upcoming events, live odds, stake limits, and market info across soccer, basketball, tennis, esports, and more.
 - [csjoblom/musclesworked-mcp](https://github.com/csjoblom/musclesworked-mcp) 📇 ☁️ - Exercise-to-muscle mapping MCP server. Look up muscles worked by 856 exercises across 65 muscles and 14 muscle groups, analyze workouts for gaps, and find alternative exercises ranked by muscle overlap.
+- [ESPN MCP Server](https://apify.com/scrapmania/espn-mcp-server) 📇 ☁️ - Real-time ESPN sports data including live scores, standings, game summaries, betting odds, player stats, and news for 25+ leagues (NFL, NBA, MLB, NHL, Premier League, and more).
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp) 🐍 🏠 - MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.
 - [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp) 🐍 🏠 - Query TrainingPeaks workouts, analyze CTL/ATL/TSB fitness metrics, and compare power/pace PRs through Claude Desktop.
 - [khaoss85/arvo-mcp](https://github.com/khaoss85/arvo-mcp) 📇 ☁️ - AI workout coach MCP server for Arvo. Access training data, workout history, personal records, body progress, and 29 fitness tools through Claude Desktop.


### PR DESCRIPTION
## Summary

- Adds the ESPN MCP Server to the Sports section of the awesome list
- The ESPN MCP Server provides real-time ESPN sports data including live scores, standings, game summaries, betting odds, player stats, and news for 25+ leagues (NFL, NBA, MLB, NHL, Premier League, and more)
- Written in TypeScript, available as a cloud service on the Apify Store

## Changes

- Added one entry to the Sports section in `README.md`, placed in alphabetical order