### PR TITLE
Add apifable MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [xzq.xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server) 📇 🏠  - An implementation project of a JVM-based MCP (Model Context Protocol) server.
 - [yangkyeongmo@/mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow) 🐍 🏠 - MCP server that connects to [Apache Airflow](https://airflow.apache.org/) using official client.
 - [yanmxa/scriptflow-mcp](https://github.com/yanmxa/scriptflow-mcp) 📇 🏠 - A script workflow management system that transforms complex, repetitive AI interactions into persistent, executable scripts. Supports multi-language execution (Bash, Python, Node.js, TypeScript) with guaranteed consistency and reduced hallucination risks.
+- [ycs77/apifable](https://github.com/ycs77/apifable) [glama](https://glama.ai/mcp/servers/ycs77/apifable) 📇 🏠 - MCP server that helps AI agents explore OpenAPI specs, search endpoints, and generate TypeScript types.
 - [yikakia/godoc-mcp-server](https://github.com/yikakia/godoc-mcp-server) 🏎️ ☁️ 🪟 🐧 🍎 - Query Go package information on pkg.go.dev
 - [yiwenlu66/PiloTY](https://github.com/yiwenlu66/PiloTY) 🐍 🏠 - AI pilot for PTY operations enabling agents to control interactive terminals with stateful sessions, SSH connections, and background process management
 - [YuChenSSR/mindmap-mcp-server](https://github.com/YuChenSSR/mindmap-mcp-server) 🐍 🏠 - A Model Context Protocol (MCP) server for generating a beautiful interactive mindmap.


### PR DESCRIPTION
Add [apifable](https://github.com/ycs77/apifable) MCP Server to the **Developer Tools** section.

### Description

apifable is an MCP server that helps AI integrate APIs more smoothly into TypeScript frontend projects. It makes it easy to explore API structure, search endpoints, and generate TypeScript types, giving your AI agent the context it needs to write accurate integration code.

### Links

* GitHub: https://github.com/ycs77/apifable
* npm: https://www.npmjs.com/package/apifable
* Glama: https://glama.ai/mcp/servers/ycs77/apifable