### PR TITLE
Add meta-ads-analyzer to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 ### 🎯 <a name="marketing"></a>Marketing
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
-
+- [shibanshu12/meta-ads-analyzer](https://github.com/shibanshu12/meta-ads-analyzer) 🐍 🏠 - Performance marketing diagnostics MCP server for Meta Ads. 15 tools across spend leak detection, creative fatigue analysis, audience decay monitoring, and custom SQL queries with read-only security. Built for growth marketers managing $100K+ monthly ad spend.
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
 - [alexey-pelykh/lhremote](https://github.com/alexey-pelykh/lhremote) 📇 🏠 - Open-source CLI and MCP server for LinkedHelper automation — 32 tools for campaign management, messaging, and profile queries via Chrome DevTools Protocol.
 - [BlockRunAI/x-grow](https://github.com/BlockRunAI/x-grow) 📇 ☁️ - X/Twitter algorithm optimizer with post drafting, review scoring, and AI image generation for maximum engagement.


### PR DESCRIPTION
Adding meta-ads-analyzer - a Python MCP server for Meta Ads performance diagnostics.

- 15 tools across 5 modules (spend leaks, creative fatigue, audience decay, benchmarks, custom queries)
- Read-only SQLite security by default
- Built for growth marketers managing significant ad budgets
- GitHub: https://github.com/shibanshu12/meta-ads-analyzer