### PR TITLE
Add agentlookup-mcp to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [parallel-web/task-mcp](https://github.com/parallel-web/task-mcp) ☁️ 🔎 - Highest Accuracy Deep Research and Batch Tasks MCP
 - [Pearch-ai/mcp_pearch](https://github.com/Pearch-ai/mcp_pearch) 🎖️ 🐍 ☁️ - Best people search engine that reduces the time spent on talent discovery
 - [peter-j-thompson/semanticapi-mcp](https://github.com/peter-j-thompson/semanticapi-mcp) 🐍 ☁️ - Natural language API discovery — search 700+ API capabilities, get endpoints, auth setup, and code snippets. Supports auto-discovery of new APIs.
+- [peureka/agentlookup-mcp](https://github.com/peureka/agentlookup-mcp) 📇 ☁️ - MCP server for the public AI agent registry at agentlookup.dev. Search, discover, and register agents from any MCP-compatible client.
 - [pragmar/mcp-server-webcrawl](https://github.com/pragmar/mcp-server-webcrawl) 🐍 🏠 - Advanced search and retrieval for web crawler data. Supports WARC, wget, Katana, SiteOne, and InterroBot crawlers.
 - [QuentinCody/catalysishub-mcp-server](https://github.com/QuentinCody/catalysishub-mcp-server) 🐍 - Unofficial MCP server for searching and retrieving scientific data from the Catalysis Hub database, providing access to computational catalysis research and surface reaction data.
 - [r-huijts/opentk-mcp](https://github.com/r-huijts/opentk-mcp) 📇 ☁️ - Access Dutch Parliament (Tweede Kamer) information including documents, debates, activities, and legislative cases through structured search capabilities (based on opentk project by Bert Hubert)


### PR DESCRIPTION
## Summary

- Adds [peureka/agentlookup-mcp](https://github.com/peureka/agentlookup-mcp) to the **Search & Data Extraction** section in alphabetical order
- AgentLookup MCP is a TypeScript-based cloud MCP server for the public AI agent registry at [agentlookup.dev](https://agentlookup.dev)
- Enables search, discovery, and registration of AI agents from any MCP-compatible client

## Details

- **Section**: Search & Data Extraction
- **Position**: Alphabetically between `peter-j-thompson/semanticapi-mcp` and `pragmar/mcp-server-webcrawl`
- **Emojis**: 📇 (TypeScript) ☁️ (Cloud Service)
- **Repository**: https://github.com/peureka/agentlookup-mcp