### PR TITLE
Add Government Open Data & Public Records MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 - [Osseni94/oyemi-mcp](https://github.com/Osseni94/oyemi-mcp) 🐍 🏠 - Deterministic semantic word encoding and valence/sentiment analysis using 145K+ word lexicon. Provides word-to-code mapping, semantic similarity, synonym/antonym lookup with zero runtime NLP dependencies.
 - [paracetamol951/caisse-enregistreuse-mcp-server](https://github.com/paracetamol951/caisse-enregistreuse-mcp-server) 🏠 🐧 🍎 ☁️ - Allows you to automate or monitor business operations, sales recorder, POS software, CRM.
 - [saikiyusuke/registep-mcp](https://github.com/saikiyusuke/registep-mcp) 📇 ☁️ - AI-powered POS & sales analytics MCP server with 67 tools for Airレジ, スマレジ, and BASE EC integration. Provides store management, sales data querying, AI chat analysis, and weather correlation features.
+- [Two-Hundred-OK/gov-open-data-mcp](https://github.com/Two-Hundred-OK/API-Factory) 📇 ☁️ - AI agents get structured access to US government open datasets via data.gov and CKAN portals. Search federal datasets, query by ID, and browse by agency with source provenance and fast responses via Cloudflare Workers.
 - [yashshingvi/databricks-genie-MCP](https://github.com/yashshingvi/databricks-genie-MCP) 🐍 ☁️ - A server that connects to the Databricks Genie API, allowing LLMs to ask natural language questions, run SQL queries, and interact with Databricks conversational agents.
 
 


### PR DESCRIPTION
## Server Info

- **Name:** Government Open Data & Public Records MCP
- **GitHub:** [Two-Hundred-OK/API-Factory](https://github.com/Two-Hundred-OK/API-Factory) (under `apis/gov-open-data-mcp`)
- **MCP Endpoint:** https://gov-open-data-mcp.two-hundred-ok.workers.dev/mcp
- **Transport:** Streamable HTTP (Cloudflare Workers)
- **Language:** TypeScript

## Description

AI agents get structured access to US government open datasets via data.gov and CKAN portals. Search federal datasets, query by ID, and browse by agency — all with source provenance and structured metadata.

## Tools

| Tool | Description |
|------|-------------|
| `search_datasets` | Search US government open datasets by keyword, with optional agency filtering |
| `query_dataset` | Get detailed metadata for a specific dataset by ID |
| `list_agencies` | Browse available federal agencies and their dataset counts |

## Category

Added under **Data Platforms** (alphabetically between `saikiyusuke/registep-mcp` and `yashshingvi/databricks-genie-MCP`).