### PR TITLE
Add webmcp-sdk - W3C WebMCP toolkit for Chrome 146

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,6 +1682,7 @@ Interact with Git repositories and version control platforms. Enables repository
 > [!NOTE]
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 
+- [webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) 📇 - Developer toolkit for W3C WebMCP (Chrome 146). Make any website agent-ready with navigator.modelContext support.
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript

--- a/README.md
+++ b/README.md
@@ -1682,7 +1682,7 @@ Interact with Git repositories and version control platforms. Enables repository
 > [!NOTE]
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 
-- [webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) 📇 - Developer toolkit for W3C WebMCP (Chrome 146). Make any website agent-ready with navigator.modelContext support.
+- [up2itnow0822/webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) 📇 - Developer toolkit for W3C WebMCP (Chrome 146). Make any website agent-ready with navigator.modelContext support.
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript

--- a/README.md
+++ b/README.md
@@ -1682,7 +1682,7 @@ Interact with Git repositories and version control platforms. Enables repository
 > [!NOTE]
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 
-- [up2itnow0822/webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) 📇 - Developer toolkit for W3C WebMCP (Chrome 146). Make any website agent-ready with navigator.modelContext support.
+- [up2itnow0822/webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) [![up2itnow0822/webmcp-sdk MCP server](https://glama.ai/mcp/servers/up2itnow0822/claw-pay-mcp/badges/score.svg)](https://glama.ai/mcp/servers/up2itnow0822/claw-pay-mcp) 📇 - Developer toolkit for W3C WebMCP (Chrome 146). Make any website agent-ready with navigator.modelContext support.
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript


### PR DESCRIPTION
Adding `webmcp-sdk` to the Frameworks section.

**webmcp-sdk** is the developer toolkit for the W3C WebMCP standard landing in Chrome 146. It lets you:
- Expose website tools to AI agents via `navigator.modelContext`
- Mount a `/.well-known/mcp` endpoint with structured tool definitions
- Consume WebMCP endpoints from agent code

[GitHub](https://github.com/up2itnow0822/webmcp-sdk) | [npm](https://www.npmjs.com/package/webmcp-sdk) | TypeScript | MIT