### PR TITLE
feat: add microsoft/mcp official servers catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [alexei-led/k8s-mcp-server](https://github.com/alexei-led/k8s-mcp-server) 🐍 - A lightweight yet robust server that empowers AI assistants to securely execute Kubernetes CLI commands (`kubectl`, `helm`, `istioctl`, and `argocd`) using Unix pipes in a safe Docker environment with multi-architecture support.
 - [aliyun/alibaba-cloud-ops-mcp-server](https://github.com/aliyun/alibaba-cloud-ops-mcp-server) 🎖️ 🐍 ☁️ - A MCP server that enables AI assistants to operation resources on Alibaba Cloud, supporting ECS, Cloud Monitor, OOS and widely used cloud products.
 - [awslabs/mcp](https://github.com/awslabs/mcp) 🎖️ ☁️ - AWS MCP servers for seamless integration with AWS services and resources.
+- [microsoft/mcp](https://github.com/microsoft/mcp) 🎖️ 📇 ☁️ - Official Microsoft MCP servers catalog with 30+ server implementations for Azure, GitHub, Teams, Bing Search, and more.
 - [bright8192/esxi-mcp-server](https://github.com/bright8192/esxi-mcp-server) 🐍 ☁️ - A VMware ESXi/vCenter management server based on MCP (Model Control Protocol), providing simple REST API interfaces for virtual machine management.
 - [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) 🎖️ 📇 ☁️ - Integration with Cloudflare services including Workers, KV, R2, and D1
 - [cyclops-ui/mcp-cyclops](https://github.com/cyclops-ui/mcp-cyclops) 🎖️ 🏎️ ☁️ - An MCP server that allows AI agents to manage Kubernetes resources through Cyclops abstraction


### PR DESCRIPTION
Adds the official Microsoft MCP servers catalog (microsoft/mcp) which contains 30+ server implementations for Azure, GitHub, Teams, Bing Search, and more cloud services.

This is an official Microsoft repository and complements the existing microsoft/playwright-mcp entry.