### PR TITLE
Add Archetype - AI sales candidate assessment server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1520,7 +1520,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🏢 <a name="workplace-and-productivity"></a>Workplace & Productivity
 
-- [Archetype](https://archetype.swell.vc/mcp) ☁️ - Score sales candidates against a proprietary framework built over 10,000+ real interviews. Generate interview scripts and score transcripts with ADVANCE/HOLD/PASS verdicts and shareable scorecards.
+- [Archetype](https://github.com/rustafarian5/salesarchetype) ☁️ - Score sales candidates against a proprietary framework built over 10,000+ real interviews. Generate interview scripts and score transcripts with ADVANCE/HOLD/PASS verdicts and shareable scorecards.
 - [bivex/kanboard-mcp](https://github.com/bivex/kanboard-mcp) 🏎️ ☁️ 🏠 - A Model Context Protocol (MCP) server written in Go that empowers AI agents and Large Language Models (LLMs) to seamlessly interact with Kanboard. It transforms natural language commands into Kanboard API calls, enabling intelligent automation of project, task, and user management, streamlining workflows, and enhancing productivity.
 - [bug-breeder/quip-mcp](https://github.com/bug-breeder/quip-mcp) 📇 ☁️ 🍎 🪟 🐧 - A Model Context Protocol (MCP) server providing AI assistants with comprehensive Quip document access and management. Enables document lifecycle management, smart search, comment management, and secure token-based authentication for both Quip.com and enterprise instances.
 - [devroopsaha744/TexMCP](https://github.com/devroopsaha744/TexMCP) 🐍 🏠 - An MCP server that converts LaTeX into high-quality PDF documents. It provides tools for rendering both raw LaTeX input and customizable templates, producing shareable, production-ready artifacts such as reports, resumes, and research papers.


### PR DESCRIPTION
Adds Archetype, a remote MCP server for AI-powered sales candidate assessment.

- Endpoint: https://archetype.swell.vc/api/mcp
- Auth: Bearer token
- Tools: archetype_prep, archetype_score
- Docs: https://archetype.swell.vc/mcp

Built on a proprietary framework from 10,000+ real sales interviews. Returns scored verdicts with shareable scorecards.