### PR TITLE
Add VMware-AIops MCP server to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [aliyun/alibaba-cloud-ops-mcp-server](https://github.com/aliyun/alibaba-cloud-ops-mcp-server) 🎖️ 🐍 ☁️ - A MCP server that enables AI assistants to operation resources on Alibaba Cloud, supporting ECS, Cloud Monitor, OOS and widely used cloud products.
 - [awslabs/mcp](https://github.com/awslabs/mcp) 🎖️ ☁️ - AWS MCP servers for seamless integration with AWS services and resources.
 - [bright8192/esxi-mcp-server](https://github.com/bright8192/esxi-mcp-server) 🐍 ☁️ - A VMware ESXi/vCenter management server based on MCP (Model Control Protocol), providing simple REST API interfaces for virtual machine management.
+- [zw008/VMware-AIops](https://github.com/zw008/VMware-AIops) 🐍 ☁️ - AI-powered VMware vCenter/ESXi monitoring and operations via MCP: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning with webhook notifications.
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1
 - [cyclops-ui/mcp-cyclops](https://github.com/cyclops-ui/mcp-cyclops) 🎖️ 🏎️ ☁️ - An MCP server that allows AI agents to manage Kubernetes resources through Cyclops abstraction
 - [elementfm/mcp](https://gitlab.com/elementfm/mcp) 🎖️ 🐍 📇 🏠 ☁️ - Open source podcast hosting platform


### PR DESCRIPTION
## Summary
Add [VMware-AIops](https://github.com/zw008/VMware-AIops) MCP server to the Cloud Platforms section.

## About
AI-powered VMware vCenter/ESXi monitoring and operations MCP server:
- Inventory: VMs, hosts, datastores, clusters, networks
- Health: Alarms, events, hardware sensors
- VM Lifecycle: Power, create, delete, snapshot, clone, vMotion
- vSAN: Health, capacity, performance
- Aria Operations: Historical metrics, anomaly detection
- Scheduled log scanning with Slack/Discord webhooks

Built with Python (pyVmomi). Supports Claude Desktop, Cursor, and any MCP client.

- GitHub: https://github.com/zw008/VMware-AIops
- License: MIT