### PR TITLE
Update LinkShrink to public MCP server repo 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [simplypixi/bugbug-mcp-server](https://github.com/simplypixi/bugbug-mcp-server) ☁️ - MCP for BugBug API, to manage test and suites on BugBug
 - [skullzarmy/vibealive](https://github.com/skullzarmy/vibealive) 📇 🏠 🍎 🪟 🐧 — Full-featured utility to test Next.js projects for unused files and APIs, with an MCP server that exposes project analysis tools to AI assistants.
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Connect any HTTP/REST API server using an Open API spec (v3)
-- [softvoyagers/linkshrink-api](https://github.com/softvoyagers/linkshrink-api) 📇 ☁️ - Free privacy-first URL shortener API with analytics and link management. No API key required.
+- [softvoyagers/linkshrink-api-mcp](https://github.com/softvoyagers/linkshrink-api-mcp) [![softvoyagers/linkshrink-api-mcp MCP server](https://glama.ai/mcp/servers/softvoyagers/linkshrink-api-mcp/badges/score.svg)](https://glama.ai/mcp/servers/softvoyagers/linkshrink-api-mcp) 📇 ☁️ - Free privacy-first URL shortener MCP server with analytics and link management. No API key required.
 - [softvoyagers/ogforge-api](https://github.com/softvoyagers/ogforge-api) 📇 ☁️ - Free Open Graph image generator API with themes, Lucide icons, and custom layouts. No API key required.
 - [softvoyagers/pagedrop-api](https://github.com/softvoyagers/pagedrop-api) 📇 ☁️ - Free instant HTML hosting API with paste, file upload, and ZIP deploy support. No API key required.
 - [softvoyagers/pdfspark-api](https://github.com/softvoyagers/pdfspark-api) 📇 ☁️ - Free HTML/URL to PDF conversion API powered by Playwright. No API key required.


### PR DESCRIPTION
## Summary
- Updates the existing LinkShrink entry from the private API repo (`softvoyagers/linkshrink-api`) to the public MCP server repo (`softvoyagers/linkshrink-api-mcp`)
- Adds Glama score badge
- Updates description to reflect MCP server functionality

The MCP server repo is public and published on npm as `linkshrink-mcp`. It provides tools for shortening URLs, getting analytics, and unshortening links.

- GitHub: https://github.com/softvoyagers/linkshrink-api-mcp
- npm: https://www.npmjs.com/package/linkshrink-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)