### PR TITLE
Add StudioMCPHub to Art & Culture

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [asmith26/jupytercad-mcp](https://github.com/asmith26/jupytercad-mcp) 🐍 🏠 🍎 🪟 🐧 - An MCP server for [JupyterCAD](https://github.com/jupytercad/JupyterCAD) that allows you to control it using LLMs/natural language.
 - [burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp) 🐍 - Add, Analyze, Search, and Generate Video Edits from your Video Jungle Collection
 - [cantian-ai/bazi-mcp](https://github.com/cantian-ai/bazi-mcp) 📇 🏠 ☁️ 🍎 🪟 - Provides comprehensive and accurate Bazi (Chinese Astrology) charting and analysis
+- [codex-curator/studiomcphub](https://github.com/codex-curator/studiomcphub) [glama](https://glama.ai/mcp/servers/@codex-curator/studio-mcp-hub) 🐍 ☁️ - 32 creative AI tools (18 free) for autonomous agents: image generation (SD 3.5), ESRGAN upscaling, background removal, product mockups, CMYK conversion, print-ready PDF, SVG vectorization, invisible watermarking, AI metadata enrichment, provenance, Arweave storage, NFT minting, and 53K+ museum artworks. Pay per call via x402/Stripe/GCX.
 - [ConstantineB6/comfy-pilot](https://github.com/ConstantineB6/comfy-pilot) 🐍 🏠 - MCP server for ComfyUI that lets AI agents view, edit, and run node-based image generation workflows with an embedded terminal.
 - [cswkim/discogs-mcp-server](https://github.com/cswkim/discogs-mcp-server) 📇 ☁️ - MCP server to interact with the Discogs API
 - [diivi/aseprite-mcp](https://github.com/diivi/aseprite-mcp) 🐍 🏠 - MCP server using the Aseprite API to create pixel art
@@ -1718,3 +1719,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+


### PR DESCRIPTION
## Add StudioMCPHub

**Category**: Art & Culture

**Server**: [codex-curator/studiomcphub](https://github.com/codex-curator/studiomcphub)
**Glama**: [glama.ai/mcp/servers/@codex-curator/studio-mcp-hub](https://glama.ai/mcp/servers/@codex-curator/studio-mcp-hub)
**Live endpoint**: `https://studiomcphub.com/mcp` (Streamable HTTP)

32 creative AI tools (18 free, no auth required) for autonomous agents:
- Image generation (SD 3.5 Large), ESRGAN upscaling, background removal
- Product mockups (6 products), CMYK conversion, print-ready PDF with bleed
- SVG vectorization, invisible DCT watermarking, palette extraction
- AI metadata enrichment, XMP/C2PA infusion, provenance registration
- Arweave permanent storage, NFT minting (Polygon + Base L2)
- 53K+ museum artworks from Alexandria Aeternum dataset

Pay per call via x402 (USDC), Stripe, or GCX credits. MIT licensed.