### PR TITLE
Add Node API — GIS processing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome MCP Servers [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+ƒ# Awesome MCP Servers [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 [![ไทย](https://img.shields.io/badge/Thai-Click-blue)](README-th.md)
 [![English](https://img.shields.io/badge/English-Click-yellow)](README.md)
@@ -1178,6 +1178,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [mahdin75/gis-mcp](https://github.com/mahdin75/gis-mcp) 🏠 – A Model Context Protocol (MCP) server implementation that connects Large Language Models (LLMs) to GIS operations using GIS libraries, enabling AI assistants to perform accurate geospatial operations and transformations.
 - [matbel91765/gis-mcp-server](https://github.com/matbel91765/gis-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Geospatial tools for AI agents: geocoding, routing, elevation, spatial analysis, and file I/O (Shapefile, GeoJSON, GeoPackage)
 - [modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/google-maps) 📇 ☁️ - Google Maps integration for location services, routing, and place details
+- [Node API](https://github.com/eianray/node-api) 🐍 ☁️ - Machine-native GIS processing for AI agents. Convert, reproject, validate, clip, buffer, dissolve, and tile vector geodata. Pay-per-op USDC on Solana ($0.01). Remote SSE MCP at nodeapi.ai/mcp/sse.
 - [QGIS MCP](https://github.com/jjsantos01/qgis_mcp) - connects QGIS Desktop to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - [rossshannon/Weekly-Weather-mcp](https://github.com/rossshannon/weekly-weather-mcp.git) 🐍 ☁️ - Weekly Weather MCP server which returns 7 full days of detailed weather forecasts anywhere in the world.
 - [SaintDoresh/Weather-MCP-ClaudeDesktop](https://github.com/SaintDoresh/Weather-MCP-ClaudeDesktop.git) 🐍 ☁️ - An MCP tool that provides real-time weather data, forecasts, and historical weather information using the OpenWeatherMap API.


### PR DESCRIPTION
Adds Node API to the Location Services section.

Node API is a machine-native GIS processing API for AI agents. It supports converting, reprojecting, validating, repairing, clipping, buffering, dissolving, and tiling vector geodata across 25 endpoints. Pay-per-use USDC on Solana Mainnet ($0.01/op). No accounts, no API keys. Remote MCP SSE available at nodeapi.ai/mcp/sse.

GitHub: https://github.com/eianray/node-api