### PR TITLE
Add FHIRfly healthcare reference data MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 
 - [cafferychen777/ChatSpatial](https://github.com/cafferychen777/ChatSpatial) 🐍 🏠 - MCP server for spatial transcriptomics analysis with 60+ integrated methods covering cell annotation, deconvolution, spatial statistics, and visualization.
 - [dnaerys/onekgpd-mcp](https://github.com/dnaerys/onekgpd-mcp) ☕ ☁️ 🍎 🪟 🐧- real-time access to 1000 Genomes Project dataset
+- [FHIRfly-io/fhirfly-mcp-server](https://github.com/FHIRfly-io/fhirfly-mcp-server) 📇 ☁️ - Healthcare reference data for AI assistants — look up drugs (NDC, RxNorm, FDA Labels), providers (NPI), diagnoses (ICD-10, SNOMED CT), lab codes (LOINC), vaccines (CVX), and claims intelligence from authoritative sources (FDA, CMS, NLM, CDC).
 - [genomoncology/biomcp](https://github.com/genomoncology/biomcp) 🐍 ☁️ - Biomedical research MCP server providing access to PubMed, ClinicalTrials.gov, and MyVariant.info.
 - [hlydecker/ucsc-genome-mcp](https://github.com/hlydecker/ucsc-genome-mcp) 🐍 ☁️ - MCP server to interact with the UCSC Genome Browser API, letting you find genomes, chromosomes, and more.
 - [JamesANZ/medical-mcp](https://github.com/JamesANZ/medical-mcp) 📇 🏠 - An MCP server that provides access to medical information, drug databases, and healthcare resources. Enables AI assistants to query medical data, drug interactions, and clinical guidelines.
@@ -1285,6 +1286,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [erithwik/mcp-hn](https://github.com/erithwik/mcp-hn) 🐍 ☁️ - An MCP server to search Hacker News, get top stories, and more.
 - [exa-labs/exa-mcp-server](https://github.com/exa-labs/exa-mcp-server) 🎖️ 📇 ☁️ – A Model Context Protocol (MCP) server lets AI assistants like Claude use the Exa AI Search API for web searches. This setup allows AI models to get real-time web information in a safe and controlled way.
 - [fatwang2/search1api-mcp](https://github.com/fatwang2/search1api-mcp) 📇 ☁️ - Search via search1api (requires paid API key)
+- [FHIRfly-io/fhirfly-mcp-server](https://github.com/FHIRfly-io/fhirfly-mcp-server) 📇 ☁️ - Healthcare reference data for AI assistants — look up drugs (NDC, RxNorm, FDA Labels), providers (NPI), diagnoses (ICD-10, SNOMED CT), lab codes (LOINC), vaccines (CVX), and claims intelligence from authoritative sources (FDA, CMS, NLM, CDC).
 - [format37/youtube_mcp](https://github.com/format37/youtube_mcp) 🐍 ☁️ – MCP server that transcribes YouTube videos to text. Uses yt-dlp to download audio and OpenAI's Whisper-1 for more precise transcription than youtube captions. Provide a YouTube URL and get back the full transcript splitted by chunks for long videos.
 - [gemy411/multi-research-agents](https://github.com/gemy411/multi-agents-research) ☁️ - a KTOR server/ MCP server written in Kotlin applying multi-agents schools in a flexible research system to be used with coding or for research any general case.
 - [genomoncology/biomcp](https://github.com/genomoncology/biomcp) 🐍 ☁️ - Biomedical research server providing access to PubMed, ClinicalTrials.gov, and MyVariant.info.


### PR DESCRIPTION
## Summary

FHIRfly is an MCP server providing **28 tools** for healthcare reference data from authoritative sources (FDA, CMS, NLM, CDC). It enables AI assistants to look up drugs (NDC, RxNorm, FDA Labels), providers (NPI), diagnoses (ICD-10, SNOMED CT), lab codes (LOINC), vaccines (CVX), and claims intelligence.

- **npm package:** `@fhirfly-io/mcp-server`
- **MCP Registry:** Published as `io.fhirfly/mcp-server` on the official MCP Registry
- **GitHub:** [FHIRfly-io/fhirfly-mcp-server](https://github.com/FHIRfly-io/fhirfly-mcp-server)

Added to both the "Biology, Medicine and Bioinformatics" category section and the alphabetical server list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)