### PR TITLE
Add chaindead/tooner to Other Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [brianxiadong/ones-wiki-mcp-server](https://github.com/brianxiadong/ones-wiki-mcp-server) ☕ ☁️/🏠 - A Spring AI MCP-based service for retrieving ONES Waiki content and converting it to AI-friendly text format.
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) 📇 🏠 - This is a connector to allow Claude Desktop (or any MCP client) to read and search any directory containing Markdown notes (such as an Obsidian vault).
 - [caol64/wenyan-mcp](https://github.com/caol64/wenyan-mcp) 📇 🏠 🍎 🪟 🐧 - Wenyan MCP Server, which lets AI automatically format Markdown articles and publish them to WeChat GZH.
+- [chaindead/tooner](https://github.com/chaindead/tooner) 🏎️ 🏠 🍎 🪟 🐧 - MCP proxy that wraps any MCP server and converts JSON responses to TOON format, a token-efficient alternative to JSON optimized for LLMs.
 - [chrishayuk/mcp-cli](https://github.com/chrishayuk/mcp-cli) 🐍 🏠 - Yet another CLI tool for testing MCP servers
 - [danhilse/notion_mcp](https://github.com/danhilse/notion_mcp) 🐍 ☁️ - Integrates with Notion's API to manage personal todo lists
 - [danielkennedy1/pdf-tools-mcp](https://github.com/danielkennedy1/pdf-tools-mcp) 🐍 - PDF download, view & manipulation utilities.

--- a/README.md
+++ b/README.md
@@ -1572,7 +1572,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [brianxiadong/ones-wiki-mcp-server](https://github.com/brianxiadong/ones-wiki-mcp-server) ☕ ☁️/🏠 - A Spring AI MCP-based service for retrieving ONES Waiki content and converting it to AI-friendly text format.
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) 📇 🏠 - This is a connector to allow Claude Desktop (or any MCP client) to read and search any directory containing Markdown notes (such as an Obsidian vault).
 - [caol64/wenyan-mcp](https://github.com/caol64/wenyan-mcp) 📇 🏠 🍎 🪟 🐧 - Wenyan MCP Server, which lets AI automatically format Markdown articles and publish them to WeChat GZH.
-- [chaindead/tooner](https://github.com/chaindead/tooner) 🏎️ 🏠 🍎 🪟 🐧 - MCP proxy that wraps any MCP server and converts JSON responses to TOON format, a token-efficient alternative to JSON optimized for LLMs.
+- [chaindead/tooner](https://github.com/chaindead/tooner)[glama](https://glama.ai/mcp/servers/chaindead/tooner) 🏎️ 🏠 🍎 🪟 🐧 - MCP proxy that wraps any MCP server and converts JSON responses to TOON format, a token-efficient alternative to JSON optimized for LLMs.
 - [chrishayuk/mcp-cli](https://github.com/chrishayuk/mcp-cli) 🐍 🏠 - Yet another CLI tool for testing MCP servers
 - [danhilse/notion_mcp](https://github.com/danhilse/notion_mcp) 🐍 ☁️ - Integrates with Notion's API to manage personal todo lists
 - [danielkennedy1/pdf-tools-mcp](https://github.com/danielkennedy1/pdf-tools-mcp) 🐍 - PDF download, view & manipulation utilities.


### PR DESCRIPTION
## What

Adds tooner to the Other Tools and Integrations section.

## About

tooner is an MCP proxy that wraps any MCP server and transparently converts JSON responses in `tools/call` to [TOON format](https://toonformat.dev/) — a token-efficient alternative to JSON optimized for LLMs (~40% fewer tokens).

## How it works

Tooner runs any other MCP server as a subprocess and proxies messages between the client and the server. When the server returns JSON via tools/call, tooner converts result to TOON from JSON  before forwarding to the client, reducing token usage while preserving the same data and compatibility with clients.

## Installation

- Homebrew (`brew install chaindead/tap/tooner`)
- NPX (`npx -y @chaindead/tooner`)
- Binary releases (macOS, Linux, Windows)
- From source (`go install github.com/chaindead/tooner@latest`)

## Links

- GitHub: https://github.com/chaindead/tooner
- npm: https://www.npmjs.com/package/@chaindead/tooner
- TOON format: https://toonformat.dev/
- Glama https://glama.ai/mcp/servers/chaindead/tooner