### PR TITLE
Add refcheck: academic reference verification MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,6 +1238,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
 - [pminervini/deep-research-mcp](https://github.com/pminervini/deep-research-mcp) 🐍 ☁️ 🏠 - Deep research MCP server for OpenAI Responses API or Open Deep Research (smolagents), with web search and code interpreter support.
 - [thinkchainai/agentinterviews_mcp](https://github.com/thinkchainai/agentinterviews_mcp) - Conduct AI-powered qualitative research interviews and surveys at scale with [Agent Interviews](https://agentinterviews.com). Create interviewers, manage research projects, recruit participants, and analyze interview data through MCP.
+- [UMN-Choi-Lab/refcheck](https://github.com/UMN-Choi-Lab/refcheck) 🐍 ☁️ 🏠 - Verify academic citations against Crossref, Semantic Scholar, arXiv, Scopus, and IEEE Xplore. Catches hallucinated references, finds real papers on a topic, and exports publication-ready BibTeX.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 


### PR DESCRIPTION
## New Server: refcheck

**Repository:** https://github.com/UMN-Choi-Lab/refcheck
**Category:** Research
**Language:** Python

### Description

refcheck is an MCP server that verifies academic citations against real publication databases (Crossref, Semantic Scholar, arXiv, Scopus, IEEE Xplore). It catches hallucinated references, finds real papers on a topic, and exports publication-ready BibTeX.

### Tools

| Tool | Purpose |
|------|---------|
| `verify_reference` | Check if a citation is real. Returns `verified`, `partial_match`, or `not_found` with a confidence score and corrected BibTeX. |
| `search_references` | Find real papers on a topic. Only returns database-backed results. |
| `get_bibtex` | Export publication-ready BibTeX by DOI, title, or Semantic Scholar ID. |

### Why it belongs in awesome-mcp-servers

LLMs frequently hallucinate academic citations. refcheck solves this by giving AI assistants direct access to real publication databases. Every reference it returns is backed by a real database record. Useful for writing papers, grant proposals, literature reviews, and verifying .bib files.