### PR TITLE
Add pty-mcp: Interactive PTY sessions with persistent SSH 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Run commands, capture output and otherwise interact with shells and command line
 
 - [danmartuszewski/hop](https://github.com/danmartuszewski/hop) 🏎️ 🖥️ - Fast SSH connection manager with TUI dashboard and MCP server for discovering, searching, and executing commands on remote hosts.
 - [nvms/tui-mcp](https://github.com/nvms/tui-mcp) [![tui-mcp MCP server](https://glama.ai/mcp/servers/nvms/tui-mcp/badges/score.svg)](https://glama.ai/mcp/servers/nvms/tui-mcp) 📇 🏠 🍎 🪟 🐧 - What Chrome DevTools MCP is for the browser, tui-mcp is for the terminal. Launch, screenshot, and interact with any TUI app.
-- [raychao-oao/pty-mcp](https://github.com/raychao-oao/pty-mcp) 🏎️ 🏠 🍎 🐧 - Interactive PTY sessions for AI agents — local shells, SSH with persistent sessions (ai-tmux daemon for attach/detach), and serial ports. Single Go binary, no tmux dependency.
+- [raychao-oao/pty-mcp](https://github.com/raychao-oao/pty-mcp) [![pty-mcp MCP server](https://glama.ai/mcp/servers/raychao-oao/pty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/raychao-oao/pty-mcp) 🏎️ 🏠 🍎 🐧 - Interactive PTY sessions for AI agents — local shells, SSH with persistent sessions (ai-tmux daemon for attach/detach), and serial ports. Single Go binary, no tmux dependency.
 - [ferodrigop/forge](https://github.com/ferodrigop/forge) [![forge MCP server](https://glama.ai/mcp/servers/ferodrigop/forge/badges/score.svg)](https://glama.ai/mcp/servers/ferodrigop/forge) 📇 🏠 - Terminal MCP server for AI coding agents with persistent PTY sessions, ring-buffer incremental reads, headless xterm screen capture, multi-agent orchestration, and a real-time web dashboard.
 
 ### 💬 <a name="communication"></a>Communication


### PR DESCRIPTION
## Summary

- Adding [raychao-oao/pty-mcp](https://github.com/raychao-oao/pty-mcp) to the Shell section
- MCP server providing interactive PTY sessions for AI agents — local shells, SSH with persistent sessions (ai-tmux daemon), and serial ports
- Single Go binary, no tmux dependency

## Key features that differentiate from existing entries

- **Unified interface** for local, SSH, and serial sessions
- **ai-tmux daemon** for persistent sessions that survive SSH disconnects (attach/detach)
- **No external dependency** on tmux — custom-built daemon for AI agents
- **Single Go binary** — easy to install and deploy