### PR TITLE
Add AgentCard to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [AgentCard](https://github.com/radiahq/mcp) 📇☁️ - Prepaid virtual Visa cards for AI agents with MCP-native spending controls and per-task budget limits.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
## Summary

- Adds [AgentCard](https://github.com/radiahq/mcp) to the **Finance & Fintech** category
- AgentCard provides prepaid virtual Visa cards for AI agents with MCP-native spending controls and per-task budget limits
- Entry placed alphabetically within the section

## Checklist

- [x] Entry follows the existing format (`- [Name](URL) emojis - Description`)
- [x] Alphabetically ordered within the category
- [x] Emoji legend: 📇 (has a directory/listing), ☁️ (hosted/cloud service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)