### PR TITLE
Add 01protocol MCP server — AI agent identity (Ed25519, .01ai) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,6 +1666,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔒 <a name="security"></a>Security
 
+- [01ai-Admin/01ai_01protocol_mcp](https://github.com/01ai-Admin/01ai_01protocol_mcp) 📇 🏠 🍎 🪟 🐧 - Portable, cryptographically verifiable AI agent identity. Create and verify Ed25519-signed agent identities (.01ai), manage Merkle-anchored memory vaults, issue delegation tokens, and enforce consent policies — via Claude Desktop or TypeScript/Python SDK.
 - [13bm/GhidraMCP](https://github.com/13bm/GhidraMCP) 🐍 ☕ 🏠 - MCP server for integrating Ghidra with AI assistants. This plugin enables binary analysis, providing tools for function inspection, decompilation, memory exploration, and import/export analysis via the Model Context Protocol.
 - [82ch/MCP-Dandan](https://github.com/82ch/MCP-Dandan) 🐍 📇 🏠 🍎 🪟 🐧 - Real-time security framework for MCP servers that detects and blocks malicious AI agent behavior by analyzing tool call patterns and intent across multiple threat detection engines.
 - [adeptus-innovatio/solvitor-mcp](https://github.com/Adeptus-Innovatio/solvitor-mcp) 🦀 🏠 - Solvitor MCP server provides tools to access reverse engineering tools that help developers extract IDL files from closed-source Solana smart contracts and decompile them.


### PR DESCRIPTION
## 01 Protocol MCP Server

Adds the [01protocol MCP server](https://github.com/01ai-Admin/01ai_01protocol_mcp) to the Security category.

**What it does:** Portable, cryptographically verifiable AI agent identity for Claude Desktop and MCP-compatible apps. Create Ed25519-signed agent identities (.01ai files), manage Merkle-anchored memory vaults, issue delegation tokens, and enforce consent policies — without leaving the conversation.

**Category:** Security — agent identity and cryptographic verification

**Languages:** TypeScript (MCP server + SDK), Python (SDK)

**Scope:** Local service (stdio transport, offline-first verification)