### PR TITLE
feat: add agent-trade — MCP server for AI trading (Polymarket, Whales Market)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
+- [agent-trade](https://github.com/bigbearman/agent-trade) 📇 🏠 - MCP server for AI agent trading — any agent, any venue. Trade Polymarket prediction markets and Whales Market OTC pre-markets. Multi-chain: Solana + Polygon + 20+ EVM. Agent mode (auto-sign) + User mode (preview). Built-in spend limits and safety checks.
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.
 - [@frihet/mcp-server](https://github.com/Frihet-io/frihet-mcp) [![frihet-mcp MCP server](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp) 📇 ☁️ - AI-native business management — invoices, expenses, clients, products, and quotes. 31 tools for Claude, Cursor, Windsurf, and Cline.
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.


### PR DESCRIPTION
## New MCP Server: agent-trade

### Description
`agent-trade` is an MCP server enabling AI agents to trade across prediction markets, pre-markets, and DEXs through a single Model Context Protocol server.

### Links
- **Repository**: https://github.com/bigbearman/agent-trade
- **npm**: https://www.npmjs.com/package/agent-trade (pending publish)

### Features
- 🔌 **Multi-venue** — One MCP server, multiple trading venues
- 🤖 **Agent Mode** — Auto-sign trades with a dedicated wallet
- 👤 **User Mode** — Preview trades, sign manually  
- 🛡️ **Safety built-in** — Spend limits, price sanity checks, persistent tracking
- 🔗 **Multi-chain** — Solana, Polygon, 20+ EVM chains
- 📖 **Read-only works instantly** — No API keys needed for market data

### Supported Venues
| Venue | Type | Chain |
|-------|------|-------|
| Polymarket | Prediction Market | Polygon |
| Whales Market | Pre-market OTC | Solana, 20+ EVM |

### Quick Start
```json
{
  "mcpServers": {
    "agent-trade": {
      "command": "npx",
      "args": ["-y", "agent-trade"]
    }
  }
}
```

### Checklist
- [x] Repository is public
- [x] MIT License
- [x] README with clear description and usage
- [x] Works with npx (zero install)
- [x] First-mover in multi-venue MCP trading category