### PR TITLE
Add appnova-app-store-connect-mcp to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [yWorks/mcp-typescribe](https://github.com/yWorks/mcp-typescribe) 📇 🏠 - MCP server that provides Typescript API information efficiently to the agent to enable it to work with untrained APIs
 - [zaizaizhao/mcp-swagger-server](https://github.com/zaizaizhao/mcp-swagger-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server that converts OpenAPI/Swagger specifications to MCP format, enabling AI assistants to interact with REST APIs through standardized protocol.
 - [zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp) 📇 🏠 - An MCP server to flexibly fetch JSON, text, and HTML data
+- [alperduzgun/appnova-app-store-connect-mcp](https://github.com/alperduzgun/appnova-app-store-connect-mcp) 🐍 ☁️ 🍎 - App Store Connect MCP server with 48 tools for iOS app management, ASO metadata editing, reviews, subscriptions, TestFlight, finance reports, and bundle ID capability management.
 - [zelentsov-dev/asc-mcp](https://github.com/zelentsov-dev/asc-mcp) 🏠 🍎 - App Store Connect API server with 208 tools for managing apps, builds, TestFlight, subscriptions, reviews, and more — directly from any MCP client.
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing


### PR DESCRIPTION
## New MCP Server

**[appnova-app-store-connect-mcp](https://github.com/alperduzgun/appnova-app-store-connect-mcp)**

App Store Connect MCP server with 48 tools across 14 categories:

- **ASO** — read/update metadata, keywords, descriptions across all locales
- **Reviews** — fetch, filter by rating, post/edit/delete developer responses
- **Analytics & Sales** — daily breakdowns up to 365 days
- **Finance** — monthly proceeds by territory and currency
- **Subscriptions & IAPs** — create, price, localize
- **TestFlight** — builds, beta groups, tester management
- **Phased Release** — create, pause, complete rollout
- **Bundle ID Capabilities** — list, enable, disable (Sign in with Apple, Push, etc.)
- **App Versions** — create, submit for review, cancel submission

Built with Python + FastMCP. MIT license.