### PR TITLE
Add nightlife-mcp: Tokyo nightlife event discovery MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,7 +1485,7 @@ Tools for converting text-to-speech and vice-versa
 
 Access to travel and transportation information. Enables querying schedules, routes, and real-time travel data.
 
-- [alcylu/nightlife-mcp](https://github.com/alcylu/nightlife-mcp) [glama](https://glama.ai/mcp/servers/alcylu/nightlife-mcp) 📇 ☁️ - MCP server for Tokyo nightlife event discovery, venue search, performer info, AI recommendations, and VIP table booking.
+- [alcylu/nightlife-mcp](https://github.com/alcylu/nightlife-mcp) [![nightlife](https://glama.ai/mcp/servers/alcylu/nightlife-mcp/badges/score.svg)](https://glama.ai/mcp/servers/alcylu/nightlife-mcp) 📇 ☁️ - MCP server for Tokyo nightlife event discovery, venue search, performer info, AI recommendations, and VIP table booking.
 - [campertunity/mcp-server](https://github.com/campertunity/mcp-server) 🎖️ 📇 🏠 - Search campgrounds around the world on campertunity, check availability, and provide booking links
 - [cobanov/teslamate-mcp](https://github.com/cobanov/teslamate-mcp) 🐍 🏠 - A Model Context Protocol (MCP) server that provides access to your TeslaMate database, allowing AI assistants to query Tesla vehicle data and analytics.
 - [helpful-AIs/triplyfy-mcp](https://github.com/helpful-AIs/triplyfy-mcp) 📇 ☁️ - An MCP server that lets LLMs plan and manage itineraries with interactive maps in Triplyfy; manage itineraries, places and notes, and search/save flights.


### PR DESCRIPTION
## Summary

Adds [nightlife-mcp](https://github.com/alcylu/nightlife-mcp) to the **Travel & Transportation** section.

**nightlife-mcp** is an open-source TypeScript MCP server providing real-time Tokyo nightlife data:
- 9 MCP tools + 8 REST API endpoints
- Event search, venue profiles, performer info, AI recommendations, VIP table booking
- OpenAPI 3.1 spec + interactive docs at https://api.nightlife.dev/api/v1/docs
- Hosted at https://api.nightlife.dev/mcp

Entry placed in alphabetical order within Travel & Transportation.

## Checklist
- [x] TypeScript codebase (📇)
- [x] Cloud service (☁️)
- [x] Open source (MIT license)
- [x] Alphabetical ordering maintained
- [x] Single-line entry following repo conventions