### PR TITLE
Add feenlace/mcp-1c - 1C:Enterprise MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [edwinbernadus/nocodb-mcp-server](https://github.com/edwinbernadus/nocodb-mcp-server) 📇 ☁️ - Nocodb database integration, read and write capabilities
 - [ergut/mcp-bigquery-server](https://github.com/ergut/mcp-bigquery-server) 📇 ☁️ - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 - [f4ww4z/mcp-mysql-server](https://github.com/f4ww4z/mcp-mysql-server) 📇 🏠 - Node.js-based MySQL database integration that provides secure MySQL database operations
+- [feenlace/mcp-1c](https://github.com/feenlace/mcp-1c) 🏎️ 🏠 - 1C:Enterprise integration with metadata inspection, BSL code search, query execution, event log access, and syntax reference. One binary, zero dependencies.
 - [ferrants/memvid-mcp-server](https://github.com/ferrants/memvid-mcp-server) 🐍 🏠 - Python Streamable HTTP Server you can run locally to interact with [memvid](https://github.com/Olow304/memvid) storage and semantic search.
 - [fireproof-storage/mcp-database-server](https://github.com/fireproof-storage/mcp-database-server) 📇 ☁️ - Fireproof ledger database with multi-user sync
 - [freema/mcp-gsheets](https://github.com/freema/mcp-gsheets) 📇 ☁️ - MCP server for Google Sheets API integration with comprehensive reading, writing, formatting, and sheet management capabilities.


### PR DESCRIPTION
## What is mcp-1c?

MCP server for [1C:Enterprise](https://1c.ru) - the most widely used business platform in Russia (ERP, accounting, HR, CRM). 

AI assistant gets access to your 1C database: metadata inspection, BSL code search, query execution, event log, syntax reference. One Go binary, zero dependencies, 9 tools.

**GitHub:** https://github.com/feenlace/mcp-1c  
**License:** MIT  
**Language:** Go