### PR TITLE
Add csvglow to Data Visualization 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 Interactive charts, dashboards, and visual data tools rendered inside AI conversations.
 
 - [KyuRish/mcp-dashboards](https://github.com/KyuRish/mcp-dashboards) [![mcp-dashboards MCP server](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards/badges/score.svg)](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards) 📇 🏠 🍎 🪟 🐧 - 45+ interactive chart types (bar, line, pie, candlestick, sankey, geo, radar, funnel, treemap, and more), dashboards with KPI cards, drill-down navigation, live API polling, 20 themes, and export to PNG/PPT/A4. Built on MCP Apps.
+- [Ratnaditya-J/csvglow](https://github.com/Ratnaditya-J/csvglow) [![csvglow MCP server](https://glama.ai/mcp/servers/Ratnaditya-J/csvglow/badges/score.svg)](https://glama.ai/mcp/servers/Ratnaditya-J/csvglow) 🐍 🏠 🍎 🪟 🐧 - Generate beautiful self-contained HTML dashboards from CSV/Excel files with interactive ECharts visualizations, dark gradient theme, and sortable data tables.
 
 ### 📟 <a name="embedded-system"></a>Embedded System
 


### PR DESCRIPTION
Adds [csvglow](https://github.com/Ratnaditya-J/csvglow) to the **Data Visualization** section.

**csvglow** is a Python CLI + MCP server that generates beautiful self-contained HTML dashboards from CSV/Excel files using ECharts with a dark gradient theme.

- **Repo:** https://github.com/Ratnaditya-J/csvglow
- **Category:** Data Visualization
- **Language:** Python 🐍
- **Scope:** Local 🏠
- **Platforms:** macOS 🍎, Windows 🪟, Linux 🐧
- **Glama:** https://glama.ai/mcp/servers/Ratnaditya-J/csvglow