### PR TITLE
Add Arcology Knowledge Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ Persistent memory storage using knowledge graph structures. Enables AI models to
 - [upstash/context7](https://github.com/upstash/context7) 📇 ☁️ - Up-to-date code documentation for LLMs and AI code editors.
 - [varun29ankuS/shodh-memory](https://github.com/varun29ankuS/shodh-memory) 🦀 🏠 - Cognitive memory for AI agents with Hebbian learning, 3-tier architecture, and knowledge graphs. Single ~15MB binary, runs offline on edge devices.
 - [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) 🐍 ☁️ 🏠 - Hindsight: Agent Memory That Works Like Human Memory - Built for AI Agents to manage Long Term Memory
+- [YourLifewithAI/Lifewithai](https://github.com/YourLifewithAI/Lifewithai/tree/main/mcp) 🐍 ☁️ - Read-only MCP server for querying an 8-domain engineering knowledge base covering a speculative 10M-person arcology. 32 entries with quantitative parameters, cross-references, and 140+ open engineering questions.
 
 ### ⚖️ <a name="legal"></a>Legal
 


### PR DESCRIPTION
## New Server: Arcology Knowledge Node

**Category:** Knowledge & Memory

- **Repository:** https://github.com/YourLifewithAI/Lifewithai/tree/main/mcp
- **Language:** Python (FastMCP 2.0)
- **Transport:** SSE (Server-Sent Events)
- **Auth:** None (read-only, public data)

Read-only MCP server for querying an 8-domain collaborative engineering knowledge base. The knowledge base covers the design of Arcology One — a speculative mile-high city for 10 million people.

32 technical entries span structural engineering, energy systems, environmental systems, mechanical/electrical, AI & compute infrastructure, institutional design, construction logistics, and urban livability. Each entry includes quantitative parameters with units and confidence levels, cross-domain references, citations, and open engineering questions.

**6 tools:** read_node, search_knowledge, list_domains, get_open_questions, get_entry_parameters, get_domain_stats

**Live server:** https://arcology-mcp.fly.dev/sse