### PR TITLE
🤖🤖🤖 Add ZeroDB MCP servers (77 tools + 6-tool memory server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,8 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [yincongcyincong/VictoriaMetrics-mcp-server](https://github.com/yincongcyincong/VictoriaMetrics-mcp-server) 🐍 🏠 - An MCP server for interacting with VictoriaMetrics database.
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.
 - [zilliztech/mcp-server-milvus](https://github.com/zilliztech/mcp-server-milvus) 🐍 🏠 ☁️ - MCP Server for Milvus / Zilliz, making it possible to interact with your database.
+- [AINative-Studio/ainative-zerodb-mcp-server](https://github.com/AINative-Studio/ainative-zerodb-mcp-server) 📇 ☁️ 🏠 - ZeroDB MCP Server — 77 tools for vector search, agent memory, NoSQL, PostgreSQL, file storage, embeddings, events, and quantum compression. All tools annotated with MCP readOnly/destructive hints. Hosted and local (stdio) transport.
+- [AINative-Studio/ainative-zerodb-memory-mcp](https://github.com/AINative-Studio/ainative-zerodb-memory-mcp) 📇 ☁️ 🏠 - ZeroDB Memory MCP — lightweight 6-tool server for persistent agent memory with semantic search, context management, and session tracking.
 - [wklee610/kafka-mcp](https://github.com/wklee610/kafka-mcp)[![kafka-mcp MCP server](https://glama.ai/mcp/servers/wklee610/kafka-mcp/badges/score.svg)](https://glama.ai/mcp/servers/wklee610/kafka-mcp) 🐍 🏠 ☁️ - MCP server for Apache Kafka that allows LLM agents to inspect topics, consumer groups, and safely manage offsets (reset, rewind).
 
 ### 📊 <a name="data-platforms"></a>Data Platforms


### PR DESCRIPTION
## New Servers

### 1. ainative-zerodb-mcp-server (77 tools)
- **npm:** https://www.npmjs.com/package/ainative-zerodb-mcp-server
- **GitHub:** https://github.com/AINative-Studio/ainative-zerodb-mcp-server
- **Category:** Databases
- **Features:** Vector search (384/768/1024/1536 dims), persistent agent memory, NoSQL tables, dedicated PostgreSQL, S3-compatible file storage, event streaming, RLHF, quantum compression
- **Install:** `npx ainative-zerodb-mcp-server`
- All 77 tools annotated with readOnly/destructive/idempotent hints per MCP spec 2025-03-26

### 2. ainative-zerodb-memory-mcp (6 tools)
- **npm:** https://www.npmjs.com/package/ainative-zerodb-memory-mcp
- **GitHub:** https://github.com/AINative-Studio/ainative-zerodb-memory-mcp
- **Category:** Databases
- **Features:** Store memory, search memory, get context, embed text, semantic search, clear session
- **Install:** `npx ainative-zerodb-memory-mcp`

Both servers support stdio and hosted WebSocket transport.