### PR TITLE
Add Rolli MCP — social media search and analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 - [kunallunia/twitter-mcp](https://github.com/LuniaKunal/mcp-twitter) 🐍 🏠 - All-in-one Twitter management solution providing timeline access, user tweet retrieval, hashtag monitoring, conversation analysis, direct messaging, sentiment analysis of a post, and complete post lifecycle control - all through a streamlined API.
 - [macrocosm-os/macrocosmos-mcp](https://github.com/macrocosm-os/macrocosmos-mcp) - 🎖️ 🐍 ☁️ Access real-time X/Reddit/YouTube data directly in your LLM applications  with search phrases, users, and date filtering.
 - [MarceauSolutions/fitness-influencer-mcp](https://github.com/MarceauSolutions/fitness-influencer-mcp) 🐍 🏠 ☁️ - Fitness content creator workflow automation - video editing with jump cuts, revenue analytics, and branded content creation
+- [rolliinc/rolli-mcp](https://github.com/rolliinc/rolli-mcp) 📇 ☁️ 🍎 🪟 🐧 - Social media search and analytics across X, Reddit, Bluesky, YouTube, LinkedIn, Facebook, Instagram, and Weibo. Keyword search, user search, topic trees, and post retrieval via the Rolli IQ API.
 - [scrape-badger/scrapebadger-mcp](https://github.com/scrape-badger/scrapebadger-mcp) 🐍 ☁️ - Access Twitter/X data including user profiles, tweets, followers, trends, lists, and communities via the ScrapeBadger API.
 - [sinanefeozler/reddit-summarizer-mcp](https://github.com/sinanefeozler/reddit-summarizer-mcp) 🐍 🏠 ☁️ - MCP server for summarizing users's Reddit homepage or any subreddit based on posts and comments.
 


### PR DESCRIPTION
## What's being added

**Rolli MCP** — Social Media section

- MCP server for [Rolli IQ](https://rolli.ai) — social media search and analytics across X, Reddit, Bluesky, YouTube, LinkedIn, Facebook, Instagram, and Weibo
- 12 tools: keyword search, user search, topic trees, post retrieval, webhook setup, usage tracking
- TypeScript, published on npm as [@rolli/mcp](https://www.npmjs.com/package/@rolli/mcp)
- GitHub: https://github.com/rolliinc/rolli-mcp