### PR TITLE
Add Agent Cards - Virtual Visa cards for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
-- [agent-cards/mcp](https://github.com/agent-cards/mcp) 📇 ☁️ - Give your AI agent a debit card. Create and manage prepaid virtual Visa cards with fixed budgets — agents can create cards, make payments, check balances, and handle 402 Payment Required responses automatically.
+- [agent-cards/mcp](https://github.com/agent-cards/mcp) [![agent-cards/mcp MCP server](https://glama.ai/mcp/servers/agent-cards/mcp/badges/score.svg)](https://glama.ai/mcp/servers/agent-cards/mcp) 📇 ☁️ - Give your AI agent a debit card. Create and manage prepaid virtual Visa cards with fixed budgets — agents can create cards, make payments, check balances, and handle 402 Payment Required responses automatically.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.

--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
+- [agent-cards/mcp](https://github.com/agent-cards/mcp) 📇 ☁️ - Give your AI agent a debit card. Create and manage prepaid virtual Visa cards with fixed budgets — agents can create cards, make payments, check balances, and handle 402 Payment Required responses automatically.
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.


### PR DESCRIPTION
## Summary
- Adds [Agent Cards](https://github.com/agent-cards/mcp) to the **Finance & Fintech** category
- Prepaid virtual Visa cards for AI agents — create cards with fixed budgets, make payments, check balances, and handle 402 Payment Required responses automatically
- Tools: `list_cards`, `create_card`, `get_card_details`, `check_balance`, `close_card`, `x402_fetch`
- Transport: HTTP + stdio
- Install: `npx agent-cards setup-mcp`