### PR TITLE
Add AOP MCP Server — Agent-Executable Compliance Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,7 +1131,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
-
+- [jeremytuite/aop-mcp-server](https://github.com/jeremytuite/aop-mcp-server) 📇 ☁️ - Agent-executable compliance documentation for the Colorado AI Act (SB 24-205) — protocol browsing, schema retrieval, compliance assessment, and deployer classification.
 ### 🗺️ <a name="location-services"></a>Location Services
 
 Location-based services and mapping tools. Enables AI models to work with geographic data, weather information, and location-based analytics.


### PR DESCRIPTION
Adds [AOP MCP Server](https://github.com/jeremytuite/aop-mcp-server) to the Legal section.

**What it does:** Gives AI agents direct access to compliance protocol documentation — starting with the Colorado AI Act (SB 24-205). Tools include protocol browsing, schema retrieval, compliance gap assessment, and deployer classification.

**Why it belongs in Legal:** First MCP server focused specifically on AI governance and regulatory compliance documentation. The Colorado AI Act takes effect June 30, 2026, making this immediately relevant for thousands of deployers.

**Tools:** `list_protocols`, `get_protocol`, `get_protocol_schema`, `assess_compliance`, `colorado_ai_act_check`