### PR TITLE
Add filesystem-mcp to File Systems section

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [MarceauSolutions/md-to-pdf-mcp](https://github.com/MarceauSolutions/md-to-pdf-mcp) 🐍 🏠 🍎 🪟 🐧 - Convert Markdown files to professional PDFs with customizable themes, headers, footers, and styling
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.
-- [LincolnBurrows2017/filesystem-mcp](https://github.com/LincolnBurrows2017/filesystem-mcp) 🐍 🏠 - Model Context Protocol server for file system operations. Supports read, write, search, copy, move with security path restrictions.
+- [LincolnBurrows2017/filesystem-mcp](https://github.com/LincolnBurrows2017/filesystem-mcp) [glama](https://glama.ai/mcp/servers/LincolnBurrows2017/filesystem-mcp) 🐍 🏠 - Model Context Protocol server for file system operations. Supports read, write, search, copy, move with security path restrictions.
 - [mickaelkerjean/filestash](https://github.com/mickael-kerjean/filestash/tree/master/server/plugin/plg_handler_mcp) 🏎️ ☁️ - Remote Storage Access: SFTP, S3, FTP, SMB, NFS, WebDAV, GIT, FTPS, gcloud, azure blob, sharepoint, etc.
 - [microsoft/markitdown](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) 🎖️ 🐍 🏠 - MCP tool access to MarkItDown -- a library that converts many file formats (local or remote) to Markdown for LLM consumption.
 - [modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/filesystem) 📇 🏠 - Direct local file system access.


### PR DESCRIPTION
Add LincolnBurrows2017/filesystem-mcp to the File Systems section.

filesystem-mcp is a Model Context Protocol server for file system operations with security path restrictions and support for read, write, search, copy, move operations.