### PR TITLE
feat: add mcp-bcra - MCP server for Argentina's Central Bank APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp) 🎖️ 🐍 ☁️ 🏠 - Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp) 🎖️ 🐍 ☁️ - Risk score / asset holdings of EVM blockchain address (EOA, CA, ENS) and even domain names.
 - [alchemy/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server) 🎖️ 📇 ☁️ - Allow AI agents to interact with Alchemy's blockchain APIs.
+- [alejandro-medici/mcp-bcra](https://github.com/alejandro-medici/mcp-bcra) 🐍 🏠 - MCP server for Argentina's Central Bank (BCRA) public APIs. Access exchange rates, monetary variables, debtor registry, rejected checks, and transparency data from financial entities.
 - [anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server) 🐍 ☁️ - Coinmarket API integration to fetch cryptocurrency listings and quotes
 - [araa47/jupiter-mcp](https://github.com/araa47/jupiter-mcp) 🐍 ☁️ - Jupiter API Access (allow AI to Trade Tokens on Solana + Access Balances + Search Tokens + Create Limit Orders )
 - [ariadng/metatrader-mcp-server](https://github.com/ariadng/metatrader-mcp-server) 🐍 🏠 🪟 - Enable AI LLMs to execute trades using MetaTrader 5 platform


### PR DESCRIPTION
## Description

Adds [mcp-bcra](https://github.com/alejandro-medici/mcp-bcra) to the Finance & Fintech section.

**mcp-bcra** is a Python MCP server for Argentina's Central Bank (BCRA) public APIs. It provides 17 tools covering:

- Exchange rates and currency evolution
- Monetary variables (reserves, inflation, etc.)
- Debtor registry and credit history
- Rejected checks lookup
- Transparency regime (savings accounts, loans, credit cards, fixed-term deposits)

Available on PyPI: `pip install mcp-bcra` or `uvx mcp-bcra`