### PR TITLE
Add Slovakia's central reference register to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
+- [LegalEngineering/sk-registers-mcp](https://github.com/LegalEngineering/sk-registers-mcp) 🐍 ☁️ - Access Slovakia's central reference register (RPO) aggregating 100+ source registers. Query 1.4M+ legal entities, entrepreneurs, and public authorities by name, IČO, or municipality.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
Added a new entry for Slovakia's central reference register in the legal resources section.