### PR TITLE
Add OpenClaw Fortune to Gaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,7 @@ Integration with gaming related data, game engines, and services
 - [pab1ito/chess-mcp](https://github.com/pab1it0/chess-mcp) 🐍 ☁️ - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 - [rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/) 🐍 ☁️ - An MCP server for real-time Fantasy Premier League data and analysis tools.
 - [sonirico/mcp-stockfish](https://github.com/sonirico/mcp-stockfish) - 🏎️ 🏠 🍎 🪟 🐧️ MCP server connecting AI systems to Stockfish chess engine.
+- [openclaw-ai/fortune](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers) ☁️ - Daily zodiac horoscope and tarot card readings MCP server for all 12 signs. Scores, lucky items, rankings. Japanese-localized entertainment for AI agents.
 - [stefan-xyz/mcp-server-runescape](https://github.com/stefan-xyz/mcp-server-runescape) 📇 - An MCP server with tools for interacting with RuneScape (RS) and Old School RuneScape (OSRS) data, including item prices, player hiscores, and more.
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.


### PR DESCRIPTION
Adding OpenClaw Fortune MCP server to the Entertainment section.

## Server Details
- **Name**: OpenClaw Fortune
- **Description**: Daily zodiac horoscope and tarot card readings for all 12 signs. Japanese-localized.
- **URL**: https://openclaw-fortune-mcp.yagami8095.workers.dev/mcp
- **Transport**: Streamable HTTP (remote, no install needed)
- **GitHub**: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers
- **Smithery**: https://smithery.ai/servers/openclaw-ai/fortune
