### PR TITLE
Add mcp-swiss: Swiss open data MCP server (68 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 - [Osseni94/oyemi-mcp](https://github.com/Osseni94/oyemi-mcp) 🐍 🏠 - Deterministic semantic word encoding and valence/sentiment analysis using 145K+ word lexicon. Provides word-to-code mapping, semantic similarity, synonym/antonym lookup with zero runtime NLP dependencies.
 - [paracetamol951/caisse-enregistreuse-mcp-server](https://github.com/paracetamol951/caisse-enregistreuse-mcp-server) 🏠 🐧 🍎 ☁️ - Allows you to automate or monitor business operations, sales recorder, POS software, CRM.
 - [saikiyusuke/registep-mcp](https://github.com/saikiyusuke/registep-mcp) 📇 ☁️ - AI-powered POS & sales analytics MCP server with 67 tools for Airレジ, スマレジ, and BASE EC integration. Provides store management, sales data querying, AI chat analysis, and weather correlation features.
-- [vikramgorla/mcp-swiss](https://github.com/vikramgorla/mcp-swiss) [glama](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss) 📇 ☁️ - 68 tools for Swiss open data: transport, weather, geodata, companies, parliament, and more. Zero API keys required.
+- [vikramgorla/mcp-swiss](https://github.com/vikramgorla/mcp-swiss) [![https://glama.ai/mcp/servers/vikramgorla/mcp-swiss/badges/score.svg]](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss) 📇 ☁️ - 68 tools for Swiss open data: transport, weather, geodata, companies, parliament, and more. Zero API keys required.
 - [yashshingvi/databricks-genie-MCP](https://github.com/yashshingvi/databricks-genie-MCP) 🐍 ☁️ - A server that connects to the Databricks Genie API, allowing LLMs to ask natural language questions, run SQL queries, and interact with Databricks conversational agents.
 
 


### PR DESCRIPTION
## mcp-swiss

**Repository:** https://github.com/vikramgorla/mcp-swiss
**npm:** https://www.npmjs.com/package/mcp-swiss

### What it does
MCP server providing 68 tools across 20 modules for Swiss public data — transport (SBB/PostBus), weather (MeteoSwiss), hydrology (BAFU), geodata (swisstopo), companies (ZEFIX), parliament, avalanche bulletins, air quality, energy tariffs, and more.

### Key features
- 📇 TypeScript / Node.js
- ☁️ Cloud service (Swiss public APIs)
- Zero API keys required — all data sources are free Swiss government APIs
- Works with Claude Desktop, VS Code, Cursor, Windsurf, Cline, Amazon Q

### Category
Added to **Data Platforms** section (similar to agrobr-mcp for Brazilian data).