### PR TITLE
Add pyxel-mcp to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ Integration with gaming related data, game engines, and services
 - [hkaanengin/opendota-mcp-server](https://github.com/hkaanengin/opendota-mcp-server) 🐍 🏠 ☁️ - MCP server providing AI assistants with access to Dota 2 statistics via OpenDota API. 20+ tools for player stats, hero data, and match    analysis with natural language support.
 - [IvanMurzak/Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) #️⃣ 🏠 🍎 🪟 🐧 - MCP Server for Unity Editor and for a game made with Unity
 - [jiayao/mcp-chess](https://github.com/jiayao/mcp-chess) 🐍 🏠 - A MCP server playing chess against LLMs.
-- [kitao/pyxel-mcp](https://github.com/kitao/pyxel-mcp) 🐍 🏠 - MCP server for [Pyxel](https://github.com/kitao/pyxel) retro game engine, enabling AI to run, capture screenshots, inspect sprites, and analyze audio of Pyxel games.
+- [kitao/pyxel-mcp](https://github.com/kitao/pyxel-mcp) [glama](https://glama.ai/mcp/servers/@kitao/pyxel-mcp) 🐍 🏠 - MCP server for [Pyxel](https://github.com/kitao/pyxel) retro game engine, enabling AI to run, capture screenshots, inspect sprites, and analyze audio of Pyxel games.
 - [kkjdaniel/bgg-mcp](https://github.com/kkjdaniel/bgg-mcp) 🏎️ ☁️ - An MCP server that enables interaction with board game related data via the BoardGameGeek API (XML API2).
 - [opgginc/opgg-mcp](https://github.com/opgginc/opgg-mcp) 📇 ☁️ - Access real-time gaming data across popular titles like League of Legends, TFT, and Valorant, offering champion analytics, esports schedules, meta compositions, and character statistics.
 - [pab1ito/chess-mcp](https://github.com/pab1it0/chess-mcp) 🐍 ☁️ - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.


### PR DESCRIPTION
Add [pyxel-mcp](https://github.com/kitao/pyxel-mcp) to the Gaming section.

pyxel-mcp is an MCP server for [Pyxel](https://github.com/kitao/pyxel), a retro game engine for Python. It enables AI to autonomously run, capture screenshots, inspect sprites, analyze layout, and render audio of Pyxel games.

- Published on PyPI: https://pypi.org/project/pyxel-mcp/
- MCP Registry name: `io.github.kitao/pyxel-mcp`
- License: MIT