### PR TITLE
Add Edict — agent-first programming language with 19 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Code execution servers. Allow LLMs to execute code in a secure environment, e.g.
 - [ouvreboite/openapi-to-mcp](https://github.com/ouvreboite/openapi-to-mcp) #️⃣ ☁️ - Lightweight MCP server to access any API using their OpenAPI specification. Supports OAuth2 and full JSON schema parameters and request body.
 - [pydantic/pydantic-ai/mcp-run-python](https://github.com/pydantic/pydantic-ai/tree/main/mcp-run-python) 🐍 🏠 - Run Python code in a secure sandbox via MCP tool calls
 - [r33drichards/mcp-js](https://github.com/r33drichards/mcp-js) 🦀 🏠 🐧 🍎 - A Javascript code execution sandbox that uses v8 to isolate code to run AI generated javascript locally without fear. Supports heap snapshotting for persistent sessions.
+- [Sowiedu/Edict](https://github.com/Sowiedu/Edict) [![Sowiedu/Edict MCP server](https://glama.ai/mcp/servers/sowiedu/edict/badges/score.svg)](https://glama.ai/mcp/servers/sowiedu/edict) 📇 🏠 – Agent-first programming language: agents produce JSON AST, the compiler validates, type-checks, effect-checks, verifies contracts via Z3/SMT, and compiles to WASM. 19 MCP tools for the full compile-and-execute loop.
 - [yepcode/mcp-server-js](https://github.com/yepcode/mcp-server-js) 🎖️ 📇 ☁️ - Execute any LLM-generated code in a secure and scalable sandbox environment and create your own MCP tools using JavaScript or Python, with full support for NPM and PyPI packages
 
 ### 🤖 <a name="coding-agents"></a>Coding Agents


### PR DESCRIPTION
## Add Edict — Agent-first programming language

[Edict](https://github.com/Sowiedu/Edict) is a programming language designed exclusively for AI agents. There is no text syntax and no parser — agents produce JSON AST directly. The compiler validates, resolves names, type-checks, effect-checks, verifies contracts via Z3/SMT, and compiles to WebAssembly.

**Category:** Code Execution

**Key features:**
- 19 MCP tools covering the full compile-and-execute loop (`edict_schema`, `edict_validate`, `edict_check`, `edict_compile`, `edict_run`, `edict_patch`, `edict_lint`, `edict_debug`, etc.)
- 5-phase pipeline: validation → name resolution → type checking → effect checking → contract verification → WASM codegen
- Structured errors with `nodeId`, expected/actual values, candidate suggestions, and counterexamples — designed for automated agent self-repair
- Available via `npx edict-lang` (npm) and Docker

**npm:** [edict-lang](https://www.npmjs.com/package/edict-lang)
**MCP Registry:** [io.github.Sowiedu/edict](https://registry.modelcontextprotocol.io)