### PR TITLE
Add mass-tort-mcp to Legal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act) [glama](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act) 📇 ☁️ - EU AI Act compliance scanner that detects regulatory violations in AI codebases with risk classification and remediation guidance.
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
+- [RujaMedia/mass-tort-mcp](https://github.com/RujaMedia/mass-tort-mcp) 📇 ☁️ - Mass tort litigation data server with case statistics, eligibility checking, state statutes of limitations, and PFAS water contamination data covering 12 active litigations.
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
 
 ### 🗺️ <a name="location-services"></a>Location Services


### PR DESCRIPTION
Adding [mass-tort-mcp](https://github.com/RujaMedia/mass-tort-mcp) — an MCP server providing mass tort litigation data including case statistics for 12 active litigations, eligibility checking, state statutes of limitations, and EPA PFAS water contamination data.

Deployed on Cloudflare Workers, free to use, no API key required.