### PR TITLE
Add MoltBook Publisher MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ Translation tools and services to enable AI assistants to translate content betw
 
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
+- [yedanyagamiai-cmd/moltbook-publisher-mcp](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers) 📇 ☁️ - Japanese content publishing toolkit with Markdown to HTML conversion, SEO optimization, EN→JP translation, article outlines, trending topics, and cross-platform formatting for note.com, Zenn, and Qiita.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech


### PR DESCRIPTION
Adds MoltBook Publisher MCP to Translation Services section.

MoltBook Publisher is a Japanese content publishing toolkit MCP server with 8 tools: Markdown to HTML conversion, SEO optimization, EN→JP translation, article outlines, trending topics, and cross-platform formatting for note.com, Zenn, and Qiita.

- **URL**: https://moltbook-publisher-mcp.yagami8095.workers.dev/mcp
- **Protocol**: Streamable HTTP (MCP 2025-03-26)
- **Transport**: Remote (Cloudflare Workers)