### PR TITLE
Add sheetsdata-mcp — electronic component datasheets for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.
+- [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp) 🐍 ☁️ 📟 - Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 


### PR DESCRIPTION
## What

Adds [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp) to the **Embedded System** section.

## About SheetsData MCP

MCP server that gives AI agents instant access to electronic component datasheets — specs, pinouts, package info, absolute max ratings — extracted from manufacturer PDFs on demand. No uploads required.

- **10 tools** including search_parts, read_datasheet, compare_parts, check_design_fit, find_alternative, analyze_image
- **Remote server** (Streamable HTTP) + npm stdio proxy
- **Published on** the official MCP Registry as `io.github.octoco-ltd/sheetsdata-mcp`
- **Website:** https://sheetsdata.com