### PR TITLE
Add LobsterMail MCP server to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Integration with communication platforms for message management and channel oper
 - [AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp) ☁️ - A Nostr MCP server that allows to interact with Nostr, enabling posting notes, and more.
 - [adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit) 🐍 ☁️ - Interact with Twitter search and timeline
 - [agentmail-toolkit/mcp](https://github.com/agentmail-to/agentmail-toolkit/tree/main/mcp) 🐍 💬 - An MCP server to create inboxes on the fly to send, receive, and take actions on email. We aren't AI agents for email, but email for AI Agents.
+- [lobstermail](https://lobstermail.ai/) 📇 ☁️ - Email infrastructure MCP server for AI agents. Agents self-provision inboxes — no human signup, no API keys. Includes prompt injection scanning, SPF/DKIM/DMARC, and per-account reputation isolation. Also available as native OpenClaw skill and Node.js SDK.
 - [areweai/tsgram-mcp](https://github.com/areweai/tsgram-mcp) - TSgram: Telegram + Claude with local workspace access on your phone in typescript. Read, write, and vibe code on the go!
 - [arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks) 📇 ☁️ - An MCP server to interface with the Google Tasks API
 - [Cactusinhand/mcp_server_notify](https://github.com/Cactusinhand/mcp_server_notify) 🐍 🏠 - A MCP server that send desktop notifications with sound effect when agent tasks are completed.


### PR DESCRIPTION
Added LobsterMail MCP server to the Communication section.

[LobsterMail](https://lobstermail.ai/) provides an MCP server for email infrastructure — agents self-provision inboxes with no human signup or API keys. Includes prompt injection scanning across 6 categories, SPF/DKIM/DMARC authentication, and per-account reputation isolation.

Also available as a native OpenClaw skill on ClawHub and Node.js SDK (`npm install lobstermail`).