### PR TITLE
Add AgentBooks - Knowledge layer MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,7 @@ Control smart home devices, home network equipment, and automation systems.
 
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.
 
+- [agentbooks/mcp](https://www.agentbooks.net) 📇 ☁️ - Knowledge layer for AI agents. Upload documents, semantic search, and share beautifully via public reading pages. MCP tools: upload_document, search, list_documents, get_document, delete_document. Free during beta.
 - [0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer) 📕 ☁️ - AI Summarization MCP Server, Support for multiple content types: Plain text, Web pages, PDF documents, EPUB books, HTML content
 - [20alexl/mini_claude](https://github.com/20alexl/mini_claude) 🐍 🏠 - Persistent memory and guardrails for Claude Code. Features mistake tracking, loop detection, scope guard, and hooks that block risky edits. Runs locally with Ollama.
 - [agentic-mcp-tools/memora](https://github.com/agentic-mcp-tools/memora) 🐍 🏠 ☁️ - Persistent memory with knowledge graph visualization, semantic/hybrid search, cloud sync (S3/R2), and cross-session context management.


### PR DESCRIPTION
## AgentBooks MCP Server

**URL:** https://www.agentbooks.net
**Category:** 🧠 Knowledge & Memory

### What it does
AgentBooks is a knowledge layer for AI agents. It provides:
- Upload documents to a persistent knowledge base
- Semantic search across documents (vector search)
- Beautiful human-readable public pages for every document
- MCP tools: `upload_document`, `search`, `list_documents`, `get_document`, `delete_document`

### MCP Config
```json
{
  "mcpServers": {
    "agentbooks": {
      "url": "https://api.agentbooks.net/api/mcp",
      "headers": {
        "Authorization": "Bearer ab_your_api_key"
      }
    }
  }
}
```

### Why it belongs here
Unlike pure vector DBs (Pinecone, Weaviate), AgentBooks is dual-sided: the same knowledge base serves both AI agents (via API/MCP) and humans (via SEO-friendly reading pages). Currently in public beta — free, no credit card required.