### PR TITLE
Add mcp-dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 
 Interactive charts, dashboards, and visual data tools rendered inside AI conversations.
 
-- [KyuRish/mcp-dashboards](https://github.com/KyuRish/mcp-dashboards) 📇 🏠 🍎 🪟 🐧 - 45+ interactive chart types (bar, line, pie, candlestick, sankey, geo, radar, funnel, treemap, and more), dashboards with KPI cards, drill-down navigation, live API polling, 20 themes, and export to PNG/PPT/A4. Built on MCP Apps.
+- [KyuRish/mcp-dashboards](https://github.com/KyuRish/mcp-dashboards) [![mcp-dashboards MCP server](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards/badges/score.svg)](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards) 📇 🏠 🍎 🪟 🐧 - 45+ interactive chart types (bar, line, pie, candlestick, sankey, geo, radar, funnel, treemap, and more), dashboards with KPI cards, drill-down navigation, live API polling, 20 themes, and export to PNG/PPT/A4. Built on MCP Apps.
 
 ### 📟 <a name="embedded-system"></a>Embedded System
 


### PR DESCRIPTION
## Server

- **Name**: mcp-dashboards
- **GitHub**: https://github.com/KyuRish/mcp-dashboards
- **npm**: https://www.npmjs.com/package/mcp-dashboards
- **Language**: TypeScript
- **Transport**: stdio + Streamable HTTP

## What it does

45+ interactive chart types rendered directly inside AI conversations via MCP Apps. Includes dashboards with KPI cards, drill-down bar charts, live API polling, 20 themes, and export to PNG/PPT/A4.

Chart types include: bar, line, pie, scatter, candlestick, sankey, geo/choropleth, bubble map, radar, funnel, treemap, waterfall, heatmap, boxplot, word cloud, and more.

## New section

Added a "Data Visualization" section since there isn't one currently. Chart/visualization MCP servers are currently scattered across Customer Data Platforms and Data Science Tools.

## Glama

Submitted to Glama, pending review. Will update with badge once approved.