### PR TITLE
Add mcp-await to Command Line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 Run commands, capture output and otherwise interact with shells and command line tools.
 
 - [danmartuszewski/hop](https://github.com/danmartuszewski/hop) 🏎️ 🖥️ - Fast SSH connection manager with TUI dashboard and MCP server for discovering, searching, and executing commands on remote hosts.
+- [ricardo-hdrn/mcp-await](https://github.com/ricardo-hdrn/mcp-await) 🦀 🏠 - Condition watcher for AI CLI assistants — block until a port opens, a file changes, a URL responds, a process exits, and more. Replaces sleep loops and polling scripts with a single MCP tool call.
 
 ### 💬 <a name="communication"></a>Communication
 


### PR DESCRIPTION
**[mcp-await](https://github.com/ricardo-hdrn/mcp-await)** — Condition watcher MCP server + CLI for AI CLI assistants.

8 tools that block (or run in background) until a condition is met: TCP port open, file event, HTTP status, process exit, Docker container exit, GitHub Actions run completion, or arbitrary shell command succeeding.

- **Language**: Rust
- **Scope**: Local
- **Category**: Command Line
- **License**: MIT
- **Published on**: [crates.io](https://crates.io/crates/mcp-await), [GitHub Releases](https://github.com/ricardo-hdrn/mcp-await/releases)
- **Glama**: https://glama.ai/mcp/servers/ricardo-hdrn/mcp-await