### PR TITLE
Add MoltBook Publisher MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,6 +1432,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 - [MarceauSolutions/fitness-influencer-mcp](https://github.com/MarceauSolutions/fitness-influencer-mcp) 🐍 🏠 ☁️ - Fitness content creator workflow automation - video editing with jump cuts, revenue analytics, and branded content creation
 - [scrape-badger/scrapebadger-mcp](https://github.com/scrape-badger/scrapebadger-mcp) 🐍 ☁️ - Access Twitter/X data including user profiles, tweets, followers, trends, lists, and communities via the ScrapeBadger API.
 - [sinanefeozler/reddit-summarizer-mcp](https://github.com/sinanefeozler/reddit-summarizer-mcp) 🐍 🏠 ☁️ - MCP server for summarizing users's Reddit homepage or any subreddit based on posts and comments.
+- [yedanyagamiai-cmd/openclaw-mcp-servers](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers#moltbook-publisher) 📇 ☁️ - MoltBook Publisher MCP: Content publishing and engagement tools for the MoltBook AI social platform.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
## Summary
- Adding MoltBook Publisher MCP to the awesome-mcp-servers list
- Hosted on Cloudflare Workers with Streamable HTTP transport
- Free tier available, no API key required

## Server Details
- **URL**: https://moltbook-publisher-mcp.yagami8095.workers.dev/mcp
- **Tools**: 8 tools (create post, markdown to HTML, SEO optimize, content schedule, engagement analytics, tag suggest, cross-post, archive)
- **Transport**: Streamable HTTP (MCP 2025-03-26)
- **Source**: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers

## Quick Connect
```json
{
  "mcpServers": {
    "moltbook-publisher": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://moltbook-publisher-mcp.yagami8095.workers.dev/mcp"]
    }
  }
}
```