### PR TITLE
Add fulfil-mcp to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,7 @@ Interact with Git repositories and version control platforms. Enables repository
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.
+- [ExpertVagabond/fulfil-mcp](https://github.com/ExpertVagabond/fulfil-mcp) [![ExpertVagabond/fulfil-mcp MCP server](https://glama.ai/mcp/servers/ExpertVagabond/fulfil-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ExpertVagabond/fulfil-mcp) 📇 ☁️ - Fulfil.io ERP — 29 tools for inventory, orders, shipments, customers, purchase orders, warehouses, and returns.
 - [2niuhe/qrcode_mcp](https://github.com/2niuhe/qrcode_mcp) 🐍 🏠 🍎 🪟 🐧 - A QR code generation MCP server that converts any text (including Chinese characters) to QR codes with customizable colors and base64 encoding output.
 - [AbdelStark/bitcoin-mcp](https://github.com/AbdelStark/bitcoin-mcp) - ₿ A Model Context Protocol (MCP) server that enables AI models to interact with Bitcoin, allowing them to generate keys, validate addresses, decode transactions, query the blockchain, and more.
 - [akseyh/bear-mcp-server](https://github.com/akseyh/bear-mcp-server) - Allows the AI to read from your Bear Notes (macOS only)


### PR DESCRIPTION
## Summary

Adds [fulfil-mcp](https://github.com/ExpertVagabond/fulfil-mcp) to **Other Tools**.

Fulfil.io ERP — 29 tools for inventory, orders, shipments, customers, purchase orders, and warehouses.

- Published on npm as [`fulfil-mcp`](https://www.npmjs.com/package/fulfil-mcp)
- Dockerfile included
- GitHub release created
- Glama score badge included