### PR TITLE
add RendrKit to Art & Culture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [r-huijts/oorlogsbronnen-mcp](https://github.com/r-huijts/oorlogsbronnen-mcp) 📇 ☁️ - Oorlogsbronnen (War Sources) API integration for accessing historical WWII records, photographs, and documents from the Netherlands (1940-1945)
 - [r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp) 📇 ☁️ - Rijksmuseum API integration for artwork search, details, and collections
 - [raveenb/fal-mcp-server](https://github.com/raveenb/fal-mcp-server) 🐍 ☁️ - Generate AI images, videos, and music using Fal.ai models (FLUX, Stable Diffusion, MusicGen) directly in Claude Desktop
+- [RendrKit](https://github.com/vbiff/rendrkit-mcp-server) 📇 ☁️ - Design API for AI agents. Generate social media images, banners, and infographics from text prompts or structured data.
 - [samuelgursky/davinci-resolve-mcp](https://github.com/samuelgursky/davinci-resolve-mcp) 🐍 - MCP server integration for DaVinci Resolve providing powerful tools for video editing, color grading, media management, and project control
 - [TwelveTake-Studios/reaper-mcp](https://github.com/TwelveTake-Studios/reaper-mcp) 🐍 🏠 🍎 🪟 🐧 - MCP server enabling AI assistants to control REAPER DAW for mixing, mastering, MIDI composition, and full music production with 129 tools
 - [yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp) 📇 ☁️ - A MCP server integrating AniList API for anime and manga information


### PR DESCRIPTION
Added RendrKit - Design API for AI agents that generates social media images, banners, and infographics from text prompts or structured data.

- Website: https://rendrkit.dev
- npm: @rendrkit/mcp
- 50+ templates, 5 sizes, Unsplash/Pexels photos