### PR TITLE
Add Chessmata MCP server to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ Integration with gaming related data, game engines, and services
 - [hkaanengin/opendota-mcp-server](https://github.com/hkaanengin/opendota-mcp-server) 🐍 🏠 ☁️ - MCP server providing AI assistants with access to Dota 2 statistics via OpenDota API. 20+ tools for player stats, hero data, and match    analysis with natural language support.
 - [IvanMurzak/Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) #️⃣ 🏠 🍎 🪟 🐧 - MCP Server for Unity Editor and for a game made with Unity
 - [jiayao/mcp-chess](https://github.com/jiayao/mcp-chess) 🐍 🏠 - A MCP server playing chess against LLMs.
+- [jonradoff/chessmata](https://github.com/jonradoff/chessmata) 🏎️ ☁️ - MCP server for Chessmata, an open-source multiplayer chess platform for humans and AI agents. 25+ tools for authentication, matchmaking, real-time gameplay, and leaderboard queries.
 - [kkjdaniel/bgg-mcp](https://github.com/kkjdaniel/bgg-mcp) 🏎️ ☁️ - An MCP server that enables interaction with board game related data via the BoardGameGeek API (XML API2).
 - [opgginc/opgg-mcp](https://github.com/opgginc/opgg-mcp) 📇 ☁️ - Access real-time gaming data across popular titles like League of Legends, TFT, and Valorant, offering champion analytics, esports schedules, meta compositions, and character statistics.
 - [pab1ito/chess-mcp](https://github.com/pab1it0/chess-mcp) 🐍 ☁️ - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.


### PR DESCRIPTION
## Summary

Adds [jonradoff/chessmata](https://github.com/jonradoff/chessmata) to the Gaming section.

Chessmata is an open-source multiplayer chess platform with a built-in MCP server exposing 25+ tools for AI agents to:
- Authenticate with API keys
- Find opponents and enter matchmaking (human-only, agent-only, or mixed)
- Play games in real-time (make moves, resign, draw offers)
- Query the leaderboard and game history

This is distinct from the other chess MCP servers in the list (mcp-chess plays against LLMs locally, chess-mcp reads Chess.com data, mcp-stockfish wraps Stockfish engine). Chessmata is a full online multiplayer platform where AI agents can play against each other or humans in ranked/casual games.

Live: https://chessmata.metavert.io | Source: https://github.com/jonradoff/chessmata