### PR TITLE
Add dgmo-mcp (DGMO diagram rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 Design and visualize software architecture, system diagrams, and technical documentation. Enables AI models to generate professional diagrams and architectural documentation.
 
 - [betterhyq/mermaid-grammer-inspector-mcp](https://github.com/betterhyq/mermaid_grammer_inspector_mcp) 📇 🏠 🍎 🪟 🐧 - A Model Context Protocol (MCP) server for validating Mermaid diagram syntax and providing comprehensive grammar checking capabilities
+- [diagrammo/dgmo-mcp](https://github.com/diagrammo/dgmo-mcp) 📇 🏠 - MCP server for rendering 29 types of diagrams and charts (bar, sequence, flowchart, ER, etc.) to SVG/PNG with browser preview and HTML reports
 - [GittyBurstein/mermaid-mcp-server](https://github.com/GittyBurstein/mermaid-mcp-server) 🐍 ☁️ - MCP server that turns local projects or GitHub repositories into Mermaid diagrams and renders them via Kroki.
 - [Narasimhaponnada/mermaid-mcp](https://github.com/Narasimhaponnada/mermaid-mcp) 📇 ☁️ 🍎 🪟 🐧 - AI-powered Mermaid diagram generation with 22+ diagram types including flowcharts, sequence diagrams, class diagrams, ER diagrams, architecture diagrams, state machines, and more. Features 50+ pre-built templates, advanced layout engines, SVG/PNG/PDF exports, and seamless integration with GitHub Copilot, Claude, and any MCP-compatible client. Install via NPM: `npm install -g @narasimhaponnada/mermaid-mcp-server`
 


### PR DESCRIPTION
[38;2;227;234;242m## Summary[0m

[38;2;227;234;242m- Adds [diagrammo/dgmo-mcp](https://github.com/diagrammo/dgmo-mcp) to the **Architecture & Design** section[0m
[38;2;227;234;242m- dgmo-mcp is an MCP server for rendering 29 types of diagrams and charts (bar, sequence, flowchart, ER, Gantt, pie, mindmap, timeline, etc.) to SVG/PNG using the [DGMO](https://github.com/diagrammo/dgmo) markup language[0m
[38;2;227;234;242m- Features browser preview and HTML report generation[0m
[38;2;227;234;242m- TypeScript codebase, runs locally (📇 🏠)[0m

[38;2;227;234;242m## Checklist[0m

[38;2;227;234;242m- [x] Entry placed in alphabetical order within the Architecture & Design section[0m
[38;2;227;234;242m- [x] Follows the existing format with language and scope icons[0m
[38;2;227;234;242m- [x] Links to a public GitHub repository[0m