### PR TITLE
Add polymarket-paper-trader to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [agent-next/polymarket-paper-trader](https://github.com/agent-next/polymarket-paper-trader) 🐍 🏠 🍎 🪟 🐧 - Paper trading simulator for Polymarket prediction markets. 23 MCP tools for AI agents to trade with real order books, zero risk. Includes analytics, limit orders, backtesting, and shareable stats cards.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
## Summary
- Adds [agent-next/polymarket-paper-trader](https://github.com/agent-next/polymarket-paper-trader) to the Finance & Fintech section

## Description
Paper trading simulator for Polymarket prediction markets. Exposes 23 MCP tools for AI agents to:
- Trade with real order books (zero risk, no real money)
- Analyze performance (Sharpe ratio, win rate, drawdown)
- Run limit orders (GTC/GTD), backtest strategies
- Generate shareable stats cards for X/Twitter/Telegram

Python 3.10+, SQLite, stdio transport. 579 tests, 100% coverage.