### PR TITLE
Add HadiCherkaoui/crafty-mcp to Gaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,7 +1289,7 @@ Integration with gaming related data, game engines, and services
 - [jhomen368/steam-reviews-mcp](https://github.com/jhomen368/steam-reviews-mcp) [![steam-reviews-mcp MCP server](https://glama.ai/mcp/servers/@jhomen368/steam-reviews-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@jhomen368/steam-reviews-mcp) 📇 ☁️ - Search Steam games, fetch user reviews, and analyze sentiment with topic drill-down to make informed purchasing decisions.
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
-- [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) 📇 🏠 🐧 🪟 🍎 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
+- [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adding crafty-mcp — an MCP server for Crafty Controller 4, the open-source Minecraft server management panel.

- **npm:** https://www.npmjs.com/package/crafty-mcp
- **GitHub:** https://github.com/HadiCherkaoui/crafty-mcp
- **Glama:** https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp

Covers 45+ tools wrapping the full Crafty Controller API V2: server lifecycle (start/stop/restart/backup), console commands, file management, scheduled tasks, webhooks, user/role management, and system stats.

This is the first MCP server for Crafty Controller.

[![HadiCherkaoui/crafty-mcp](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp)