### PR TITLE
Add antbotlab/mac-use-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 
 - [34892002/bilibili-mcp-js](https://github.com/34892002/bilibili-mcp-js) 📇 🏠 - A MCP server that supports searching for Bilibili content. Provides LangChain integration examples and test scripts.
 - [agent-infra/mcp-server-browser](https://github.com/bytedance/UI-TARS-desktop/tree/main/packages/agent-infra/mcp-servers/browser) 📇 🏠 - Browser automation capabilities using Puppeteer, both support local and remote browser connection.
+- [antbotlab/mac-use-mcp](https://github.com/antbotlab/mac-use-mcp) 📇 🏠 🍎 - Zero-dependency macOS desktop automation — screenshot, click, type, scroll, window management, and accessibility inspection via 18 MCP tools.
 - [automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) 🦀 Lightweight browser automation MCP server in Rust with zero dependencies.
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation,more suitable for llm


### PR DESCRIPTION
Adds [mac-use-mcp](https://github.com/antbotlab/mac-use-mcp) to the Browser Automation section.

**mac-use-mcp** — Zero-dependency macOS desktop automation for AI agents.

- One command install: `npx mac-use-mcp`
- 18 tools: screenshot, click, type, scroll, drag, window management, menu bar, accessibility inspection, clipboard
- macOS 13+ (Ventura through Sequoia), Intel & Apple Silicon
- Zero native dependencies — no Xcode, no node-gyp, no Python
- Works with Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP client
- MIT licensed