### PR TITLE
Add bamwor-mcp-server to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,7 +1287,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 
 Location-based services and mapping tools. Enables AI models to work with geographic data, weather information, and location-based analytics.
 
-- [bamwor-dev/bamwor-mcp-server](https://github.com/bamwor-dev/bamwor-mcp-server) 📇 ☁️ - World geographic data for AI agents. 261 countries with 20+ statistics and 13.4M cities with population, coordinates, and timezone. Powered by Bamwor API.
+- [bamwor-dev/bamwor-mcp-server](https://github.com/bamwor-dev/bamwor-mcp-server) [glama](https://glama.ai/mcp/servers/bamwor-dev/bamwor-mcp-server) 📇 ☁️ - World geographic data for AI agents. 261 countries with 20+ statistics and 13.4M cities with population, coordinates, and timezone. Powered by Bamwor API.
 - [briandconnelly/mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo) 🐍 ☁️  - IP address geolocation and network information using IPInfo API
 - [cqtrinv/trinvmcp](https://github.com/cqtrinv/trinvmcp) 📇 ☁️ - Explore French communes and cadastral parcels based on name and surface
 - [devilcoder01/weather-mcp-server](https://github.com/devilcoder01/weather-mcp-server) 🐍 ☁️ - Access real-time weather data for any location using the WeatherAPI.com API, providing detailed forecasts and current conditions.


### PR DESCRIPTION
## What

Adds [bamwor-mcp-server](https://github.com/bamwor-dev/bamwor-mcp-server) to the **Location Services** section.

## Server Details

- **Name:** bamwor-mcp-server
- **npm:** [bamwor-mcp-server](https://www.npmjs.com/package/bamwor-mcp-server)
- **GitHub:** [bamwor-dev/bamwor-mcp-server](https://github.com/bamwor-dev/bamwor-mcp-server)
- **License:** MIT
- **Transport:** stdio
- **Description:** World geographic data for AI agents — 261 countries with 20+ statistics and 13.4M cities with population, coordinates, and timezone.

## Category

**Location Services** — the server provides structured access to world geographic data (countries, cities, coordinates, population, timezone), fitting naturally alongside other location/geo tools.