### PR TITLE
Add Signbee - Document signing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act) [glama](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act) 📇 ☁️ - EU AI Act compliance scanner that detects regulatory violations in AI codebases with risk classification and remediation guidance.
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
+- [signbee/mcp](https://github.com/signbee/mcp) 📇 ☁️ - Document signing for AI agents. Send contracts for e-signature via [Signbee](https://signb.ee) with email OTP verification and SHA-256 signing certificates. Supports MCP, Agent Skills, and direct API.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
Adds [Signbee](https://signb.ee) to the Legal section.

Signbee is a document signing MCP server that lets AI agents send contracts for e-signature with email OTP verification and SHA-256 signing certificates.

- **npm**: https://www.npmjs.com/package/signbee-mcp
- **GitHub**: https://github.com/signbee/mcp
- **Website**: https://signb.ee