### PR TITLE
Add Graqle — dev intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [qainsights/k6-mcp-server](https://github.com/QAInsights/k6-mcp-server) 🐍 🏠 - Grafana k6 MCP Server for performance testing
 - [qainsights/locust-mcp-server](https://github.com/QAInsights/locust-mcp-server) 🐍 🏠 - Locust MCP Server for performance testing
 - [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp) 🏎️ 🏠 - Docker container management and operations through MCP
+- [quantamixsol/graqle](https://github.com/quantamixsol/graqle) 🐍 🏠 ☁️ 🍎 🪟 🐧 - Dev intelligence layer that builds a knowledge graph from any codebase and reasons over it. 7 MCP tools (context, reason, impact, preflight, lessons, learn, inspect), graph-of-agents reasoning with 14 LLM backends, self-evolving graphs, and 201 ontology skills. CLI: `graq`. PyPI: `pip install graqle`.
 - [r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server) 📇 🏠 🍎 - Xcode integration for project management, file operations, and build automation
 - [ReAPI-com/mcp-openapi](https://github.com/ReAPI-com/mcp-openapi) 📇 🏠 - MCP server that lets LLMs know everything about your OpenAPI specifications to discover, explain and generate code/mock data
 - [reflagcom/mcp](https://github.com/reflagcom/javascript/tree/main/packages/cli#model-context-protocol) 🎖️ 📇 ☁️ - Flag features directly from chat in your IDE with [Reflag](https://reflag.com).


### PR DESCRIPTION
## Summary

Adds [Graqle](https://github.com/quantamixsol/graqle) to the **Developer Tools** section.

Graqle is a dev intelligence layer that builds a knowledge graph from any codebase and exposes it through 7 MCP tools:

- **`context`** — focused context for a module
- **`reason`** — multi-agent graph reasoning (graph-of-agents)
- **`impact`** — change impact analysis
- **`preflight`** — pre-change safety checks
- **`lessons`** — past mistake patterns
- **`learn`** — teach the graph (self-evolving)
- **`inspect`** — graph stats

**Key facts:**
- Python SDK + CLI (`graq`) — available on PyPI: `pip install graqle`
- 14 LLM backend providers (Anthropic, OpenAI, Bedrock, Ollama, Gemini, Groq, DeepSeek, Together, Mistral, OpenRouter, Fireworks, Cohere, + Custom)
- 201 curated ontology skills for code understanding
- 1,655+ tests
- Self-evolving graphs — `graq learn` discovers and updates the knowledge graph automatically
- Works locally (zero-dep JSON/NetworkX graph) or with Neo4j

GitHub: https://github.com/quantamixsol/graqle
PyPI: https://pypi.org/project/graqle/