### PR TITLE
add server to developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
+- [webslop.ai/mcp][https://webslop.ai/mcp] 🐍 🏠 🍎 🪟 🐧 - AI first app deployment, unlike lovable or figma make, webslop.ai lets you or your ai of choice setup node.ja apps or static sites in seconds. 
 
 ### 🔒 <a name="delivery"></a>Delivery
 

--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
-- [webslop.ai/mcp][https://webslop.ai/mcp] 🐍 🏠 🍎 🪟 🐧 - AI first app deployment, unlike lovable or figma make, webslop.ai lets you or your ai of choice setup node.ja apps or static sites in seconds. 
+- [webslop.ai/mcp][https://webslop.ai/mcp] 🐍 🏠 🍎 🪟 🐧 - AI first app deployment, unlike lovable or figma make, webslop.ai lets you or your ai of choice setup node.js apps or static sites in seconds. 
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
THanks for making this repo! I added my new web based app deployment and editor system.

Here is more info about it in-case you are interested! I also posted this in the discord. I came here from your post on reddit about the open source bot problem. 

AI first app deployment, unlike lovable or figma make, webslop.ai lets you or your ai setup node.js apps or static sites in seconds. Designed be be the perfect place for you to deploy websites and apps super fast to the rest of the world and has a generous free tier. Fully integrated with your favourite CLI with MCP, and you can even run Claude code/codex inside the web app through the terminal interface (xterm.js), we are also working on a better chat wrapper for your favourite ai CLI to run in the cloud too. It’s got too many features to mention but some include: 

unlimited apps
static sites are completely free
free SSL,
instant domains like my-app.webslop.ai (custom domain support too),
real-time collaboration with a full web based editor based on Monaco,
volume sharing between apps,
ready made extensions and service templates ready to deploy,
full git integration in all directions,
fine grained access control
clause and codex built in (can run inside the app) with MCP and skills ready to go.
enterprise team options too

any many many more..

https://webslop.ai/ 
Anyone familiar with glitch.com which shutdown last year will feel right at home.