### PR TITLE
Add astronomy-oracle MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 ### 🚀 <a name="aerospace-and-astrodynamics"></a>Aerospace & Astrodynamics
 
+- [gregario/astronomy-oracle](https://github.com/gregario/astronomy-oracle) [![astronomy-oracle MCP server](https://glama.ai/mcp/servers/gregario/astronomy-oracle/badges/score.svg)](https://glama.ai/mcp/servers/gregario/astronomy-oracle) 📇 🏠 🍎 🪟 🐧 - Accurate astronomical catalog data and observing session planner. 13,000+ deep-sky objects from OpenNGC with deterministic visibility, rise/transit/set, and alt/az calculations. `npx astronomy-oracle`
 - [IO-Aerospace-software-community/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture


### PR DESCRIPTION
## Add astronomy-oracle

Adds [astronomy-oracle](https://github.com/gregario/astronomy-oracle) to the Aerospace & Astrodynamics section.

**What it does:** Accurate astronomical catalog data and observing session planner for LLM assistants. Embeds the OpenNGC catalog (13,000+ deep-sky objects) with deterministic astronomy math for visibility calculations.

**Tools (3):**
- `lookup_object` — Look up any object by Messier/NGC/IC/common name with optional location-aware visibility
- `search_objects` — Filter catalog by type, constellation, magnitude, size, catalog membership
- `plan_session` — "What can I see tonight?" with time-windowed scoring

**Install:** `npx astronomy-oracle`

**Published on:** [npm](https://www.npmjs.com/package/astronomy-oracle) · [MCP Registry](https://registry.modelcontextprotocol.io) · [Glama](https://glama.ai/mcp/servers/gregario/astronomy-oracle)