### PR TITLE
Add aegis-defi - DeFi safety MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2016,4 +2016,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 
-- [aegis-defi](https://github.com/StanleytheGoat/aegis) - Safety layer for autonomous DeFi agents. Scans contracts for exploit patterns, simulates transactions, blocks honeypots. `npx aegis-defi`
+- [StanleytheGoat/aegis](https://github.com/StanleytheGoat/aegis) 📇 - Safety layer for autonomous DeFi agents. Scans contracts for exploit patterns, simulates transactions, blocks honeypots. `npx aegis-defi`


### PR DESCRIPTION
Adds [aegis-defi](https://github.com/StanleytheGoat/aegis), an MCP server that protects AI agents from DeFi exploits.

Scans contracts for 12 exploit patterns (honeypots, rug pulls, reentrancy), simulates transactions on forked chains, and enforces safety on-chain via verified smart contracts on Base.

- **npm**: `npx aegis-defi`
- **GitHub**: https://github.com/StanleytheGoat/aegis
- **Website**: https://aegis-defi.netlify.app
- **Contracts**: Deployed and verified on Base mainnet