### PR TITLE
Add Xquik X/Twitter data platform to Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 - [macrocosm-os/macrocosmos-mcp](https://github.com/macrocosm-os/macrocosmos-mcp) - 🎖️ 🐍 ☁️ Access real-time X/Reddit/YouTube data directly in your LLM applications  with search phrases, users, and date filtering.
 - [MarceauSolutions/fitness-influencer-mcp](https://github.com/MarceauSolutions/fitness-influencer-mcp) 🐍 🏠 ☁️ - Fitness content creator workflow automation - video editing with jump cuts, revenue analytics, and branded content creation
 - [scrape-badger/scrapebadger-mcp](https://github.com/scrape-badger/scrapebadger-mcp) 🐍 ☁️ - Access Twitter/X data including user profiles, tweets, followers, trends, lists, and communities via the ScrapeBadger API.
+- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) 📇 ☁️ - X/Twitter data platform with 76 REST API endpoints, 20 extraction tools, account monitoring, giveaway draws, and MCP server (v2 sandbox + v1 legacy). AI agent skill for Claude Code, Cursor, Codex, and 40+ agents.
 - [sinanefeozler/reddit-summarizer-mcp](https://github.com/sinanefeozler/reddit-summarizer-mcp) 🐍 🏠 ☁️ - MCP server for summarizing users's Reddit homepage or any subreddit based on posts and comments.
 
 ### 🏃 <a name="sports"></a>Sports


### PR DESCRIPTION
Adds [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the Social Media section.

**What it does:** X/Twitter data platform with MCP server (v2: 2-tool sandbox covering 76 endpoints, v1 legacy: 18 discrete tools), REST API, HMAC webhooks, 20 bulk extraction tools, account monitoring, giveaway draws, and write actions. Available as an AI agent skill for 40+ coding agents.

- **MCP transport:** StreamableHTTP
- **Auth:** API key
- **License:** MIT

Disclosure: I am the developer of Xquik.