### PR TITLE
Add NormaAI to Legal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,7 +1424,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act) [![mcp-eu-ai-act MCP server](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act/badges/score.svg)](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act) 📇 ☁️ - EU AI Act compliance scanner that detects regulatory violations in AI codebases with risk classification and remediation guidance.
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
-- [NormaAI](https://github.com/agenticsimpermeo/NormaAI) 📇 ☁️ - Italy's first AI legal API. Query 77,000+ normative documents across 5 practice areas (labor, tax, law, engineering, finance) with cited sources. `npm: @normaai/mcp-server`
+- [agenticsimpermeo/NormaAI](https://github.com/agenticsimpermeo/NormaAI) 📇 ☁️ - Italy's first AI legal API. Query 77,000+ normative documents across 5 practice areas (labor, tax, law, engineering, finance) with cited sources.
 - [philrox/ris-mcp-ts](https://github.com/philrox/ris-mcp-ts) [![philrox/ris-mcp-ts MCP server](https://glama.ai/mcp/servers/philrox/ris-mcp-ts/badges/score.svg)](https://glama.ai/mcp/servers/philrox/ris-mcp-ts) 📇 ☁️ - Access Austrian federal laws, state laws, court decisions, and legal documents via the RIS (Rechtsinformationssystem) API with 12 specialized tools.
 
 ### 🗺️ <a name="location-services"></a>Location Services


### PR DESCRIPTION
## Summary

Adds [NormaAI](https://github.com/agenticsimpermeo/NormaAI) to the **Legal** section.

NormaAI is Italy's first AI legal API — an MCP server that provides access to 77,000+ Italian normative documents across 5 practice areas (labor, tax, law, engineering, finance) with cited sources.

- **npm:** [@normaai/mcp-server](https://www.npmjs.com/package/@normaai/mcp-server)
- **License:** MIT
- **Transport:** stdio
- **Language:** TypeScript

The entry is placed in alphabetical order within the Legal section.