### PR TITLE
Add Remote Vibe Coding Jobs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 ### 🔎 <a name="search"></a>Search & Data Extraction
 
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
+- [di-su/vibe-coding-jobs](https://github.com/di-su/vibe-coding-jobs/tree/main/packages/mcp-server) 📇 ☁️ - Search 630+ remote software jobs with structured filters for tech stack, culture/vibe signals, salary, and experience level. Free API (100 req/day).
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.
 - [Aas-ee/open-webSearch](https://github.com/Aas-ee/open-webSearch) 🐍 📇 ☁️ - Web search using free multi-engine search (NO API KEYS REQUIRED) — Supports Bing, Baidu, DuckDuckGo, Brave, Exa, and CSDN.
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration


### PR DESCRIPTION
Adds MCP server for searching remote software/developer jobs.

- **Tools:** search_jobs, get_job, job_market_stats
- **Data:** 630+ active remote dev jobs with structured tech_stack, vibe_tags, salary, experience_level
- **Transport:** stdio
- **Language:** TypeScript
- **Install:** `npx @remotevibecodingjobs/mcp-server`
- **Free tier:** 100 API requests/day, no credit card
- **Docs:** https://remotevibecodingjobs.com/developers