### PR TITLE
Add postgres-scout-mcp to Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [amineelkouhen/mcp-cockroachdb](https://github.com/amineelkouhen/mcp-cockroachdb) 🐍 ☁️ - A Model Context Protocol server for managing, monitoring, and querying data in [CockroachDB](https://cockroachlabs.com).
 - [benborla29/mcp-server-mysql](https://github.com/benborla/mcp-server-mysql) ☁️ 🏠 - MySQL database integration in NodeJS with configurable access controls and schema inspection
 - [bram2w/baserow](https://github.com/bram2w/baserow) - Baserow database integration with table search, list, and row create, read, update, and delete capabilities.
+- [bluwork/postgres-scout-mcp](https://github.com/bluwork/postgres-scout-mcp) 📇 🏠 - Scout your PostgreSQL databases safely with AI — schema inspection, query execution, and health checks.
 - [c4pt0r/mcp-server-tidb](https://github.com/c4pt0r/mcp-server-tidb) 🐍 ☁️ - TiDB database integration with schema inspection and query capabilities
 - [Canner/wren-engine](https://github.com/Canner/wren-engine) 🐍 🦀 🏠 - The Semantic Engine for Model Context Protocol(MCP) Clients and AI Agents
 - [centralmind/gateway](https://github.com/centralmind/gateway) 🏎️ 🏠 🍎 🪟 - MCP and MCP SSE Server that automatically generate API based on database schema and data. Supports PostgreSQL, Clickhouse, MySQL, Snowflake, BigQuery, Supabase


### PR DESCRIPTION
Adds [postgres-scout-mcp](https://github.com/bluwork/postgres-scout-mcp) to the Databases section.

**postgres-scout-mcp** is a TypeScript MCP server for scouting PostgreSQL databases safely with AI — schema inspection, query execution, and health checks.

- npm: [postgres-scout-mcp](https://www.npmjs.com/package/postgres-scout-mcp)
- License: Apache-2.0