### PR TITLE
Add 0xArchive MCP under Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
+- [0xArchiveIO/0xarchive-mcp](https://github.com/0xArchiveIO/0xarchive-mcp) 📇 ☁️ 🏠 - Hyperliquid market data MCP server for funding, order books, candles, trades, open interest, liquidations, and data quality endpoints for quant research and backtesting.
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.


### PR DESCRIPTION
## Summary
Add 0xArchive MCP to Finance & Fintech.

## Entry added
- [0xArchiveIO/0xarchive-mcp](https://github.com/0xArchiveIO/0xarchive-mcp) 📇 ☁️ 🏠 - Hyperliquid market data MCP server for funding, order books, candles, trades, open interest, liquidations, and data quality endpoints for quant research and backtesting.
