### PR TITLE
Add WAzion MCP Server — 244 WhatsApp Business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Integration with communication platforms for message management and channel oper
 - [userad/didlogic_mcp](https://github.com/UserAd/didlogic_mcp) 🐍 ☁️ - An MCP server for [DIDLogic](https://didlogic.com). Adds functionality to manage SIP endpoints, numbers and destinations.
 - [wyattjoh/imessage-mcp](https://github.com/wyattjoh/imessage-mcp) 📇 🏠 🍎 - A Model Context Protocol server for reading iMessage data from macOS.
 - [wyattjoh/jmap-mcp](https://github.com/wyattjoh/jmap-mcp) 📇 ☁️ - A Model Context Protocol (MCP) server that provides tools for interacting with JMAP (JSON Meta Application Protocol) email servers. Built with Deno and using the jmap-jam client library.
-- [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server) 📇 ☁️ - 244 WhatsApp Business tools: send messages, automate workflows, run campaigns, and manage CRM. Streamable HTTP + stdio.
+- [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server) [glama](https://glama.ai/mcp/servers/@wazionapps/wazion-mcp-server) 📇 ☁️ - 244 WhatsApp Business tools: send messages, automate workflows, run campaigns, and manage CRM. Streamable HTTP + stdio.
 - [YCloud-Developers/ycloud-whatsapp-mcp-server](https://github.com/YCloud-Developers/ycloud-whatsapp-mcp-server) 📇 🏠 - MCP server for WhatsApp Business Platform by YCloud.
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) 📇 ☁️ - An MCP server to Manage Google Tasks
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.


### PR DESCRIPTION
## Summary

Adds WAzion MCP Server to the list.

**What it is:** A public MCP server that exposes 244 WhatsApp Business tools through the Model Context Protocol.

**Transport:** Streamable HTTP (no install needed) + stdio via `npx -y wazion-mcp-server`.

**Tool categories (24 total):**
- WhatsApp messaging and session management
- Workflow automation / WhatsApp Auto
- Mass marketing campaigns
- CRM — customers, notes, tags, tasks, calendar
- AI analysis — sentiment, conversation summaries, smart follow-ups
- Knowledge base, storage, plugins, agents, integrations

**GitHub:** https://github.com/wazionapps/mcp-server
**npm:** https://www.npmjs.com/package/wazion-mcp-server
**License:** MIT

## Checklist

- [x] The server is publicly available
- [x] The repository has a README
- [x] The server is MIT licensed
- [x] Tested with Claude Code and stdio transport