### PR TITLE
feat: add 0nMCP — Universal AI API Orchestrator (850 tools, 53 services, $0.10/execution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 Servers for accessing many apps and tools through a single MCP server.
 
+- [0nMCP](https://github.com/0nork/0nMCP) 📇 ☁️ 🍎 🪟 🐧 - Universal AI API Orchestrator with 850 tools across 53 services. $0.10/execution, no subscription. Connect Claude, GPT, or Gemini to Stripe, Slack, GitHub, Cloudflare, and 49+ more via natural language. Patent Pending (USPTO #63/990,046). `npm install 0nmcp`
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 Servers for accessing many apps and tools through a single MCP server.
 
-- [0nMCP](https://github.com/0nork/0nMCP) 📇 ☁️ 🍎 🪟 🐧 - Universal AI API Orchestrator with 850 tools across 53 services. $0.10/execution, no subscription. Connect Claude, GPT, or Gemini to Stripe, Slack, GitHub, Cloudflare, and 49+ more via natural language. Patent Pending (USPTO #63/990,046). `npm install 0nmcp`
+- [0nork/0nMCP](https://github.com/0nork/0nMCP) 📇 ☁️ 🍎 🪟 🐧 - Universal AI API Orchestrator with 850 tools across 53 services. $0.10/execution, no subscription. Connect Claude, GPT, or Gemini to Stripe, Slack, GitHub, Cloudflare, and 49+ more via natural language. Patent Pending (USPTO #63/990,046). `npm install 0nmcp`
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).


### PR DESCRIPTION
## Add 0nMCP to Aggregators

**Tool:** [0nMCP](https://github.com/0nork/0nMCP)
**npm:** `npm install 0nmcp`
**Site:** https://0nmcp.com

### What it is

0nMCP is a Universal AI API Orchestrator that federates 850 tools across 53 services under a single MCP interface. Any MCP-capable AI (Claude, GPT, Gemini) invokes all 850 tools through one server config.

### Why Aggregators

The section description: *"Servers for accessing many apps and tools through a single MCP server"* — exact match. Services: Stripe, Slack, GitHub, LinkedIn, Cloudflare, GoDaddy, Resend, HubSpot, Airtable, Shopify, Twilio, and 42 more.

### Checklist

- [x] Open source (MIT): https://github.com/0nork/0nMCP
- [x] Actively maintained — v2.3.0 released March 2026
- [x] npm published: https://npmjs.com/package/0nmcp
- [x] Entry follows existing format with emoji indicators
- [x] Alphabetically ordered within Aggregators (before [1mcp/agent])

---
*Patent Pending: USPTO #63/990,046 | RocketOpp LLC*