### PR TITLE
Add Vexa - open-source meeting bot API with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [UnMarkdown/mcp-server](https://github.com/UnMarkdown/mcp-server) [glama](https://glama.ai/mcp/servers/@UnMarkdown/mcp-server) 📇 ☁️ - The document publishing layer for AI tools. Convert markdown to formatted documents for Google Docs, Word, Slack, OneNote, Email, and Plain Text with 62 templates.
 - [vakharwalad23/google-mcp](https://github.com/vakharwalad23/google-mcp) 📇 ☁️ - Collection of Google-native tools (Gmail, Calendar, Drive, Tasks) for MCP with OAuth management, automated token refresh, and auto re-authentication capabilities.
 - [vasylenko/claude-desktop-extension-bear-notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) 📇 🏠 🍎 - Search, read, create, and update Bear Notes directly from Claude. Local-only with complete privacy.
+- [Vexa-ai/vexa](https://github.com/Vexa-ai/vexa) 📇 ☁️ 🏠 - Open-source meeting bot API with native MCP server. Search and query meeting transcripts, get summaries, and access conversation history from Google Meet, Zoom, and Teams directly in Claude Desktop or Cursor.
 - [wyattjoh/calendar-mcp](https://github.com/wyattjoh/calendar-mcp) 📇 🏠 🍎 - MCP server for accessing macOS Calendar events
 - [yuvalsuede/claudia](https://github.com/yuvalsuede/claudia) 📇 🏠 🍎 🪟 🐧 - AI-native task management system for Claude agents. Hierarchical tasks, dependencies, sprints, acceptance criteria, multi-agent coordination, and MCP server integration.
 


### PR DESCRIPTION
## What is Vexa?

[Vexa](https://github.com/Vexa-ai/vexa) is an open-source (Apache 2.0) meeting bot API with a native MCP server. It lets AI agents search and query meeting transcripts, get summaries, and access conversation history.

## Details

- **Category**: Workplace & Productivity
- **Language**: TypeScript (📇)
- **Hosting**: Cloud (☁️) and Self-hosted (🏠)
- **Platforms**: Google Meet, Zoom, Microsoft Teams
- **npm**: `@anthropic-ai/vexa-mcp`
- **Cloud API**: `https://api.cloud.vexa.ai/mcp`
- **Docs**: https://docs.vexa.ai
- **GitHub Stars**: 1.7K+
- **License**: Apache 2.0