### PR TITLE
Add Trillboards DOOH Advertising MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [pipeboard-co/meta-ads-mcp](https://github.com/pipeboard-co/meta-ads-mcp) 🐍 ☁️ 🏠 - Meta Ads automation that just works. Trusted by 10,000+ businesses to analyze performance, test creatives, optimize spend, and scale results — simply and reliably.
 - [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 - [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
+- [trillboards/dooh-agent-example](https://github.com/trillboards/dooh-agent-example) 📇 ☁️ - DOOH (Digital Out-of-Home) advertising via AI agents. Discover 5,000+ screens, get real-time audience signals, and buy programmatic ads — Streamable HTTP (remote).
 - [tomba-io/tomba-mcp-server](https://github.com/tomba-io/tomba-mcp-server) 📇 ☁️ - Email discovery, verification, and enrichment tools. Find email addresses, verify deliverability, enrich contact data, discover authors and LinkedIn profiles, validate phone numbers, and analyze technology stacks.
 
 ### 📊 <a name="monitoring"></a>Monitoring


### PR DESCRIPTION
## Summary

Adds **Trillboards DOOH** to the **Marketing** category.

- **Name**: [trillboards/dooh-agent-example](https://github.com/trillboards/dooh-agent-example)
- **Description**: DOOH (Digital Out-of-Home) advertising via AI agents. Discover 5,000+ screens, get real-time audience signals, and buy programmatic ads — Streamable HTTP (remote).
- **Language**: TypeScript
- **Scope**: Cloud Service

## What is Trillboards DOOH?

Trillboards is a DOOH (Digital Out-of-Home) advertising platform with a remote MCP server that allows AI agents to:

- **Discover screens** — Search 5,000+ digital billboards, transit displays, and retail screens by location, venue type, and audience demographics
- **Get real-time audience signals** — Access foot traffic, dwell time, and impression estimates for each screen
- **Buy programmatic ads** — Place and manage campaigns through OpenRTB-compatible programmatic buying

The server uses Streamable HTTP transport (remote) so no local installation is required.

## Checklist

- [x] Entry follows the existing format (`- [org/repo](url) <badges> - description`)
- [x] Placed alphabetically within the Marketing category
- [x] Repository URL is valid and public
- [x] Description is concise and informative