### PR TITLE
Add Follow Up Boss MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1441,6 +1441,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [mindwear-capitian/followupboss-mcp-server](https://github.com/mindwear-capitian/followupboss-mcp-server) 📇 🏠 🍎 🪟 🐧 - 157-tool MCP server for Follow Up Boss CRM covering contacts, deals, pipeline, tasks, emails, smart lists, action plans, and webhooks for real estate professionals.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## New Server: Follow Up Boss MCP Server

**GitHub:** https://github.com/mindwear-capitian/followupboss-mcp-server
**Category:** Real Estate

157-tool MCP server for Follow Up Boss CRM covering contacts, deals, pipeline, tasks, emails, smart lists, action plans, and webhooks. Built for real estate professionals who use Follow Up Boss as their CRM.

- TypeScript/JavaScript codebase
- Local service (stdio)
- Cross-platform (macOS, Windows, Linux)
- Covers 100% of the Follow Up Boss API