### PR TITLE
Add xiaohongshu-skill — Xiaohongshu (小红书/RED) MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1631,6 +1631,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 - [scrape-badger/scrapebadger-mcp](https://github.com/scrape-badger/scrapebadger-mcp) 🐍 ☁️ - Access Twitter/X data including user profiles, tweets, followers, trends, lists, and communities via the ScrapeBadger API.
 - [sinanefeozler/reddit-summarizer-mcp](https://github.com/sinanefeozler/reddit-summarizer-mcp) 🐍 🏠 ☁️ - MCP server for summarizing users's Reddit homepage or any subreddit based on posts and comments.
 - [bulatko/vk-mcp-server](https://github.com/bulatko/vk-mcp-server) [glama](https://glama.ai/mcp/servers/bulatko/vk-mcp-server) 📇 ☁️ - MCP server for VK (VKontakte) social network API. Access users, walls, groups, friends, newsfeed, photos, and community stats.
+- [Youhai020616/xiaohongshu-skill](https://github.com/Youhai020616/xiaohongshu-skill) 🏎️ 🐍 🏠 🍎 - Xiaohongshu (小红书/RED) automation with 14 MCP tools — publish image/video posts, search, comment, like, favorite, user profiles. Includes Python CDP scripts for creator analytics dashboard, notifications, and advanced search.
 
 ### 🏃 <a name="sports"></a>Sports
 

--- a/README.md
+++ b/README.md
@@ -1631,7 +1631,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 - [scrape-badger/scrapebadger-mcp](https://github.com/scrape-badger/scrapebadger-mcp) 🐍 ☁️ - Access Twitter/X data including user profiles, tweets, followers, trends, lists, and communities via the ScrapeBadger API.
 - [sinanefeozler/reddit-summarizer-mcp](https://github.com/sinanefeozler/reddit-summarizer-mcp) 🐍 🏠 ☁️ - MCP server for summarizing users's Reddit homepage or any subreddit based on posts and comments.
 - [bulatko/vk-mcp-server](https://github.com/bulatko/vk-mcp-server) [glama](https://glama.ai/mcp/servers/bulatko/vk-mcp-server) 📇 ☁️ - MCP server for VK (VKontakte) social network API. Access users, walls, groups, friends, newsfeed, photos, and community stats.
-- [Youhai020616/xiaohongshu-skill](https://github.com/Youhai020616/xiaohongshu-skill) 🏎️ 🐍 🏠 🍎 - Xiaohongshu (小红书/RED) automation with 14 MCP tools — publish image/video posts, search, comment, like, favorite, user profiles. Includes Python CDP scripts for creator analytics dashboard, notifications, and advanced search.
+- [Youhai020616/xiaohongshu-skill](https://github.com/Youhai020616/xiaohongshu-skill) [![Youhai020616/xiaohongshu-skill MCP server](https://glama.ai/mcp/servers/Youhai020616/xiaohongshu-skill/badges/score.svg)](https://glama.ai/mcp/servers/Youhai020616/xiaohongshu-skill) 🏎️ 🐍 🏠 🍎 - Xiaohongshu (小红书/RED) automation with 14 MCP tools — publish image/video posts, search, comment, like, favorite, user profiles. Includes Python CDP scripts for creator analytics dashboard, notifications, and advanced search.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
## Description

Adds [xiaohongshu-skill](https://github.com/Youhai020616/xiaohongshu-skill) to the **Social Media** section.

**Xiaohongshu (小红书/RED)** is one of China's largest social media platforms with 300M+ monthly active users. It's essentially China's Instagram+Pinterest hybrid, widely used for lifestyle content, product reviews, and brand marketing.

## What the server does

- **14 MCP tools** via JSON-RPC (Streamable HTTP transport):
  - Publish image/video posts with tags, scheduling, visibility control
  - Search posts by keyword
  - Comment, reply, like, favorite
  - Fetch user profiles and post details
  - QR code login with persistent cookies

- **Python CDP scripts** for features MCP doesn't cover:
  - Creator analytics dashboard (CSV export)
  - Notification mentions
  - Advanced search with suggested keywords
  - Multi-account management

## Tech Stack

- Go MCP binary (14 tools, always-on daemon)
- Python CDP scripts (~5000 lines)
- macOS ARM64 (Apple Silicon)

## Checklist

- [x] Open source (MIT license)
- [x] Has README with documentation
- [x] Works as described
- [x] Follows MCP protocol (Streamable HTTP transport)
- [x] Placed in correct category (Social Media)
- [x] Alphabetically sorted