### PR TITLE
Add NeedHuman MCP — Human-as-a-Service for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,7 +1682,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [louiscklaw/hko-mcp](https://github.com/louiscklaw/hko-mcp) 📇 🏠 - MCP server with basic demonstration of getting weather from Hong Kong Observatory
 - [magarcia/mcp-server-giphy](https://github.com/magarcia/mcp-server-giphy) 📇 ☁️ - Search and retrieve GIFs from Giphy's vast library through the Giphy API.
 - [marcelmarais/Spotify](https://github.com/marcelmarais/spotify-mcp-server) - 📇 🏠 Control Spotify playback and manage playlists.
-- [MariusAure/needhuman-mcp](https://github.com/MariusAure/needhuman-mcp) 📇 ☁️ - Human-as-a-Service for AI agents — submit tasks (accept ToS, create accounts, verify identity) to a real human when the agent gets stuck.
+- [MariusAure/needhuman-mcp](https://github.com/MariusAure/needhuman-mcp) [glama](https://glama.ai/mcp/servers/@MariusAure/need-human) 📇 ☁️ - Human-as-a-Service for AI agents — submit tasks (accept ToS, create accounts, verify identity) to a real human when the agent gets stuck.
 - [MarkusPfundstein/mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) 🐍 ☁️ 🏠 - Interacting with Obsidian via REST API
 - [mediar-ai/screenpipe](https://github.com/mediar-ai/screenpipe) - 🎖️ 🦀 🏠 🍎 Local-first system capturing screen/audio with timestamped indexing, SQL/embedding storage, semantic search, LLM-powered history analysis, and event-triggered actions - enables building context-aware AI agents through a NextJS plugin ecosystem.
 - [metorial/metorial](https://github.com/metorial/metorial) - 🎖️ 📇 ☁️ Connect AI agents to 600+ integrations with a single interface - OAuth, scaling, and monitoring included


### PR DESCRIPTION
Adds [NeedHuman MCP](https://github.com/MariusAure/needhuman-mcp) to the **Other Tools and Integrations** section.

- **npm:** `@needhuman/mcp-server`
- **License:** MIT
- **Tools:** `need_human`, `check_task_status`, `list_tasks`

When an AI agent hits a step only a human can do (accept ToS, create accounts, verify identity), it calls NeedHuman and a real human completes the task.