### PR TITLE
Add openobserve-community-mcp to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1452,6 +1452,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.
 
+- [alilxxey/openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) 🐍 🏠 🍎 🪟 🐧 - Read-only MCP server for OpenObserve Community Edition via REST API. Search logs, traces, stream schemas, and dashboards without requiring the Enterprise license.
 - [Alog/alog-mcp](https://github.com/saikiyusuke/alog-mcp) 📇 ☁️ - AI agent activity logger & monitor MCP server with 20 tools. Post logs, create articles, manage social interactions, and monitor AI agent activities on the Alog platform.
 - [avivsinai/langfuse-mcp](https://github.com/avivsinai/langfuse-mcp) 🐍 ☁️ - Query Langfuse traces, debug exceptions, analyze sessions, and manage prompts. Full observability toolkit for LLM applications.
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Leverage AI-driven observability, security, and automation to analyze anomalies, logs, traces, events, metrics.


### PR DESCRIPTION
Adds [openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) to the Monitoring section.
                                                                                                                            
  A read-only MCP server for OpenObserve Community Edition that works over the REST API. Provides tools for searching logs,
  traces, stream schemas, and dashboards — no Enterprise license required.                                                  
                                                                          
  - Language: Python                                                                                                        
  - Scope: Local (stdio transport)
  - Platforms: macOS, Windows, Linux
  - Published on PyPI: `openobserve-community-mcp`