### PR TITLE
Add codebeamer-mcp to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 
 Tools and integrations that enhance the development workflow and environment management.
 
+- [3KniGHtcZ/codebeamer-mcp](https://github.com/3KniGHtcZ/codebeamer-mcp) [![codebeamer-mcp MCP server](https://glama.ai/mcp/servers/3KniGHtcZ/codebeamer-mcp/badges/score.svg)](https://glama.ai/mcp/servers/3KniGHtcZ/codebeamer-mcp) 📇 ☁️ 🍎 🪟 🐧 - Codebeamer ALM integration for managing work items, trackers, and projects. Provides 17 tools for reading and writing items, associations, references, comments, and risk management data via Codebeamer REST API v3.
 - [21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp) - Create crafted UI components inspired by the best 21st.dev design engineers.
 - [a-25/ios-mcp-code-quality-server](https://github.com/a-25/ios-mcp-code-quality-server) 📇 🏠 🍎 - iOS code quality analysis and test automation server. Provides comprehensive Xcode test execution, SwiftLint integration, and detailed failure analysis. Operates in both CLI and MCP server modes for direct developer usage and AI assistant integration.
 - [AaronVick/ECHO_RIFT_MCP](https://github.com/AaronVick/ECHO_RIFT_MCP) 📇 ☁️ - MCP server for EchoRift infrastructure primitives (BlockWire, CronSynth, Switchboard, Arbiter). Makes EchoRift's agent infrastructure callable as MCP tools so any MCP client can treat EchoRift like a native capability layer.


### PR DESCRIPTION
## Summary

Adds [codebeamer-mcp](https://github.com/3KniGHtcZ/codebeamer-mcp) to the Developer Tools category.

**codebeamer-mcp** is a TypeScript MCP server for [Codebeamer ALM](https://codebeamer.com/) integration. It provides 17 tools for reading and writing work items, trackers, projects, associations, traceability references, comments, and risk management data via Codebeamer REST API v3.

- **Language:** TypeScript
- **License:** MIT
- **npm:** [`codebeamer-mcp`](https://www.npmjs.com/package/codebeamer-mcp)
- **Glama:** Listed and verified

Follows the contribution guidelines — entry placed in alphabetical order with correct badges and Glama score badge.