### PR TITLE
Add Unity AI Bridge to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 Integration with gaming related data, game engines, and services
 
+- [butterlatte-zhang/unity-ai-bridge](https://github.com/butterlatte-zhang/unity-ai-bridge) #️⃣ 🐍 🏠 🍎 🪟 - Remote-control Unity Editor from any AI IDE via file-based IPC — 62 tools across 13 categories, zero dependencies, supports Claude Code, Cursor, Copilot, Windsurf, Claude Desktop.
 - [CoderGamester/mcp-unity](https://github.com/CoderGamester/mcp-unity) #️⃣ 🏠 - MCP Server for Unity3d Game Engine integration for game development
 - [Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp) 📇 🏠 - A MCP server for interacting with the Godot game engine, providing tools for editing, running, debugging, and managing scenes in Godot projects.
 - [ddsky/gamebrain-api-clients](https://github.com/ddsky/gamebrain-api-clients) ☁️ - Search and discover hundreds of thousands of video games on any platform through the [GameBrain API](https://gamebrain.co/api).


### PR DESCRIPTION
## New Server

- **Name**: Unity AI Bridge
- **Repository**: https://github.com/butterlatte-zhang/unity-ai-bridge
- **Category**: Gaming (Unity Editor)

## Description

Remote-control Unity Editor from any AI IDE via file-based IPC — 62 tools across 13 categories (Scene, GameObject, Assets, Prefab, Script, Profiler, LightProbe, Tests, and more). Zero external dependencies, supports Claude Code (Skill mode), Cursor, GitHub Copilot, Windsurf, and Claude Desktop (MCP mode).

## Key Differentiators

- File-based IPC (no open ports, no WebSocket, survives recompilation and play-mode transitions)
- Zero external dependencies (pure Python stdlib + self-contained C# Unity package)
- Dual-channel: same plugin serves both Skill mode and MCP mode
- 5-line extensibility via `[BridgeTool]` attribute