### PR TITLE
Add Fullrun MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,6 +1371,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 - [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
 - [tomba-io/tomba-mcp-server](https://github.com/tomba-io/tomba-mcp-server) 📇 ☁️ - Email discovery, verification, and enrichment tools. Find email addresses, verify deliverability, enrich contact data, discover authors and LinkedIn profiles, validate phone numbers, and analyze technology stacks.
+- [tuckerschreiber/fullrun-cli](https://github.com/tuckerschreiber/fullrun-cli) 📇 ☁️ - Google Ads management for AI agents — diagnose account health, view campaigns and performance, trigger AI-powered optimizations. Also available as [`@fullrun/mcp`](https://www.npmjs.com/package/@fullrun/mcp) on npm.
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
Adds [Fullrun](https://github.com/tuckerschreiber/fullrun-cli) to the Marketing section.

Fullrun is a TypeScript MCP server for Google Ads management — it lets AI agents diagnose account health, view campaigns and performance metrics, and trigger AI-powered optimizations. Available on npm as [`@fullrun/mcp`](https://www.npmjs.com/package/@fullrun/mcp).

**Placement:** Marketing section, alphabetical order (after `tomba-io/tomba-mcp-server`).