### PR TITLE
Add apple-shortcuts-mcp to Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Full coding agents that enable LLMs to read, edit, and execute code and solve ge
 Run commands, capture output and otherwise interact with shells and command line tools.
 
 - [danmartuszewski/hop](https://github.com/danmartuszewski/hop) 🏎️ 🖥️ - Fast SSH connection manager with TUI dashboard and MCP server for discovering, searching, and executing commands on remote hosts.
+- [ExpertVagabond/apple-shortcuts-mcp](https://github.com/ExpertVagabond/apple-shortcuts-mcp) [![ExpertVagabond/apple-shortcuts-mcp MCP server](https://glama.ai/mcp/servers/ExpertVagabond/apple-shortcuts-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ExpertVagabond/apple-shortcuts-mcp) 📇 🏠 🍎 - macOS Shortcuts automation — run shortcuts, clipboard, volume, speak, notifications, DND, screenshots, open apps, and system info.
 - [ferodrigop/forge](https://github.com/ferodrigop/forge) [![forge MCP server](https://glama.ai/mcp/servers/ferodrigop/forge/badges/score.svg)](https://glama.ai/mcp/servers/ferodrigop/forge) 📇 🏠 - Terminal MCP server for AI coding agents with persistent PTY sessions, ring-buffer incremental reads, headless xterm screen capture, multi-agent orchestration, and a real-time web dashboard.
 
 ### 💬 <a name="communication"></a>Communication


### PR DESCRIPTION
## Summary

Adds [apple-shortcuts-mcp](https://github.com/ExpertVagabond/apple-shortcuts-mcp) to **Command Line**.

macOS Shortcuts automation — run shortcuts, clipboard, volume, speak, notifications, DND, screenshots, open apps, system info.

- Published on npm as [`apple-shortcuts-mcp`](https://www.npmjs.com/package/apple-shortcuts-mcp)
- Dockerfile included
- GitHub release created
- Glama score badge included