### PR TITLE
Add LightCMS - AI-native CMS with 41 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.
 - [joshuarileydev/app-store-connect-mcp-server](https://github.com/JoshuaRileyDev/app-store-connect-mcp-server) 📇 🏠 - An MCP server to communicate with the App Store Connect API for iOS Developers
 - [joshuarileydev/simulator-mcp-server](https://github.com/JoshuaRileyDev/simulator-mcp-server) 📇 🏠 - An MCP server to control iOS Simulators
+- [jonradoff/lightcms](https://github.com/jonradoff/lightcms) 🏎️ ☁️ 🏠 🍎 🐧 - AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
 - [Jpisnice/shadcn-ui-mcp-server](https://github.com/Jpisnice/shadcn-ui-mcp-server) 📇 🏠 - MCP server that gives AI assistants seamless access to shadcn/ui v4 components, blocks, demos, and metadata.
 - [jsdelivr/globalping-mcp-server](https://github.com/jsdelivr/globalping-mcp-server) 🎖️ 📇 ☁️ - The Globalping MCP server provides users and LLMs access to run network tools like ping, traceroute, mtr, HTTP and DNS resolve from thousands of locations around the world.
 - [kadykov/mcp-openapi-schema-explorer](https://github.com/kadykov/mcp-openapi-schema-explorer) 📇 ☁️ 🏠 - Token-efficient access to OpenAPI/Swagger specs via MCP Resources.


### PR DESCRIPTION
Adds [LightCMS](https://github.com/jonradoff/lightcms) to the Developer Tools category.

LightCMS is a lightweight, AI-native content management system built with Go and MongoDB Atlas. The MCP server provides 41 tools for complete website management through natural language:

- **Content**: Create, read, update, delete, publish, unpublish, versioning with rollback
- **Templates**: Define reusable content structures with custom fields
- **Assets**: Upload and manage images, documents, and other files
- **Theme**: Customize colors, fonts, header/footer HTML
- **Collections**: Group and display content by category
- **Search**: Full-text search and bulk search-and-replace across all content
- **Settings**: Redirects, folders, site configuration

Published to the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.jonradoff/lightcms`.