### PR TITLE
Add Bortlesboat/bitcoin-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [base/base-mcp](https://github.com/base/base-mcp) 🎖️ 📇 ☁️ - Base Network integration for onchain tools, allowing interaction with Base Network and Coinbase API for wallet management, fund transfers, smart contracts, and DeFi operations
 - [berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp) 🐍 ☁️ - Alpha Vantage API integration to fetch both stock and crypto information
 - [bitteprotocol/mcp](https://github.com/BitteProtocol/mcp) 📇 - Bitte Protocol integration to run AI Agents on several blockchains.
+- [Bortlesboat/bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) 🐍 ☁️ 🏠 - Bitcoin fee intelligence MCP server with 43 tools for AI agents. Fee recommendations, mempool analysis, transaction decoding, and real-time streaming from your own node.
 - [bubilife1202/crossfin](https://github.com/bubilife1202/crossfin) 📇 ☁️ - Korean & global crypto exchange routing, arbitrage signals, and x402 USDC micropayments for AI agents. 16 tools, 9 exchanges, 11 bridge coins.
 - [carsol/monarch-mcp-server](https://github.com/carsol/monarch-mcp-server) 🐍 ☁️ - MCP server providing read-only access to Monarch Money financial data, enabling AI assistants to analyze transactions, budgets, accounts, and cashflow data with MFA support.
 - [chargebee/mcp](https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol) 🎖️ 📇 ☁️ - MCP Server that connects AI agents to [Chargebee platform](https://www.chargebee.com/).


### PR DESCRIPTION
Adds bitcoin-mcp — a Bitcoin fee intelligence MCP server with 43 tools, 6 prompts, and 7 resources for AI agents.

- Fee recommendations that save money on every Bitcoin transaction
- Real-time mempool analysis and congestion scoring  
- Transaction decoding, address validation, mining stats
- Self-hostable on your own Bitcoin Core node
- Published on PyPI: pip install bitcoin-mcp

GitHub: https://github.com/Bortlesboat/bitcoin-mcp
PyPI: https://pypi.org/project/bitcoin-mcp/