### PR TITLE
Add apiarya/wemo-mcp-server to Home Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,7 @@ Integration with gaming related data, game engines, and services
 
 Control smart home devices, home network equipment, and automation systems.
 
-- [apiarya/wemo-mcp-server](https://github.com/apiarya/wemo-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Control WeMo smart home devices via AI assistants using natural language. Built on pywemo for 100% local control — no cloud dependency. Supports dimmer brightness, device rename, HomeKit codes, and multi-phase discovery.
+- [apiarya/wemo-mcp-server](https://github.com/apiarya/wemo-mcp-server) - [glama](https://glama.ai/mcp/servers/@apiarya/wemo-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Control WeMo smart home devices via AI assistants using natural language. Built on pywemo for 100% local control — no cloud dependency. Supports dimmer brightness, device rename, HomeKit codes, and multi-phase discovery.
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
## Description

Adds [apiarya/wemo-mcp-server](https://github.com/apiarya/wemo-mcp-server) to the 🏠 Home Automation section.

## What is this MCP server?

A production-ready MCP server that enables natural language control of WeMo smart home devices via AI assistants. Built on pywemo for 100% local control — no cloud dependency.

**Features:**
- Multi-phase device discovery (UPnP/SSDP + network scanning)
- Real-time device control (on/off/toggle/brightness)
- Device rename, HomeKit code extraction
- Persistent device caching
- MCP Resources and Prompts support

**Installation:** `uvx wemo-mcp-server`

**Published on:** [PyPI](https://pypi.org/project/wemo-mcp-server/) | [MCP Registry](https://registry.modelcontextprotocol.io/?q=apiarya/wemo)

## Checklist

- [x] The server is listed alphabetically under the appropriate category
- [x] The entry follows the format: `- [owner/repo](link) 🐍 🏠 🍎 🪟 🐧 - description`
- [x] The repo exists and is publicly available
- [x] The description is concise and informative