### PR TITLE
Add Arcadia Finance MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.
-- [arcadia-finance/mcp-server](https://github.com/arcadia-finance/mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Manage Uniswap and Aerodrome liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Unichain.
+- [arcadia-finance/mcp-server](https://github.com/arcadia-finance/mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Manage Uniswap and Aerodrome liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Unichain. [![arcadia-finance/mcp-server MCP server](https://glama.ai/mcp/servers/arcadia-finance/mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/arcadia-finance/mcp-server)
 - [anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server) 🐍 ☁️ - Coinmarket API integration to fetch cryptocurrency listings and quotes
 - [araa47/jupiter-mcp](https://github.com/araa47/jupiter-mcp) 🐍 ☁️ - Jupiter API Access (allow AI to Trade Tokens on Solana + Access Balances + Search Tokens + Create Limit Orders )
 - [ariadng/metatrader-mcp-server](https://github.com/ariadng/metatrader-mcp-server) 🐍 🏠 🪟 - Enable AI LLMs to execute trades using MetaTrader 5 platform


### PR DESCRIPTION
Adds Arcadia Finance MCP Server — a DeFi MCP server for managing Uniswap and Aerodrome liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Unichain.

- npm: @arcadia-finance/mcp-server
- GitHub: https://github.com/arcadia-finance/mcp-server
- 26 tools (read, write, advanced)