### PR TITLE
Add SheetsData MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.
+- [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp) [![sheetsdata-mcp MCP server](https://glama.ai/mcp/servers/octoco-ltd/sheetsdata-mcp/badges/score.svg)](https://glama.ai/mcp/servers/octoco-ltd/sheetsdata-mcp) 🐍 ☁️ 🍎 🪟 🐧 - Electronic component datasheets for AI agents — search parts across JLCPCB, Mouser, DigiKey, read structured datasheet sections (pinout, electrical, package), compare parts, and validate designs against datasheet limits. No PDFs required.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 


### PR DESCRIPTION
## Server Information

- **Name:** SheetsData
- **Repository:** https://github.com/octoco-ltd/sheetsdata-mcp
- **Glama:** https://glama.ai/mcp/servers/octoco-ltd/sheetsdata-mcp
- **Category:** Embedded System
- **Language:** Python (🐍)
- **Scope:** Cloud (☁️)
- **Platforms:** macOS (🍎), Windows (🪟), Linux (🐧)

## Description

Electronic component datasheets for AI agents — specs, pinouts, package data on demand. No PDFs required.

SheetsData gives AI agents instant, structured access to electronic component data extracted from manufacturer datasheets. Search parts across JLCPCB, Mouser, and DigiKey. Read structured datasheet sections (pinout, electrical, package). Compare parts side by side. Validate designs against datasheet limits.

**10 tools:** `search_parts`, `search_datasheets`, `prefetch_datasheets`, `check_extraction_status`, `get_part_details`, `read_datasheet`, `compare_parts`, `check_design_fit`, `find_alternative`, `analyze_image`

## Links

- Website: https://sheetsdata.com
- npm: https://www.npmjs.com/package/@sheetsdata/mcp
- MCP Registry: https://registry.modelcontextprotocol.io