### PR TITLE
Add TRACE32 MCP tools for Lauterbach hardware debuggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [adancurusul/embedded-debugger-mcp](https://github.com/adancurusul/embedded-debugger-mcp) 🦀 📟 - A Model Context Protocol server for embedded debugging with probe-rs - supports ARM Cortex-M, RISC-V debugging via J-Link, ST-Link, and more
 - [adancurusul/serial-mcp-server](https://github.com/adancurusul/serial-mcp-server) 🦀 📟 - A comprehensive MCP server for serial port communication
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
+- [ormastes/simple](https://github.com/ormastes/simple/tree/main/examples/10_tooling/trace32_tools) 🌊 📟 🏠 🐧 🪟 - Two MCP servers for Lauterbach TRACE32 hardware debuggers: `t32-mcp-server` (20 tools — session management, command execution, window capture, register/memory inspection) and `t32-lsp-mcp-server` (6 tools — CMM/PRACTICE script parsing, diagnostics, completions, hover). Pre-built binaries available.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.


### PR DESCRIPTION
## New Server

Adds two MCP servers for [Lauterbach TRACE32](https://www.lauterbach.com/) hardware debuggers to the **Embedded System** category.

### Servers

| Server | Tools | Description |
|--------|:---:|-------------|
| **t32-mcp-server** | 20 | TRACE32 debug session control — session management, PRACTICE command execution, window capture, register/memory inspection, action invocation |
| **t32-lsp-mcp-server** | 6 | CMM/PRACTICE script intelligence — parsing, diagnostics, completions, hover documentation, symbol extraction |

### Details

- **Repository:** https://github.com/ormastes/simple/tree/main/examples/10_tooling/trace32_tools
- **Protocol:** MCP 2025-06-18 (JSON-RPC 2.0 over stdio)
- **Platforms:** Linux x86_64, Windows x86_64
- **Language:** C/C++ (compiled from Simple language source)
- **Distribution:** Pre-built native binaries via [GitHub Releases](https://github.com/ormastes/simple/releases?q=t32-v), one-line install script
- **No runtime dependencies** — standalone static binaries

### Use case

TRACE32 is the industry-standard hardware debugger for embedded systems (ARM Cortex-M/R/A, RISC-V, PowerPC, TriCore, etc.). These MCP servers enable AI assistants to:
- Control live debug sessions (connect, step, run, set breakpoints)
- Capture register views, memory dumps, and variable watches
- Analyze and lint CMM/PRACTICE automation scripts
- Convert GUI-only scripts to headless/CI-compatible CLI versions

### Install

```bash
curl -fsSL https://raw.githubusercontent.com/ormastes/simple/main/examples/10_tooling/trace32_tools/install.sh | bash
```

### Checklist

- [x] Entry placed in alphabetical order within Embedded System section
- [x] Description is concise and informative
- [x] Link points to repository with README
- [x] Follows existing formatting conventions
- [x] Icons: 🌊 (C/C++), 📟 (Embedded), 🏠 (Local), 🐧 (Linux), 🪟 (Windows)