### PR TITLE
Add Verilex Data MCP server (20 datasets, x402 payments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 
 Data Platforms for data integration, transformation and pipeline orchestration.
 
-- [carrierone/verilexdata-mcp](https://github.com/carrierone/verilexdata-mcp) 📇 ☁️ - 20 structured datasets (NPI healthcare, SEC filings, OFAC sanctions, crypto whales, Polymarket signals, patents, economic indicators) via x402 pay-per-query with USDC. Free stats/sample endpoints, MCP + HTTP transport.
+- [carrierone/verilexdata-mcp](https://github.com/carrierone/verilexdata-mcp) [![carrierone/verilexdata-mcp MCP server](https://glama.ai/mcp/servers/carrierone/verilexdata-mcp/badges/score.svg)](https://glama.ai/mcp/servers/carrierone/verilexdata-mcp) 📇 ☁️ - 20 structured datasets (NPI healthcare, SEC filings, OFAC sanctions, crypto whales, Polymarket signals, patents, economic indicators) via x402 pay-per-query with USDC. Free stats/sample endpoints, MCP + HTTP transport.
 - [alkemiai/alkemi-mcp](https://github.com/alkemi-ai/alkemi-mcp) 📇 ☁️ - MCP Server for natural language querying of Snowflake, Google BigQuery, and DataBricks Data Products through Alkemi.ai.
 - [avisangle/method-crm-mcp](https://github.com/avisangle/method-crm-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Production-ready MCP server for Method CRM API integration with 20 comprehensive tools for tables, files, users, events, and API key management. Features rate limiting, retry logic, and dual transport support (stdio/HTTP).
 - [aywengo/kafka-schema-reg-mcp](https://github.com/aywengo/kafka-schema-reg-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Comprehensive Kafka Schema Registry MCP server with 48 tools for multi-registry management, schema migration, and enterprise features.


### PR DESCRIPTION
## Verilex Data MCP Server

**GitHub:** https://github.com/carrierone/verilexdata-mcp
**Website:** https://verilexdata.com
**Smithery:** https://smithery.ai/servers/carrierone/verilexdata-mcp

### What it does
20 structured datasets accessible via MCP with x402 crypto micropayments (USDC on Base chain). No API keys needed — free endpoints work immediately, paid endpoints use x402 pay-per-query.

### Datasets include
- **Government:** NPI (9M healthcare providers), SEC filings, PACER courts, patents (1.6M), gov contracts, weather
- **Crypto:** OFAC sanctions screening, whale tracking, address labels, token holders, DEX trades, DeFi liquidation signals
- **Prediction Markets:** Polymarket smart money, cross-platform arbitrage (AI-powered), resolution intelligence, microstructure

### Features
- 50+ MCP tools with zod schemas
- Stale data detection via `X-Data-Stale` response headers
- Change feed endpoints (`?since=` for efficient polling)
- Streamable HTTP transport at `https://api.verilexdata.com/mcp`
- stdio transport via `npx github:carrierone/verilexdata-mcp`