### PR TITLE
Add BioBTree v2 - unified biomedical graph database MCP server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 - [OHNLP/omop_mcp](https://github.com/OHNLP/omop_mcp) 🐍 🏠 ☁️ - Map clinical terminology to OMOP concepts using LLMs for healthcare data standardization and interoperability.
 - [the-momentum/apple-health-mcp-server](https://github.com/the-momentum/apple-health-mcp-server) 🐍 🏠 🍎 🪟 🐧 - An MCP server that provides access to exported data from Apple Health. Data analytics included.
 - [the-momentum/fhir-mcp-server](https://github.com/the-momentum/fhir-mcp-server) 🐍 🏠 ☁️ - MCP Server that connects AI agents to FHIR servers. One example use case is querying patient history in natural language.
-- [tamerh/biobtree](https://github.com/tamerh/biobtree) 🐍 🏎️ ☁️ - Unified biomedical graph database integrating 50+ data sources (genes, proteins, compounds, diseases, pathways) into a queryable graph with billions of cross-reference edges and intuitive chain query syntax.
+- [tamerh/biobtree](https://github.com/tamerh/biobtree) [glama](https://glama.ai/mcp/connectors/bio.sugi/bio-btree) 🐍 🏎️ ☁️ - Unified biomedical graph database integrating 50+ data sources (genes, proteins, compounds, diseases, pathways) into a queryable graph with billions of cross-reference edges and intuitive chain query syntax.
 - [wso2/fhir-mcp-server](https://github.com/wso2/fhir-mcp-server) 🐍 🏠 ☁️ - Model Context Protocol server for Fast Healthcare Interoperability Resources (FHIR) APIs. Provides seamless integration with FHIR servers, enabling AI assistants to search, retrieve, create, update, and analyze clinical healthcare data with SMART-on-FHIR authentication support.
 
 ### 📂 <a name="browser-automation"></a>Browser Automation


### PR DESCRIPTION

Adds BioBTree v2 to the Biology, Medicine and Bioinformatics section. It integrates 50+ primary biomedical data sources (Ensembl, UniProt, ChEMBL, MONDO, Reactome, etc.) into a single     
  queryable graph with billions of cross-reference edges, accessible via a native MCP server.                                                                                                 
                                                            
  - Repository: [https://github.com/tamerh/biobtree](https://github.com/tamerh/biobtree)                                                                                                                                            
  - MCP endpoint: [https://sugi.bio/biobtree/mcp](https://sugi.bio/biobtree/mcp)      

Server added as connector to the Glama

[https://glama.ai/mcp/connectors/bio.sugi/bio-btree](https://glama.ai/mcp/connectors/bio.sugi/bio-btree)