### PR TITLE
Add AgentForge Compare MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [xzq.xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server) 📇 🏠  - An implementation project of a JVM-based MCP (Model Context Protocol) server.
 - [yangkyeongmo@/mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow) 🐍 🏠 - MCP server that connects to [Apache Airflow](https://airflow.apache.org/) using official client.
 - [yanmxa/scriptflow-mcp](https://github.com/yanmxa/scriptflow-mcp) 📇 🏠 - A script workflow management system that transforms complex, repetitive AI interactions into persistent, executable scripts. Supports multi-language execution (Bash, Python, Node.js, TypeScript) with guaranteed consistency and reduced hallucination risks.
+- [yedanyagamiai-cmd/openclaw-mcp-servers](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers#agentforge-compare) 📇 ☁️ - AgentForge Compare MCP: AI coding tool comparison engine with feature, pricing, and capability analysis.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
 - [yiwenlu66/PiloTY](https://github.com/yiwenlu66/PiloTY) 🐍 🏠 - AI pilot for PTY operations enabling agents to control interactive terminals with stateful sessions, SSH connections, and background process management
 - [YuChenSSR/mindmap-mcp-server](https://github.com/YuChenSSR/mindmap-mcp-server) 🐍 🏠 - A Model Context Protocol (MCP) server for generating a beautiful interactive mindmap.


### PR DESCRIPTION
## Summary
- Adding AgentForge Compare MCP to the awesome-mcp-servers list
- Hosted on Cloudflare Workers with Streamable HTTP transport
- Free tier available, no API key required

## Server Details
- **URL**: https://agentforge-compare-mcp.yagami8095.workers.dev/mcp
- **Tools**: 5 tools (compare tools, feature matrix, pricing analysis, recommendation engine, trend report)
- **Transport**: Streamable HTTP (MCP 2025-03-26)
- **Source**: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers

## Quick Connect
```json
{
  "mcpServers": {
    "agentforge-compare": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://agentforge-compare-mcp.yagami8095.workers.dev/mcp"]
    }
  }
}
```