### PR TITLE
Add ReplenishRadar MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1834,6 +1834,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Rai220/think-mcp](https://github.com/Rai220/think-mcp) 🐍 🏠 - Enhances any agent's reasoning capabilities by integrating the think-tools, as described in [Anthropic's article](https://www.anthropic.com/engineering/claude-think-tool).
 - [reeeeemo/ancestry-mcp](https://github.com/reeeeemo/ancestry-mcp) 🐍 🏠 - Allows the AI to read .ged files and genetic data
 - [rember/rember-mcp](https://github.com/rember/rember-mcp) 📇 🏠 - Create spaced repetition flashcards in [Rember](https://rember.com) to remember anything you learn in your chats.
+- [ReplenishRadar/MCP](https://github.com/ReplenishRadar/MCP) 📇 ☁️ - Multi-channel inventory intelligence for Shopify and Amazon sellers. 28 tools for stockout risk, demand forecasts, purchase order lifecycle, and sales analytics. Human-in-the-loop: all write operations create drafts only.
 - [roychri/mcp-server-asana](https://github.com/roychri/mcp-server-asana) - 📇 ☁️ This Model Context Protocol server implementation of Asana allows you to talk to Asana API from MCP Client such as Anthropic's Claude Desktop Application, and many more.
 - [rusiaaman/wcgw](https://github.com/rusiaaman/wcgw/blob/main/src/wcgw/client/mcp_server/Readme.md) 🐍 🏠 - Autonomous shell execution, computer control and coding agent. (Mac)
 - [SecretiveShell/MCP-wolfram-alpha](https://github.com/SecretiveShell/MCP-wolfram-alpha) 🐍 ☁️ - An MCP server for querying wolfram alpha API.


### PR DESCRIPTION
## Add ReplenishRadar MCP Server

**ReplenishRadar** is a production MCP server for multi-channel e-commerce inventory management. It connects AI agents to live Shopify and Amazon inventory data.

### Details

- **28 tools** — stockout risk, demand forecasts, suggested POs, inventory position, sales analytics, purchase order lifecycle
- **Human-in-the-loop** — all write operations create drafts only; requires explicit human approval before sending POs to suppliers
- **Tier-gated** — Growth ($199/mo) for read tools, Scale ($499/mo) for full PO management
- **Security** — org-scoped API keys, audit logging, circuit breaker, Amazon BSA compliant

### Links

- **Repository:** https://github.com/ReplenishRadar/MCP
- **npm:** [@replenishradar/mcp-server](https://www.npmjs.com/package/@replenishradar/mcp-server)
- **Website:** https://replenishradar.com

### Placement

Added under **Other Tools and Integrations** in alphabetical order (between `rember-mcp` and `mcp-server-asana`).