### PR TITLE
Add LastSaaS Admin MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jaspertvdm/mcp-server-tibet](https://github.com/jaspertvdm/mcp-server-tibet) 🐍 ☁️ 🏠 - TIBET provenance tracking for AI decisions. Cryptographic audit trails with ERIN/ERAAN/EROMHEEN/ERACHTER intent logging for compliance.
 - [jetbrains/mcpProxy](https://github.com/JetBrains/mcpProxy) 🎖️ 📇 🏠 - Connect to JetBrains IDE
 - [Jktfe/serveMyAPI](https://github.com/Jktfe/serveMyAPI) 📇 🏠 🍎 - A personal MCP (Model Context Protocol) server for securely storing and accessing API keys across projects using the macOS Keychain.
+- [jonradoff/lastsaas](https://github.com/jonradoff/lastsaas) 🏎️ ☁️ - Read-only admin MCP server for open-source SaaS platform with 26 tools for dashboards, users, tenants, financials, logs, and health monitoring.
 - [jordandalton/restcsv-mcp-server](https://github.com/JordanDalton/RestCsvMcpServer) 📇 ☁️ - An MCP server for CSV files.
 - [joshuarileydev/app-store-connect-mcp-server](https://github.com/JoshuaRileyDev/app-store-connect-mcp-server) 📇 🏠 - An MCP server to communicate with the App Store Connect API for iOS Developers
 - [joshuarileydev/simulator-mcp-server](https://github.com/JoshuaRileyDev/simulator-mcp-server) 📇 🏠 - An MCP server to control iOS Simulators


### PR DESCRIPTION
## Summary

- Adds [LastSaaS](https://github.com/jonradoff/lastsaas) to the Developer Tools section
- LastSaaS is an open-source SaaS platform (Go + React) with a built-in read-only admin MCP server providing 26 tools for dashboards, users, tenants, financials, logs, and health monitoring
- Entry placed in alphabetical order following the existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)