### PR TITLE
Add OpenClaw Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,6 +1241,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
 - [pminervini/deep-research-mcp](https://github.com/pminervini/deep-research-mcp) 🐍 ☁️ 🏠 - Deep research MCP server for OpenAI Responses API or Open Deep Research (smolagents), with web search and code interpreter support.
 - [thinkchainai/agentinterviews_mcp](https://github.com/thinkchainai/agentinterviews_mcp) - Conduct AI-powered qualitative research interviews and surveys at scale with [Agent Interviews](https://agentinterviews.com). Create interviewers, manage research projects, recruit participants, and analyze interview data through MCP.
+- [yedanyagamiai-cmd/openclaw-mcp-servers](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers#openclaw-intel) 📇 ☁️ - OpenClaw Intel MCP: AI market intelligence and competitive analysis with feature comparison and pricing data.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 


### PR DESCRIPTION
## Summary
- Adding OpenClaw Intel MCP to the awesome-mcp-servers list
- Hosted on Cloudflare Workers with Streamable HTTP transport
- Free tier available, no API key required

## Server Details
- **URL**: https://openclaw-intel-mcp.yagami8095.workers.dev/mcp
- **Tools**: 6 tools (market analysis, competitor comparison, pricing intel, trend tracking, feature matrix, ecosystem map)
- **Transport**: Streamable HTTP (MCP 2025-03-26)
- **Source**: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers

## Quick Connect
```json
{
  "mcpServers": {
    "openclaw-intel": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://openclaw-intel-mcp.yagami8095.workers.dev/mcp"]
    }
  }
}
```