### PR TITLE
Add ProofBets MCP Server to Finance & Fintech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [trayders/trayd-mcp](https://github.com/trayders/trayd-mcp) 🐍 ☁️ - Trade Robinhood through natural language. Portfolio analysis, real-time quotes, and order execution via Claude Code.
 - [twelvedata/mcp](https://github.com/twelvedata/mcp) 🐍 ☁️ - Interact with [Twelve Data](https://twelvedata.com) APIs to access real-time and historical financial market data for your AI agents.
 - [VENTURE-AI-LABS/cryptodataapi-mcp](https://github.com/VENTURE-AI-LABS/cryptodataapi-mcp) 📇 ☁️ - Real-time crypto market data for AI agents — market health scores, derivatives, funding rates, ETF flows, cycle indicators, and 100+ endpoints via CryptoDataAPI.
+- [vjrmuc/proofbets](https://github.com/vjrmuc/proofbets/tree/main/mcp-server) 📇 ☁️ - Query verified crypto casino reviews, bonus codes, prediction market fees, and sports betting odds. 13 tools with on-chain data verification via Etherscan.
 - [wowinter13/solscan-mcp](https://github.com/wowinter13/solscan-mcp) 🦀 🏠 - An MCP tool for querying Solana transactions using natural language with Solscan API.
 - [Wuye-AI/mcp-server-wuye-ai](https://github.com/wuye-ai/mcp-server-wuye-ai) 🎖️ 📇 ☁️ - An MCP server that interact with capabilities of the CRIC Wuye AI platform, an intelligent assistant specifically for the property management industry.
 - [XeroAPI/xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server) 📇 ☁️ – An MCP server that integrates with Xero's API, allowing for standardized access to Xero's accounting and business features.


### PR DESCRIPTION
Adding ProofBets MCP Server (TypeScript, ☁️ SSE transport) to the Finance & Fintech section.

13 tools including: search_casinos, get_casino, search_bonuses, check_bonus_code, calculate_ev, compare_casinos, search_p2p_platforms, compare_platforms, get_platform_fees.

- 50+ crypto casinos with verified data
- 7 P2P prediction market platforms (Polymarket, Kalshi, Azuro, BetDEX, etc.)
- On-chain wallet verification via Etherscan
- Live TVL tracking via DeFi Llama
- Free tier: 20 req/min anon, 100/min with API key

GitHub: https://github.com/proofbets/proofbets-mcp
SSE: https://proofbets.com/api/mcp/

Placed alphabetically in Finance & Fintech section. Uses 📇 (TypeScript) and ☁️ (cloud/SSE) badges per contributing guidelines.