### PR TITLE
Add Scout — 57-tool browser automation MCP server (Go)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [eat-pray-ai/yutu](https://github.com/eat-pray-ai/yutu) 🏎️ 🏠 🍎 🐧 🪟 - A fully functional MCP server and CLI for YouTube to automate YouTube operation
 - [executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright) 📇 - An MCP server using Playwright for browser automation and webscrapping
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
+- [felixgeelhaar/scout](https://github.com/felixgeelhaar/scout) 🏎️ 🏠 - Single-binary MCP server with 57 tools for browser automation. Pure Chrome DevTools Protocol, DOM diffing (50-80% token savings), 5-level content distillation, semantic form filling, annotated screenshots, and Gin-like middleware. No Node.js, no Python.
 - [fradser/mcp-server-apple-reminders](https://github.com/FradSer/mcp-server-apple-reminders) 📇 🏠 🍎 - An MCP server for interacting with Apple Reminders on macOS
 - [freema/firefox-devtools-mcp](https://github.com/freema/firefox-devtools-mcp) 📇 🏠 - Firefox browser automation via WebDriver BiDi for testing, scraping, and browser control. Supports snapshot/UID-based interactions, network monitoring, console capture, and screenshots.
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 📇 🏠 - Extract structured data from any website. Just prompt and get JSON.


### PR DESCRIPTION
## What is Scout?

[Scout](https://github.com/felixgeelhaar/scout) is a single-binary MCP server written in Go that gives AI agents a browser. It implements the Chrome DevTools Protocol directly over WebSocket — no rod, no chromedp, no Node.js, no Python.

## Why it belongs in Browser Automation

- **57 MCP tools** covering navigation, interaction, forms, extraction, screenshots, network capture, multi-tab, playbook recording, and framework detection
- **Token-efficient by design**: DOM diffing saves 50-80% tokens, 5 levels of content distillation, screenshot auto-compression
- **Agent-first**: structured JSON output, semantic form filling, annotated screenshots with clickable labels, token budgets
- **Single binary**: `brew install felixgeelhaar/tap/scout` — no runtime dependencies
- **Gin-like middleware**: retry, timeout, circuit breaker, rate limit, bulkhead, stealth

## Install

```bash
brew install felixgeelhaar/tap/scout
claude mcp add scout -- scout mcp serve
```

MIT licensed. Landing page: https://felixgeelhaar.github.io/scout/