### PR TITLE
Add menyoung/paperqa-mcp-server to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 Tools for conducting research, surveys, interviews, and data collection.
 
 - [Embassy-of-the-Free-Mind/sourcelibrary-v2](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/tree/main/mcp-server) 📇 ☁️ - Search and cite rare historical texts (alchemy, Hermeticism, Renaissance philosophy) with DOI-backed academic citations from [Source Library](https://sourcelibrary.org)
+- [menyoung/paperqa-mcp-server](https://github.com/menyoung/paperqa-mcp-server) 🐍 🏠 ☁️ - Deep search and synthesis across local PDF libraries using PaperQA2. Point it at your Zotero storage or any folder of PDFs.
 - [ovlabs/mcp-server-originalvoices](https://github.com/ovlabs/mcp-server-originalvoices) 📇 ☁️ - Instantly understand what real users think and why by querying our network of 1:1 Digital Twins - each representing a real person. Give your AI agents authentic human context to ground outputs, improve creative, and make smarter decisions.
 - [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
 - [pminervini/deep-research-mcp](https://github.com/pminervini/deep-research-mcp) 🐍 ☁️ 🏠 - Deep research MCP server for OpenAI Responses API or Open Deep Research (smolagents), with web search and code interpreter support.


### PR DESCRIPTION
Adds [paperqa-mcp-server](https://github.com/menyoung/paperqa-mcp-server) to the 🔬 Research section.

MCP server that gives Claude deep search and synthesis across local PDF libraries using PaperQA2. Works with Zotero storage or any folder of PDFs. Installable via `uvx paperqa-mcp-server`.

- Python (`🐍`)
- Local PDFs (`🏠`) + OpenAI API for embeddings (`☁️`)
- Published on [PyPI](https://pypi.org/project/paperqa-mcp-server/)