### PR TITLE
Add Ori Mnemos - persistent memory infrastructure with identity layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ Control smart home devices, home network equipment, and automation systems.
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.
 
 - [0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer) 📕 ☁️ - AI Summarization MCP Server, Support for multiple content types: Plain text, Web pages, PDF documents, EPUB books, HTML content
+- [aayoawoyemi/Ori-Mnemos](https://github.com/aayoawoyemi/Ori-Mnemos) 📇 🏠 🍎 🪟 🐧 - Persistent memory infrastructure with agent identity layer, wiki-link knowledge graph, 3-signal retrieval (semantic + keyword + PageRank), vitality decay model, and guided onboarding. Agents wake up knowing who they are. No database, no cloud, no API keys required.
 - [20alexl/mini_claude](https://github.com/20alexl/mini_claude) 🐍 🏠 - Persistent memory and guardrails for Claude Code. Features mistake tracking, loop detection, scope guard, and hooks that block risky edits. Runs locally with Ollama.
 - [agentic-mcp-tools/memora](https://github.com/agentic-mcp-tools/memora) 🐍 🏠 ☁️ - Persistent memory with knowledge graph visualization, semantic/hybrid search, cloud sync (S3/R2), and cross-session context management.
 - [AgenticRevolution/memory-nexus-cloud](https://github.com/AgenticRevolution/memory-nexus-cloud) 📇 ☁️ - Cloud-hosted persistent semantic memory for AI agents. Semantic search, knowledge graphs, specialist expertise hats, and multi-tenant isolation. Free 7-day trial.


### PR DESCRIPTION
## New Server

**Ori Mnemos** — persistent memory infrastructure for AI agents.

- **npm:** `ori-memory` (v0.3.1)
- **GitHub:** [aayoawoyemi/Ori-Mnemos](https://github.com/aayoawoyemi/Ori-Mnemos)
- **MCP Registry:** `io.github.aayoawoyemi/ori-memory`
- **Category:** Knowledge & Memory
- **Language:** TypeScript
- **Scope:** Local (runs on macOS, Windows, Linux)

### What it does

Ori gives AI agents persistent, structured memory that survives across sessions. Agents that connect to an Ori vault wake up knowing who they are — identity, goals, methodology, and operational state travel with the vault via MCP instructions and resources.

### Key features

- **Agent identity layer** — MCP `instructions` field auto-injects agent identity at connect. First-run detection with guided onboarding.
- **Wiki-link knowledge graph** — notes are nodes, `[[links]]` are edges. Orphan detection, backlinks, PageRank, community detection.
- **3-signal retrieval** — semantic (local embeddings via all-MiniLM-L6-v2), keyword (BM25), and graph (PageRank + Louvain communities) fused via score-weighted RRF.
- **Vitality decay model** — ACT-R cognitive science activation functions track how "alive" notes are over time.
- **13 MCP tools, 5 resources** — full memory operations over stdio JSON-RPC.
- **No database, no cloud, no API keys** — plain markdown files, SQLite for embeddings, git for version control.

### Installation

```bash
npm install -g ori-memory
ori init my-vault
```

Apache-2.0 licensed.