### PR TITLE
feat: add AgentSIM — real SIM-backed phone numbers for AI agent OTP verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ See [Helpful Tools & Utilities](#helpful-tools-&-utilities) section for tools to
 - <img src="https://cdn.simpleicons.org/atlassian/0052CC" height="14"/> [Atlassian](https://github.com/sooperset/mcp-atlassian) - Comprehensive integration with Atlassian suite including Confluence for documentation management and Jira for issue tracking.
 - <img src="https://carbonvoice.app/favicon.ico" height="14"/> [Carbon Voice](https://github.com/PhononX/cv-mcp-server)<sup><sup>⭐</sup></sup> - MCP Server that connects AI Agents to [Carbon Voice](https://getcarbon.app). Create, manage, and interact with voice messages, conversations, direct messages, folders, voice memos, AI actions and more in [Carbon Voice](https://getcarbon.app).
 - <img src="https://m2tg1pnwn0.ufs.sh/f/GMqNN8nd9I8l9tUbmif1CnFX8Baqr7mHeicYu0AULDyNVWJE" height="14"/> [ntfy](https://github.com/gitmotion/ntfy-me-mcp) - An ntfy MCP server for sending/fetching ntfy notifications to your self-hosted ntfy.sh server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)
+- <img src="https://agentsim.dev/favicon.ico" height="14"/> [AgentSIM](https://github.com/agentsimdev/agentsim-mcp) - Provision real SIM-backed mobile numbers for AI agents to receive SMS and OTP codes. Bypasses VoIP blocks that reject Twilio/Vonage numbers. Hosted MCP server with HTTP transport.
 
 <br />
 


### PR DESCRIPTION
## AgentSIM

**Category:** 💬 Communication

AgentSIM provisions real SIM-backed mobile numbers for AI agents that need to pass SMS OTP verification. Unlike Twilio, Vonage, or any VoIP service, AgentSIM numbers return `line_type: mobile` on carrier lookup — meaning they pass the carrier check that blocks VoIP numbers on most services (Stripe, Google, banks, etc.).

**Links:**
- GitHub: https://github.com/Fato07/agentsim
- Docs: https://docs.agentsim.dev
- MCP server: https://mcp.agentsim.dev/mcp (cloud-hosted, HTTP transport)

**Checklist:**
- [x] Server is live and accessible
- [x] Python package on PyPI: `agentsim-mcp` (`uvx agentsim-mcp`)
- [x] npm wrapper: `@agentsim/mcp-server` (`npx @agentsim/mcp-server`)
- [x] TypeScript SDK: `@agentsim/sdk`
- [x] Python SDK: `agentsim`
- [x] Free tier available (10 sessions/month)
- [x] Entry placed alphabetically in Communication section