### PR TITLE
Add mcp-orchestrator to aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/mcp?style=flat&logo=reddit&label=subreddit)](https://www.reddit.com/r/mcp/)
 
 > [!IMPORTANT]
-> Read [The State of MCP in 2025](https://glama.ai/blog/2025-12-07-th-state-of-mcp-in-2025) report.
+> Read [The State of MCP in 2025](https://glama.ai/blog/2025-12-07-the-state-of-mcp-in-2025) report.
 
 > [!IMPORTANT]
 > [Awesome MCP Servers](https://glama.ai/mcp/servers) web directory.


### PR DESCRIPTION
Adds `mcp-orchestrator` to the Aggregators section.

**mcp-orchestrator** is a Python MCP server that acts as a central hub, aggregating tools from multiple downstream MCP servers with:
- Unified BM25/regex tool search with deferred loading
- Automatic `server_name__tool_name` namespacing
- Flexible auth (static headers or token forwarding)
- stdio and HTTP transports
- In-memory and Redis storage backends

PyPI: https://pypi.org/project/mcp-orchestrator/
GitHub: https://github.com/rupinder2/mcp-orchestrator