### PR TITLE
Add Agent Reach ( 6k star ) to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
+- [Agent Reach](https://github.com/Panniantong/Agent-Reach) 🐍 🏠 🍎 🪟 🐧 - One-command installer that gives AI agents access to 13+ platforms (Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, Douyin, WeChat, LinkedIn, RSS, and more). Auto-installs and configures upstream tools including MCP servers via mcporter.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace
 - [ariekogan/ateam-mcp](https://github.com/ariekogan/ateam-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Build, validate, and deploy multi-agent AI solutions on the ADAS platform. Design skills with tools, manage solution lifecycle, and connect from any AI environment via stdio or HTTP.


### PR DESCRIPTION
[Agent Reach](https://github.com/Panniantong/Agent-Reach) is a one-command installer that gives AI agents access to 13+ internet platforms — Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, Douyin, WeChat, LinkedIn, RSS, and more.

It auto-installs and configures upstream tools including MCP servers (Exa, XiaoHongShu, Douyin, LinkedIn, Boss直聘) via mcporter. After setup, agents call the upstream tools directly — no wrapper layer.

- Python CLI, MIT License
- Works on macOS / Windows / Linux
- Compatible with Claude Code, Cursor, OpenClaw, Windsurf, Codex