### PR TITLE
Add LastBlueTape MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1538,6 +1538,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [teamwork/mcp](https://github.com/teamwork/mcp) 🎖️ 🏎️ ☁️ 🍎 🪟 🐧 - Project and resource management platform that keeps your client projects on track, makes managing resources a breeze, and keeps your profits on point.
 - [tubasasakunn/context-apps-mcp](https://github.com/tubasasakunn/context-apps-mcp) 📇 🏠 🍎 🪟 🐧 - AI-powered productivity suite connecting Todo, Idea, Journal, and Timer apps with Claude via Model Context Protocol.
 - [universalamateur/reclaim-mcp-server](https://github.com/universalamateur/reclaim-mcp-server) 🐍 ☁️ - Reclaim.ai calendar integration with 40 tools for tasks, habits, focus time, scheduling links, and productivity analytics.
+- [vulkanr/lastbluetape-mcp](https://github.com/vulkanr/lastbluetape-mcp) 📇 ☁️ - Construction punch list management — create lists, add items, track progress, and share with teams.
 - [vakharwalad23/google-mcp](https://github.com/vakharwalad23/google-mcp) 📇 ☁️ - Collection of Google-native tools (Gmail, Calendar, Drive, Tasks) for MCP with OAuth management, automated token refresh, and auto re-authentication capabilities.
 - [vasylenko/claude-desktop-extension-bear-notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) 📇 🏠 🍎 - Search, read, create, and update Bear Notes directly from Claude. Local-only with complete privacy.
 - [wyattjoh/calendar-mcp](https://github.com/wyattjoh/calendar-mcp) 📇 🏠 🍎 - MCP server for accessing macOS Calendar events


### PR DESCRIPTION
## Summary

- Adds [LastBlueTape](https://github.com/vulkanr/lastbluetape-mcp) to the **Workplace & Productivity** category
- LastBlueTape is a TypeScript/Node.js MCP server for construction punch list management — create lists, add items, track progress, and share with teams
- Placed alphabetically by GitHub org name in the existing list

## Details

- **Language**: TypeScript (📇)
- **Scope**: Cloud service (☁️)
- **Category**: Workplace & Productivity — fits alongside other project/task management tools like Kanboard, task managers, and HVAC quotes for contractors