### PR TITLE
Add MCP Database Connector Lite and MCP API Bridge Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [alexanderzuev/supabase-mcp-server](https://github.com/alexander-zuev/supabase-mcp-server) - Supabase MCP Server with support for SQL query execution and database exploration tools
 - [aliyun/alibabacloud-tablestore-mcp-server](https://github.com/aliyun/alibabacloud-tablestore-mcp-server) ☕ 🐍 ☁️ - MCP service for Tablestore, features include adding documents, semantic search for documents based on vectors and scalars, RAG-friendly, and serverless.
 - [amineelkouhen/mcp-cockroachdb](https://github.com/amineelkouhen/mcp-cockroachdb) 🐍 ☁️ - A Model Context Protocol server for managing, monitoring, and querying data in [CockroachDB](https://cockroachlabs.com).
+- [tiranmoskovitch-dev/mcp-database-connector-lite](https://github.com/tiranmoskovitch-dev/mcp-database-connector-lite) 🐍 🏠 - Free SQLite MCP server with WAL mode, foreign keys, and clean JSON responses. Zero config — point at a .db file and go. Part of the MCP Starter Arsenal.
 - [benborla29/mcp-server-mysql](https://github.com/benborla/mcp-server-mysql) ☁️ 🏠 - MySQL database integration in NodeJS with configurable access controls and schema inspection
 - [bram2w/baserow](https://github.com/bram2w/baserow) - Baserow database integration with table search, list, and row create, read, update, and delete capabilities.
 - [c4pt0r/mcp-server-tidb](https://github.com/c4pt0r/mcp-server-tidb) 🐍 ☁️ - TiDB database integration with schema inspection and query capabilities
@@ -1545,6 +1546,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
+- [tiranmoskovitch-dev/mcp-api-bridge-lite](https://github.com/tiranmoskovitch-dev/mcp-api-bridge-lite) 🐍 ☁️ - Free REST API wrapper as MCP server. Let AI agents call any REST API with Bearer auth support. Config via environment variables. Part of the MCP Starter Arsenal.
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.
 - [2niuhe/qrcode_mcp](https://github.com/2niuhe/qrcode_mcp) 🐍 🏠 🍎 🪟 🐧 - A QR code generation MCP server that converts any text (including Chinese characters) to QR codes with customizable colors and base64 encoding output.
 - [AbdelStark/bitcoin-mcp](https://github.com/AbdelStark/bitcoin-mcp) - ₿ A Model Context Protocol (MCP) server that enables AI models to interact with Bitcoin, allowing them to generate keys, validate addresses, decode transactions, query the blockchain, and more.


### PR DESCRIPTION
## Added Servers

### 1. MCP Database Connector Lite (Databases section)
- **Repo:** https://github.com/tiranmoskovitch-dev/mcp-database-connector-lite
- **Language:** Python
- **Scope:** Local
- Free SQLite MCP server with WAL mode, foreign keys, and clean JSON responses
- 3 tools: `db_query`, `db_list_tables`, `db_describe_table`
- Zero config — just set `MCP_DB_DATABASE` and run

### 2. MCP API Bridge Lite (Other Tools section)
- **Repo:** https://github.com/tiranmoskovitch-dev/mcp-api-bridge-lite
- **Language:** Python
- **Scope:** Cloud
- Free REST API wrapper as MCP server
- 1 tool: `api_request` (GET/POST/PUT/DELETE)
- Bearer token auth support

Both are part of the MCP Starter Arsenal — production-ready MCP server collection.