### PR TITLE
Add vernonstinebaker/webdav-mcp to File Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.
+- [vernonstinebaker/webdav-mcp](https://github.com/vernonstinebaker/webdav-mcp) 🏠 🍎 🪟 🐧 - Zero-dependency WebDAV MCP server. Single static binary (~100-160 KB), no Node.js or Python required. 8 tools: list, read, write, delete, mkdir, move, copy, stat. RFC 4918 correct.
 - [willianpinho/large-file-mcp](https://github.com/willianpinho/large-file-mcp) 📇 🏠 🍎 🪟 🐧 - Production-ready MCP server for intelligent handling of large files with smart chunking, navigation, streaming capabilities, regex search, and built-in LRU caching.
 - [Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal) 🐍 🏠 ☁️ - Access any storage with Apache OpenDAL™
 - [xxczaki/local-history-mcp](https://github.com/xxczaki/local-history/mcp) 📇 🏠 🍎 🪟 🐧  - MCP server for accessing VS Code/Cursor Local History


### PR DESCRIPTION
## Description

Adds [vernonstinebaker/webdav-mcp](https://github.com/vernonstinebaker/webdav-mcp) to the **File Systems** section.

## What this server does

Zero-dependency WebDAV MCP server — a single static binary with no runtime requirements (no Node.js, no Python). It exposes 8 WebDAV tools over stdio:

- `list` — directory listing
- `read` — file read
- `write` — file write
- `delete` — delete file or directory
- `mkdir` — create directory
- `move` — move/rename
- `copy` — copy
- `stat` — file metadata

RFC 4918 compliant. Works with any WebDAV server (Nextcloud, ownCloud, Apache, nginx, etc).

## Entry added

```
- [vernonstinebaker/webdav-mcp](https://github.com/vernonstinebaker/webdav-mcp) 🏠 🍎 🪟 🐧 - Zero-dependency WebDAV MCP server. Single static binary (~100-160 KB), no Node.js or Python required. 8 tools: list, read, write, delete, mkdir, move, copy, stat. RFC 4918 correct.
```

Inserted alphabetically between `willianpinho/large-file-mcp` and `Xuanwo/mcp-server-opendal`.