### PR TITLE
Add Meridian - Macroeconomic Data MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
-- [NHafnerR/meridian-mcp](https://github.com/NHafnerR/meridian-mcp) 📇 ☁️ - Bloomberg-grade macroeconomic data for AI agents. 55 FRED series with z-scores, percentile ranks, regime classification, and historical comparisons via 3 MCP tools.
+- [NHafnerR/meridian-mcp](https://github.com/NHafnerR/meridian-mcp) [glama](https://glama.ai/mcp/servers/NHafnerR/meridian-mcp) 📇 ☁️ - Bloomberg-grade macroeconomic data for AI agents. 55 FRED series with z-scores, percentile ranks, regime classification, and historical comparisons via 3 MCP tools.
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp) 📇 ☁️ - Deep Research for crypto - free & fully local
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.


### PR DESCRIPTION
## Meridian

Adding [Meridian](https://meridianapi.io) to the Finance & Fintech section.

**What it does:** Provides Bloomberg-grade macroeconomic data to AI agents via MCP. 55 FRED time series with z-scores, percentile ranks, regime classification (expansion/recession/stagflation), and historical comparisons.

**3 MCP tools:**
- `get_macro_snapshot` — current macro indicators with context
- `explain_macro_change` — what changed and why
- `compare_macro_regimes` — compare to 2008, COVID, 1970s, etc.

**Stack:** TypeScript, PostgreSQL, Redis, hosted at `https://api.meridianapi.io/sse`

**Free tier:** 1,000 requests/month