### PR TITLE
Add parapilot — headless CAE post-processing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [HumanSignal/label-studio-mcp-server](https://github.com/HumanSignal/label-studio-mcp-server) 🎖️ 🐍 ☁️ 🪟 🐧 🍎 - Create, manage, and automate Label Studio projects, tasks, and predictions for data labeling workflows.
 - [jjsantos01/jupyter-notebook-mcp](https://github.com/jjsantos01/jupyter-notebook-mcp) 🐍 🏠 - connects Jupyter Notebook to Claude AI, allowing Claude to directly interact with and control Jupyter Notebooks.
 - [kdqed/zaturn](https://github.com/kdqed/zaturn) 🐍 🏠 🪟 🐧 🍎 - Link multiple data sources (SQL, CSV, Parquet, etc.) and ask AI to analyze the data for insights and visualizations.
+- [kimimgo/parapilot](https://github.com/kimimgo/parapilot) 🐍 🏠 🍎 🪟 🐧 - Headless CAE post-processing for CFD/FEA simulations. 18 tools for rendering, slicing, contouring, and animating OpenFOAM/VTK/CGNS data via VTK — no ParaView GUI needed.
 - [mckinsey/vizro-mcp](https://github.com/mckinsey/vizro/tree/main/vizro-mcp) 🎖️ 🐍 🏠 - Tools and templates to create validated and maintainable data charts and dashboards.
 - [optuna/optuna-mcp](https://github.com/optuna/optuna-mcp) 🎖️ 🐍 🏠 🐧 🍎 - Official MCP server enabling seamless orchestration of hyperparameter search and other optimization tasks with [Optuna](https://optuna.org/).
 - [phisanti/MCPR](https://github.com/phisanti/MCPR) 🏠 🍎 🪟 🐧 - Model Context Protocol for R: enables AI agents to participate in interactive live R sessions.


### PR DESCRIPTION
Superseded by new PR with updated project name (parapilot → viznoir).