### PR TITLE
Add gwbtc/urbit-mcp to Other Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1883,6 +1883,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
 - [growilabs/growi-mcp-server](https://github.com/growilabs/growi-mcp-server) 🎖️ 📇 ☁️ - Official MCP Server to integrate with GROWI APIs.
 - [gwbischof/free-will-mcp](https://github.com/gwbischof/free-will-mcp) 🐍 🏠 - Give your AI free will tools. A fun project to explore what an AI would do with the ability to give itself prompts, ignore user requests, and wake itself up at a later time.
+- [gwbtc/urbit-mcp](https://github.com/gwbtc/urbit-mcp) - User-extensible, general-purpose MCP interface for [Urbit](https://docs.urbit.org), a networked personal server.
 - [Harry-027/JotDown](https://github.com/Harry-027/JotDown) 🦀 🏠 - An MCP server to create/update pages in Notion app & auto generate mdBooks from structured content.
 - [henilcalagiya/mcp-apple-notes](https://github.com/henilcalagiya/mcp-apple-notes) 🐍 🏠 - Powerful tools for automating Apple Notes using Model Context Protocol (MCP). Full CRUD support with HTML content, folder management, and search capabilities.
 - [HenryHaoson/Yuque-MCP-Server](https://github.com/HenryHaoson/Yuque-MCP-Server) - 📇 ☁️ A Model-Context-Protocol (MCP) server for integrating with Yuque API, allowing AI models to manage documents, interact with knowledge bases, search content, and access analytics data from the Yuque platform.

--- a/README.md
+++ b/README.md
@@ -1883,7 +1883,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
 - [growilabs/growi-mcp-server](https://github.com/growilabs/growi-mcp-server) 🎖️ 📇 ☁️ - Official MCP Server to integrate with GROWI APIs.
 - [gwbischof/free-will-mcp](https://github.com/gwbischof/free-will-mcp) 🐍 🏠 - Give your AI free will tools. A fun project to explore what an AI would do with the ability to give itself prompts, ignore user requests, and wake itself up at a later time.
-- [gwbtc/urbit-mcp](https://github.com/gwbtc/urbit-mcp) - User-extensible, general-purpose MCP interface for [Urbit](https://docs.urbit.org), a networked personal server.
+- [gwbtc/urbit-mcp](https://github.com/gwbtc/urbit-mcp) ☁️🏠🍎🪟🐧 - User-extensible, general-purpose MCP interface for [Urbit](https://docs.urbit.org), a networked personal server.
 - [Harry-027/JotDown](https://github.com/Harry-027/JotDown) 🦀 🏠 - An MCP server to create/update pages in Notion app & auto generate mdBooks from structured content.
 - [henilcalagiya/mcp-apple-notes](https://github.com/henilcalagiya/mcp-apple-notes) 🐍 🏠 - Powerful tools for automating Apple Notes using Model Context Protocol (MCP). Full CRUD support with HTML content, folder management, and search capabilities.
 - [HenryHaoson/Yuque-MCP-Server](https://github.com/HenryHaoson/Yuque-MCP-Server) - 📇 ☁️ A Model-Context-Protocol (MCP) server for integrating with Yuque API, allowing AI models to manage documents, interact with knowledge bases, search content, and access analytics data from the Yuque platform.


### PR DESCRIPTION
Adds [Urbit MCP](https://github.com/gwbtc/urbit-mcp) to *Other Tools & Integrations* section. 

[Urbit](https://docs.urbit.org/) is a general-purpose networked personal server and Urbit MCP is a general, extensible MCP interface for that server. Users and third-party app developers can add new tools into Urbit MCP, but its out-of-the-box Tools are mostly focussed on writing, testing, and deploying software on Urbit. Resources include some helpful docs. Prompts include reusable snippets for common development tasks.

Urbit MCP's `poke-agent` and `scry-agent` Tools allow AI agents to read and write to any app on the user's Urbit server; models like Claude Sonnet 4.6 are good at simply reading the app code and figuring out the correct input. Urbit MCP also comes with Tools to add new Tools, Resources, and Prompts to the MCP server itself. Have Claude Sonnet or Opus read the Urbit MCP code, then write and deploy a Tool for some task, and it becomes more reliable for a less capable model that can make a simple tool call.