### PR TITLE
Add JobGPT MCP Server to Workplace & Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🏢 <a name="workplace-and-productivity"></a>Workplace & Productivity
 
+- [6figr-com/jobgpt-mcp-server](https://github.com/6figr-com/jobgpt-mcp-server) [glama](https://glama.ai/mcp/servers/@6figr-com/job-gpt-mcp-server) 📇 ☁️ 🏠 🍎 🪟 🐧 - MCP server for [JobGPT](https://6figr.com/jobgpt) — search jobs, auto-apply, generate tailored resumes, track applications, and find recruiters from any MCP client. 34 tools for job search, applications, resumes, and outreach.
 - [bivex/kanboard-mcp](https://github.com/bivex/kanboard-mcp) 🏎️ ☁️ 🏠 - A Model Context Protocol (MCP) server written in Go that empowers AI agents and Large Language Models (LLMs) to seamlessly interact with Kanboard. It transforms natural language commands into Kanboard API calls, enabling intelligent automation of project, task, and user management, streamlining workflows, and enhancing productivity.
 - [bug-breeder/quip-mcp](https://github.com/bug-breeder/quip-mcp) 📇 ☁️ 🍎 🪟 🐧 - A Model Context Protocol (MCP) server providing AI assistants with comprehensive Quip document access and management. Enables document lifecycle management, smart search, comment management, and secure token-based authentication for both Quip.com and enterprise instances.
 - [dearlordylord/huly-mcp](https://github.com/dearlordylord/huly-mcp) [glama](https://glama.ai/mcp/servers/@dearlordylord/huly-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - MCP server for Huly project management. Query issues, create and update tasks, manage labels and priorities.


### PR DESCRIPTION
Adds [JobGPT MCP Server](https://github.com/6figr-com/jobgpt-mcp-server) to the **Workplace & Productivity** section.

**Glama listing:** https://glama.ai/mcp/servers/@6figr-com/job-gpt-mcp-server

## About

JobGPT is an MCP server for AI-powered job search and application management with 34 tools covering:

- **Job Search** - search with filters (title, location, salary, remote, H1B), match jobs from saved hunts
- **Auto-Apply** - automatically apply to matching jobs with configurable daily limits and match scores
- **Resume Management** - upload, generate AI-tailored resumes, calculate match scores
- **Applications** - track status, import jobs by URL (LinkedIn, Greenhouse, Lever, Workday)
- **Outreach** - find recruiters/referrers, send outreach emails

Supports both remote HTTP transport and local stdio via npx.

- npm: [jobgpt-mcp-server](https://www.npmjs.com/package/jobgpt-mcp-server)
- Website: [6figr.com/jobgpt](https://6figr.com/jobgpt)