### PR TITLE
Add DevSecure MCP — 67 DeFi security intelligence tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [AUTHENSOR/defi-shield](https://github.com/AUTHENSOR/defi-shield) 📇 ☁️ - 67 DeFi security intelligence tools for AI agents — contract risk scoring, wallet profiling, MEV analysis, protocol risk, NFT wash trading detection, and real-time monitoring. Pay-per-use via x402 (USDC on Base). npm: `devsecure-mcp`
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
Adds [AUTHENSOR/defi-shield](https://github.com/AUTHENSOR/defi-shield) to the **Finance & Fintech** category.

**What it is:** An MCP server with 67 security intelligence tools across 11 categories, built for autonomous AI agents operating in DeFi.

**Categories:** DeFi Intelligence, Safety & Compliance, Developer Security, Wallet Intelligence, MEV Protection, Cross-Chain Analysis, Protocol Governance, NFT Security, Stablecoin Monitoring, Insurance & Risk, Threat Intelligence.

**Key capabilities:** Contract risk scoring, honeypot detection, wallet profiling, MEV sandwich detection, bridge risk assessment, NFT wash trading detection, real-time exploit feeds.

**npm:** [`devsecure-mcp`](https://www.npmjs.com/package/devsecure-mcp)
**Production API:** https://defi-shield-hazel.vercel.app
**Payment:** x402 micropayments (USDC on Base) — no API keys or accounts needed.