### PR TITLE
Add Kiln — 3D printer fleet management MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [khglynn/spotify-bulk-actions-mcp](https://github.com/khglynn/spotify-bulk-actions-mcp) 🐍 ☁️ - Bulk Spotify operations with confidence-scored song matching, batch playlist creation from CSV/podcast lists, and library exports for discovering your most-saved artists and albums.
 - [mikechao/metmuseum-mcp](https://github.com/mikechao/metmuseum-mcp) 📇 ☁️ - Metropolitan Museum of Art Collection API integration to search and display artworks in the collection.
 - [molanojustin/smithsonian-mcp](https://github.com/molanojustin/smithsonian-mcp) 🐍 ☁️ - MCP server that provides AI assistants with access to the Smithsonian Institution's Open Access collections.
+- [codeofaxel/Kiln](https://github.com/codeofaxel/Kiln) 🐍 🏠 🍎 🪟 🐧 - Open-source 3D printer fleet management with 345 MCP tools for OctoPrint, Moonraker/Klipper, Bambu Lab, Prusa Link, and Elegoo. Search model marketplaces, slice STLs, queue prints, monitor safety, and manage multi-printer fleets.
 - [OctoEverywhere/mcp](https://github.com/OctoEverywhere/mcp) #️⃣ ☁️ - A 3D printer MCP server that allows for getting live printer state, webcam snapshots, and printer control.
 - [omni-mcp/isaac-sim-mcp](https://github.com/omni-mcp/isaac-sim-mcp) 📇 ☁️ - A MCP Server and an extension enables natural language control of NVIDIA Isaac Sim, Lab, OpenUSD and etc.
 - [PatrickPalmer/MayaMCP](https://github.com/PatrickPalmer/MayaMCP) 🐍 🏠 - MCP server for Autodesk Maya


### PR DESCRIPTION
Adds [Kiln](https://github.com/codeofaxel/Kiln) to the Art & Culture section (alongside OctoEverywhere, the existing 3D printing entry).

Kiln is an open-source MCP server with 345 tools for controlling 3D printers (OctoPrint, Moonraker/Klipper, Bambu Lab, Prusa Link, Elegoo). It handles the full workflow: search model marketplaces, slice STLs, queue prints, monitor safety, and manage multi-printer fleets.

- Python, local service, cross-platform (macOS/Windows/Linux)
- MIT licensed
- Published on PyPI as `kiln3d` and on the official MCP Registry