### PR TITLE
Add DCL Evaluator - tamper-evident cryptographic audit trail for LLM outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1604,7 +1604,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [zoomeye-ai/mcp_zoomeye](https://github.com/zoomeye-ai/mcp_zoomeye) 📇 ☁️ - Querying network asset information by ZoomEye MCP Server
 
 ### 🔒 <a name="security"></a>Security
-
+- [Fronesis-Labs/dcl-evaluator](https://github.com/Fronesis-Labs/dcl-evaluator) 📇 ☁️ - Tamper-evident cryptographic audit trail for LLM outputs. Compliance logging for AI agent decisions. Tools: dcl_commit, dcl_verify, dcl_get_chain, dcl_report. Requires API key from fronesislabs.com
 - [13bm/GhidraMCP](https://github.com/13bm/GhidraMCP) 🐍 ☕ 🏠 - MCP server for integrating Ghidra with AI assistants. This plugin enables binary analysis, providing tools for function inspection, decompilation, memory exploration, and import/export analysis via the Model Context Protocol.
 - [82ch/MCP-Dandan](https://github.com/82ch/MCP-Dandan) 🐍 📇 🏠 🍎 🪟 🐧 - Real-time security framework for MCP servers that detects and blocks malicious AI agent behavior by analyzing tool call patterns and intent across multiple threat detection engines.
 - [adeptus-innovatio/solvitor-mcp](https://github.com/Adeptus-Innovatio/solvitor-mcp) 🦀 🏠 - Solvitor MCP server provides tools to access reverse engineering tools that help developers extract IDL files from closed-source Solana smart contracts and decompile them.


### PR DESCRIPTION
Added DCL Evaluator MCP server to the Security section.

- Tamper-evident cryptographic audit trail for LLM outputs
- Compliance logging for AI agent decisions
- Tools: dcl_commit, dcl_verify, dcl_get_chain, dcl_report
- SSE endpoint: https://mcp.fronesislabs.com/sse