### PR TITLE
Add Selenix MCP Server to Browser Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 📇 🏠 - Extract structured data from any website. Just prompt and get JSON.
 - [hanzili/comet-mcp](https://github.com/hanzili/comet-mcp) 📇 🏠 🍎 - Connect to Perplexity Comet browser for agentic web browsing, deep research, and real-time task monitoring.
 - [LarryWalkerDEV/mcp-immostage](https://github.com/LarryWalkerDEV/mcp-immostage) 📇 ☁️ - AI virtual staging for real estate. Stage empty rooms, beautify floor plans into 3D renders, classify room images, generate property descriptions, and get style recommendations.
+- [markmircea/Selenix-MCP-Server](https://github.com/markmircea/Selenix-MCP-Server) 📇 🏠 🍎 🪟 🐧 - MCP server bridging Claude Desktop with Selenix for browser automation and testing. Create, run, debug, and manage browser tests through natural language.
 - [imprvhub/mcp-browser-agent](https://github.com/imprvhub/mcp-browser-agent) 📇 🏠 - A Model Context Protocol (MCP) integration that provides Claude Desktop with autonomous browser automation capabilities.
 - [kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript) 📇 ☁️ - Fetch YouTube subtitles and transcripts for AI analysis
 - [kimtth/mcp-aoai-web-browsing](https://github.com/kimtth/mcp-aoai-web-browsing) 🐍 🏠 - A `minimal` server/client MCP implementation using Azure OpenAI and Playwright.


### PR DESCRIPTION
## New Server

- **Name:** Selenix MCP Server
- **Repo:** https://github.com/markmircea/Selenix-MCP-Server
- **npm:** [@selenix/mcp-server](https://www.npmjs.com/package/@selenix/mcp-server)
- **Category:** Browser Automation
- **Language:** TypeScript
- **Scope:** Local
- **Platforms:** Windows, macOS, Linux

## Description

MCP server that bridges Claude Desktop with Selenix for browser automation and testing. Enables creating, running, debugging, and managing browser automation tests through natural language via Claude.

Key capabilities:
- Screenshot capture and page HTML inspection
- Test creation, execution, and debugging via natural language
- Full Selenix command set access (17+ tools)
- Local-only bridge with auto-generated auth tokens

## Checklist

- [x] Entry added in alphabetical order
- [x] Correct category (Browser Automation)
- [x] Badges match project attributes (📇 🏠 🍎 🪟 🐧)
- [x] Repo has README with installation and usage instructions
- [x] Repo has a license (Apache-2.0)
- [x] Package published on npm