### PR TITLE
Add APIClaw - API layer for AI agents (22,000+ APIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [duaraghav8/MCPJungle](https://github.com/duaraghav8/MCPJungle) 🏎️ 🏠 - Self-hosted MCP Server registry for enterprise AI Agents
 - [edgarriba/prolink](https://github.com/edgarriba/prolink) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Agent-to-agent marketplace middleware — MCP-native discovery, negotiation, and transaction between AI agents
 - [glenngillen/mcpmcp-server](https://github.com/glenngillen/mcpmcp-server) ☁️ 📇 🍎 🪟 🐧 - A list of MCP servers so you can ask your client which servers you can use to improve your daily workflow.
+- [nordsym/apiclaw](https://github.com/nordsym/apiclaw) 📇 ☁️ 🍎 🪟 🐧 - The API layer for AI agents. 22,000+ APIs indexed, semantic discovery, and Direct Call execution without managing keys. Works with any MCP-compatible agent.
 - [hamflx/imagen3-mcp](https://github.com/hamflx/imagen3-mcp) 📇 🏠 🪟 🍎 🐧 - A powerful image generation tool using Google's Imagen 3.0 API through MCP. Generate high-quality images from text prompts with advanced photography, artistic, and photorealistic controls.
 - [hashgraph-online/hashnet-mcp-js](https://github.com/hashgraph-online/hashnet-mcp-js) 📇 ☁️ 🍎 🪟 🐧 - MCP server for the Registry Broker. Discover, register, and chat with AI agents on the Hashgraph network.
 - [isaac-levine/forage](https://github.com/isaac-levine/forage) 📇 🏠 🍎 🪟 🐧 - Self-improving tool discovery for AI agents. Searches registries, installs MCP servers as subprocesses, and persists tool knowledge across sessions — no restarts needed.


### PR DESCRIPTION
Adding APIClaw to the Aggregators section.

## What it does
- **Semantic API discovery** — 22,000+ APIs indexed, query by capability not keywords
- **Direct Call execution** — 18 providers, no API keys needed
- **MCP native** — Works with any MCP-compatible agent (Claude, GPT, etc.)

## Links
- GitHub: https://github.com/nordsym/apiclaw
- npm: https://www.npmjs.com/package/@nordsym/apiclaw
- Website: https://apiclaw.nordsym.com

## Install
```bash
npx @nordsym/apiclaw mcp-install
```

## Stats
- 2,300+ GitHub clones in 2 weeks
- 18 Direct Call providers (Replicate, OpenRouter, ElevenLabs, etc.)
- Sub-200ms response times