### PR TITLE
Add A2ASearch — searchable directory for MCP servers, agents and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
-- [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills from the A2ASearch directory. Ask Claude: "Find MCP servers for database access". No auth required, uses the free A2ASearch API.
+- [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills. Install: `npx -y a2asearch-mcp`. Ask Claude: "Find MCP servers for database access". Free, no auth required.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).
 - [AgentHotspot](https://github.com/AgentHotspot/agenthotspot-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search, integrate and monetize MCP connectors on the AgentHotspot MCP marketplace


### PR DESCRIPTION
Hi, I wanted to add [A2ASearch](https://a2asearch.ai) to the list.

It's a searchable directory I built specifically for the MCP ecosystem — currently indexing 4,800+ MCP servers, CLI tools, AI coding agents and agent skills.

**What it offers:**
- Full-text search across all entries
- Filter by type (MCP Server, CLI Tool, AI Coding Agent, Agent Skill)
- Free REST API with no auth needed, CORS enabled
- Each entry has README, stars, forks, languages pulled from GitHub

API example:
```
GET https://a2asearch.ai/api/v1/agents?type=MCP+Server&search=database
```

Happy to adjust the description or placement if needed.