### PR TITLE
Add MiOffice — AI Office Suite MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [MarceauSolutions/md-to-pdf-mcp](https://github.com/MarceauSolutions/md-to-pdf-mcp) 🐍 🏠 🍎 🪟 🐧 - Convert Markdown files to professional PDFs with customizable themes, headers, footers, and styling
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.
+- [MiOffice-ai/mcp](https://github.com/MiOffice-ai/mcp) 📇 🏠 🍎 🪟 🐧 - AI Office Suite — process PDFs, images & documents. Merge, split, compress PDFs, resize/convert images, remove backgrounds. 100% privacy.
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.


### PR DESCRIPTION
## Summary
- Adds [MiOffice MCP server](https://github.com/MiOffice-ai/mcp) to the **File Systems** section
- AI Office Suite — process PDFs, images & documents (merge, split, compress PDFs, resize/convert images, remove backgrounds)
- 100% local processing, files never leave the machine
- TypeScript, works on macOS/Windows/Linux
- Available on npm: [@miofficeai/mcp](https://www.npmjs.com/package/@miofficeai/mcp)

## Checklist
- [x] Entry added in alphabetical order
- [x] Follows existing format with correct badges (📇 🏠 🍎 🪟 🐧)
- [x] Description is concise and descriptive
- [x] Link points to valid GitHub repository