### PR TITLE
Add actual-budget-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [xxczaki/local-history-mcp](https://github.com/xxczaki/local-history/mcp) 📇 🏠 🍎 🪟 🐧  - MCP server for accessing VS Code/Cursor Local History
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
+- [henfrydls/actual-budget-mcp](https://github.com/henfrydls/actual-budget-mcp) 📇 🏠 🍎 🪟 🐧 - Talk to your Actual Budget through Claude. 18 tools for reading, analyzing, and managing personal finances with natural language dates (EN/ES), name resolution, and formatted output.
 
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.
 - [@frihet/mcp-server](https://github.com/Frihet-io/frihet-mcp) [![frihet-mcp MCP server](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp) 📇 ☁️ - AI-native business management — invoices, expenses, clients, products, and quotes. 31 tools for Claude, Cursor, Windsurf, and Cline.


### PR DESCRIPTION
## New MCP Server: actual-budget-mcp

**Repository:** https://github.com/henfrydls/actual-budget-mcp
**npm:** https://www.npmjs.com/package/actual-budget-mcp
**Language:** TypeScript
**Scope:** Local

### Description

MCP server for [Actual Budget](https://actualbudget.org/) — talk to your budget through Claude. 18 tools for reading, analyzing, and managing personal finances.

### Key Features

- Natural language dates in English and Spanish ("last month", "este mes", "hace 3 meses")
- Name resolution — use account/category names instead of UUIDs
- Budget analysis tools: budget vs actual, spending projections, category trends
- Formatted table output, not raw JSON
- Clear error messages with instructions on how to fix

### Install

```bash
npx -y actual-budget-mcp
```