### PR TITLE
Add devtools-mcp: 25 developer tools MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
+- [Rih0z/devtools-mcp](https://github.com/Rih0z/devtools-mcp) 📇 🏠 - 25 developer tools (JSON format/validate/to-yaml/to-typescript, Base64, URL/HTML encode, hash, UUID, JWT decode, chmod, timestamps, CSV↔JSON, regex, case convert). All local processing, 46 tests.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
## New Server: devtools-mcp

**Category**: Developer Tools

MCP server providing 25 developer tools. JSON format/validate/to-yaml/to-typescript, Base64, URL/HTML encode, hash, UUID, JWT decode, chmod, timestamps, CSV to JSON, regex, case convert. All local processing, 46 tests, MCP spec compliant.

**Install**: git clone https://github.com/Rih0z/devtools-mcp

**Language**: TypeScript | **Scope**: Local