### PR TITLE
feat: add Charta MCP — presentation-quality chart generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Provides access to customer profiles inside of customer data platforms
 - [antv/mcp-server-chart](https://github.com/antvis/mcp-server-chart) 🎖️ 📇 ☁️ - A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - [hustcc/mcp-echarts](https://github.com/hustcc/mcp-echarts) 📇 🏠 - Generate visual charts using [Apache ECharts](https://echarts.apache.org) with AI MCP dynamically.
 - [hustcc/mcp-mermaid](https://github.com/hustcc/mcp-mermaid) 📇 🏠 - Generate [mermaid](https://mermaid.js.org/) diagram and chart with AI MCP dynamically.
+- [mortenator/charta-mcp](https://github.com/mortenator/charta-mcp) 📇 🏠 🍎 🪟 🐧 - Generate presentation-quality charts (bar, waterfall, line, pie, mekko, gantt) for Google Slides and other tools. Zero setup via `npx -y @charta/mcp`. SVG + PNG output.
 - [iaptic/mcp-server-iaptic](https://github.com/iaptic/mcp-server-iaptic) 🎖️ 📇 ☁️ - Connect with [iaptic](https://www.iaptic.com) to ask about your Customer Purchases, Transaction data and App Revenue statistics.
 - [OpenDataMCP/OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP) 🐍 ☁️ - Connect any Open Data to any LLM with Model Context Protocol.
 - [QuackbackIO/quackback](https://github.com/QuackbackIO/quackback) 📇 ☁️ - Open-source customer feedback platform with built-in MCP server. Agents can search feedback, triage posts, update statuses, create and comment on posts, vote, manage roadmaps, merge duplicates, and publish changelogs.


### PR DESCRIPTION
## New MCP Server: Charta

**What it does:** Generates presentation-quality charts (bar, waterfall, line, pie, mekko, gantt, scatter, area) for Google Slides and other tools. Zero setup.

**Install:**
```bash
npx -y @charta/mcp
```

**npm:** https://www.npmjs.com/package/@charta/mcp
**GitHub:** https://github.com/mortenator/charta-mcp
**Website:** https://getcharta.ai

Grouped with the other chart MCP servers (antv, mcp-echarts, mcp-mermaid). Adds the `🏠` (local) flag as it runs via npx/stdio.