### PR TITLE
🤖🤖🤖 Add VBA MCP Server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [wyattjoh/jsr-mcp](https://github.com/wyattjoh/jsr-mcp) 📇 ☁️ - Model Context Protocol server for the JSR (JavaScript Registry)
 - [xcodebuild](https://github.com/ShenghaiWang/xcodebuild) 🍎 Build iOS Xcode workspace/project and feed back errors to llm.
 - [XixianLiang/HarmonyOS-mcp-server](https://github.com/XixianLiang/HarmonyOS-mcp-server) 🐍 🏠 - Control HarmonyOS-next devices with AI through MCP. Support device control and UI automation.
+- [xiongchenghou/vba-mcp-server](https://github.com/xiongchenghou/vba-mcp-server) 🐍 🏠 🪟 - Direct read/write access to VBA code in Excel workbooks (.xlsm). No manual export/import needed.
 - [xzq.xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server) 📇 🏠  - An implementation project of a JVM-based MCP (Model Context Protocol) server.
 - [yangkyeongmo@/mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow) 🐍 🏠 - MCP server that connects to [Apache Airflow](https://airflow.apache.org/) using official client.
 - [yanmxa/scriptflow-mcp](https://github.com/yanmxa/scriptflow-mcp) 📇 🏠 - A script workflow management system that transforms complex, repetitive AI interactions into persistent, executable scripts. Supports multi-language execution (Bash, Python, Node.js, TypeScript) with guaranteed consistency and reduced hallucination risks.


### PR DESCRIPTION
## Summary

- Add [xiongchenghou/vba-mcp-server](https://github.com/xiongchenghou/vba-mcp-server) to the **Developer Tools** section
- Python 🐍 | Local 🏠 | Windows 🪟
- Direct read/write access to VBA code in Excel workbooks (.xlsm) — no manual export/import needed
- Enables AI assistants (Claude, Cursor, etc.) to directly access and modify VBA modules in open Excel workbooks

## Checklist

- [x] Entry added in alphabetical order within Developer Tools
- [x] Follows existing entry format
- [x] Description is concise and accurate
- [x] Repository is public and accessible