### PR TITLE
Add intercept-mcp to Browser Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [agent-infra/mcp-server-browser](https://github.com/bytedance/UI-TARS-desktop/tree/main/packages/agent-infra/mcp-servers/browser) 📇 🏠 - Browser automation capabilities using Puppeteer, both support local and remote browser connection.
 - [automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) 🦀 Lightweight browser automation MCP server in Rust with zero dependencies.
+- [bighippoman/intercept-mcp](https://github.com/bighippoman/intercept-mcp) 📇 🏠 - Multi-tier fallback chain for fetching web content as clean markdown. Handles tweets, YouTube, arXiv, PDFs, and regular pages with 9 fallback strategies.
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation,more suitable for llm
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) 🎖️ 📇 - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)
 - [browsermcp/mcp](https://github.com/browsermcp/mcp) 📇 🏠 - Automate your local Chrome browser


### PR DESCRIPTION
Adds [intercept-mcp](https://github.com/bighippoman/intercept-mcp) — an MCP server that fetches web content as clean markdown with multi-tier fallback. Handles tweets, YouTube, arXiv, PDFs, and regular pages. If one strategy fails, it tries up to 8 more.

Published on npm: `npx -y intercept-mcp`
Also listed on the Official MCP Registry.