### PR TITLE
Add mtw-e2e-runner (JSON-driven E2E test runner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [eat-pray-ai/yutu](https://github.com/eat-pray-ai/yutu) 🏎️ 🏠 🍎 🐧 🪟 - A fully functional MCP server and CLI for YouTube to automate YouTube operation
 - [executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright) 📇 - An MCP server using Playwright for browser automation and webscrapping
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
+- [fastslack/mtw-e2e-runner](https://github.com/fastslack/mtw-e2e-runner) 📇 🏠 - JSON-driven E2E test runner for AI agents. Define browser tests as JSON arrays, run in parallel against a Chrome pool (browserless/chrome), with 28+ built-in actions, visual verification, network debugging, and flaky test detection. 16 MCP tools.
 - [fradser/mcp-server-apple-reminders](https://github.com/FradSer/mcp-server-apple-reminders) 📇 🏠 🍎 - An MCP server for interacting with Apple Reminders on macOS
 - [freema/firefox-devtools-mcp](https://github.com/freema/firefox-devtools-mcp) 📇 🏠 - Firefox browser automation via WebDriver BiDi for testing, scraping, and browser control. Supports snapshot/UID-based interactions, network monitoring, console capture, and screenshots.
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 📇 🏠 - Extract structured data from any website. Just prompt and get JSON.


### PR DESCRIPTION
## New Server

**Repository:** https://github.com/fastslack/mtw-e2e-runner
**npm:** [@matware/e2e-runner](https://www.npmjs.com/package/@matware/e2e-runner)
**Language:** JavaScript/Node.js (📇)
**Scope:** Local (🏠)
**Category:** Browser Automation
**License:** Apache-2.0

### Description

JSON-driven E2E test runner for AI agents. Define browser tests as JSON arrays, run in parallel against a Chrome pool (browserless/chrome), with 28+ built-in actions, visual verification, network debugging, and flaky test detection. 16 MCP tools.

### Key Features

- Tests defined as JSON files — no JavaScript test code needed
- Parallel execution against a shared Chrome pool (browserless/chrome)
- 28+ built-in action types (click, type, assert, navigate, evaluate, etc.)
- AI-powered visual verification
- Network request logging and debugging
- Flaky test detection and stability learning system
- Reusable parameterized modules
- Real-time web dashboard
- 16 MCP tools for full test lifecycle management
- GitHub/GitLab issue → test generation