### PR TITLE
Add oss-autopilot to Version Control section 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1892,6 +1892,7 @@ Access to travel and transportation information. Enables querying schedules, rou
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.
 
 - [adhikasp/mcp-git-ingest](https://github.com/adhikasp/mcp-git-ingest) 🐍 🏠 - Read and analyze GitHub repositories with your LLM
+- [costajohnt/oss-autopilot](https://github.com/costajohnt/oss-autopilot) [![costajohnt/oss-autopilot MCP server](https://glama.ai/mcp/servers/costajohnt/oss-autopilot/badges/score.svg)](https://glama.ai/mcp/servers/costajohnt/oss-autopilot) 📇 ☁️ 🏠 🍎 🪟 🐧 - Open source contribution manager with PR tracking across repos, issue discovery, CI failure diagnosis, and maintainer response drafting. Available as CLI, MCP server, and Claude Code plugin.
 - [ddukbg/github-enterprise-mcp](https://github.com/ddukbg/github-enterprise-mcp) 📇 ☁️ 🏠 - MCP server for GitHub Enterprise API integration
 - [gitea/gitea-mcp](https://gitea.com/gitea/gitea-mcp) 🎖️ 🏎️ ☁️ 🏠 🍎 🪟 🐧 - Interactive with Gitea instances with MCP.
 - [github/github-mcp-server](https://github.com/github/github-mcp-server) 📇 ☁️ - Official GitHub server for integration with repository management, PRs, issues, and more.


### PR DESCRIPTION
Adds [oss-autopilot](https://github.com/costajohnt/oss-autopilot) to the Version Control section with Glama score badge.

OSS Autopilot is an open source contribution manager that ships as a CLI, MCP server (`@oss-autopilot/mcp`), and Claude Code plugin. It provides 21 MCP tools, 5 resources, and 3 prompts for PR tracking across repos, issue discovery, CI failure diagnosis, and maintainer response drafting.

- TypeScript codebase (📇)
- Cloud service — GitHub API (☁️)
- Local service — CLI runs locally (🏠)
- Cross-platform (🍎 🪟 🐧)
- Glama badge included
- Entry placed in alphabetical order