### PR TITLE
Add tui-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 Run commands, capture output and otherwise interact with shells and command line tools.
 
 - [danmartuszewski/hop](https://github.com/danmartuszewski/hop) 🏎️ 🖥️ - Fast SSH connection manager with TUI dashboard and MCP server for discovering, searching, and executing commands on remote hosts.
-- [nvms/tui-mcp](https://github.com/nvms/tui-mcp) ([glama](https://glama.ai/mcp/servers/nvms/tui-mcp)) 📇 🏠 🍎 🪟 🐧 - What Chrome DevTools MCP is for the browser, tui-mcp is for the terminal. Launch, screenshot, and interact with any TUI app.
+- [nvms/tui-mcp](https://github.com/nvms/tui-mcp) [![tui-mcp MCP server](https://glama.ai/mcp/servers/nvms/tui-mcp/badges/score.svg)](https://glama.ai/mcp/servers/nvms/tui-mcp) 📇 🏠 🍎 🪟 🐧 - What Chrome DevTools MCP is for the browser, tui-mcp is for the terminal. Launch, screenshot, and interact with any TUI app.
 - [ferodrigop/forge](https://github.com/ferodrigop/forge) [![forge MCP server](https://glama.ai/mcp/servers/ferodrigop/forge/badges/score.svg)](https://glama.ai/mcp/servers/ferodrigop/forge) 📇 🏠 - Terminal MCP server for AI coding agents with persistent PTY sessions, ring-buffer incremental reads, headless xterm screen capture, multi-agent orchestration, and a real-time web dashboard.
 
 ### 💬 <a name="communication"></a>Communication


### PR DESCRIPTION
Add tui-mcp

Category: Command Line

tui-mcp is what Chrome DevTools MCP is for the browser, but for the terminal. It gives AI agents eyes and hands over any TUI application.

- Language: JavaScript
- Transport: stdio
- License: MIT
- Key features: launch any terminal app in a managed pty, take PNG screenshots, capture text snapshots, send keystrokes/mouse events, wait for text or idle state
- Size: ~5 files, zero-config, runs via npx

Uses node-pty for process management and xterm-headless (same engine as VS Code's terminal) for ANSI parsing. Works with any TUI framework or plain terminal app - vim, htop, bubbletea, textual, ink, ncurses, whatever.