### PR TITLE
Add kafka-mcp MCP Server - MCP server for Apache Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [yincongcyincong/VictoriaMetrics-mcp-server](https://github.com/yincongcyincong/VictoriaMetrics-mcp-server) 🐍 🏠 - An MCP server for interacting with VictoriaMetrics database.
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.
 - [zilliztech/mcp-server-milvus](https://github.com/zilliztech/mcp-server-milvus) 🐍 🏠 ☁️ - MCP Server for Milvus / Zilliz, making it possible to interact with your database.
-- [wklee610/kafka-mcp](https://github.com/wklee610/kafka-mcp) 🐍 🏠 ☁️ - MCP server for Apache Kafka that allows LLM agents to inspect topics, consumer groups, and safely manage offsets (reset, rewind).
+- [wklee610/kafka-mcp](https://github.com/wklee610/kafka-mcp)[glama](https://glama.ai/mcp/servers/wklee610/kafka-mcp) 🐍 🏠 ☁️ - MCP server for Apache Kafka that allows LLM agents to inspect topics, consumer groups, and safely manage offsets (reset, rewind).
 
 ### 📊 <a name="data-platforms"></a>Data Platforms
 


### PR DESCRIPTION
Add [kafka-mcp](https://github.com/wklee610/kafka-mcp).

kafka-mcp is MCP server for Apache Kafka that allows LLM agents to inspect topics, consumer groups, and safely manage offsets (reset, rewind).

- github: https://github.com/wklee610/kafka-mcp