### PR TITLE
Add playwright-browser-skill to Browser Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) 🦀 Lightweight browser automation MCP server in Rust with zero dependencies.
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation,more suitable for llm
+- [91fapiao-cn/playwright-browser-skill](https://github.com/91fapiao-cn/playwright-browser-skill) 📇 🏠 - A powerful Playwright MCP server providing 101 browser control tools with out-of-the-box Windows/Mac/Linux auto-deploy scripts.
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) 🎖️ 📇 - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)
 - [browsermcp/mcp](https://github.com/browsermcp/mcp) 📇 🏠 - Automate your local Chrome browser
 - [brutalzinn/simple-mcp-selenium](https://github.com/brutalzinn/simple-mcp-selenium) 📇 🏠 - An MCP Selenium Server for controlling browsers using natural language in Cursor IDE. Perfect for testing, automation, and multi-user scenarios.


### PR DESCRIPTION
Hi! I've developed a comprehensive Playwright MCP server specifically designed for browser automation, containing 101 mapped browser capabilities.

It comes with out-of-the-box Windows/Mac/Linux auto-deploy scripts, making it extremely easy for AI agents to seamlessly interact with complex web pages.

Thought it would be a great addition to the Browser automation section!