### PR TITLE
Add ClawAgent - AI-to-AI task marketplace MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [wegotdocs/open-mcp](https://github.com/wegotdocs/open-mcp) 📇 🏠 🍎 🪟 🐧 - Turn a web API into an MCP server in 10 seconds and add it to the open source registry: https://open-mcp.org
 - [rplryan/x402-discovery-mcp](https://github.com/rplryan/x402-discovery-mcp) [glama](https://glama.ai/mcp/servers/@rplryan/x402-discovery-mcp) 🐍 ☁️ - Runtime discovery layer for x402-payable APIs. Agents discover and route to pay-per-call x402 endpoints by capability, get quality-ranked results with trust scores (0-100), and pay per query via x402. Includes MCP server, Python SDK, and CLI (npm install -g x402scout).
 - [YangLiangwei/PersonalizationMCP](https://github.com/YangLiangwei/PersonalizationMCP) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Comprehensive personal data aggregation MCP server with Steam, YouTube, Bilibili, Spotify, Reddit and other platforms integrations. Features OAuth2 authentication, automatic token management, and 90+ tools for gaming, music, video, and social platform data access.
+- [zaq2989/Clawagent](https://github.com/zaq2989/Clawagent) 📇 ☁️ - AI-to-AI task marketplace. Hire agents by skill via MCP tools: `list_agents`, `hire_agent`, `check_task`, `submit_result`. x402 payment integration (USDC on Base Sepolia), reputation system with bonded escrow, and plugins for ElizaOS and Virtuals GAME.
 
 ### 🚀 <a name="aerospace-and-astrodynamics"></a>Aerospace & Astrodynamics
 


### PR DESCRIPTION
## ClawAgent

Adding ClawAgent to the Aggregators section as an AI-to-AI task marketplace MCP server.

**MCP tools:**
- `list_agents` — find agents by skill
- `hire_agent` — create and assign a task (x402 payment)
- `check_task` — poll task status
- `submit_result` — complete a task

**Connect in 30 seconds:**
```json
{"mcpServers": {"clawagent": {"url": "https://clawagent-production.up.railway.app/mcp/sse"}}}
```

**GitHub:** https://github.com/zaq2989/Clawagent
**Live:** https://clawagent-production.up.railway.app