### PR TITLE
Add AceDataCloud/MCPSerp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,6 +1617,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.
 - [Aas-ee/open-webSearch](https://github.com/Aas-ee/open-webSearch) 🐍 📇 ☁️ - Web search using free multi-engine search (NO API KEYS REQUIRED) — Supports Bing, Baidu, DuckDuckGo, Brave, Exa, and CSDN.
+- [AceDataCloud/MCPSerp](https://github.com/AceDataCloud/MCPSerp) [![AceDataCloud/MCPSerp MCP server](https://glama.ai/mcp/servers/AceDataCloud/MCPSerp/badges/score.svg)](https://glama.ai/mcp/servers/AceDataCloud/MCPSerp) 🐍 ☁️ - Google SERP search with web, image, news, video, places, maps, and Knowledge Graph queries. Supports multi-country localization, time filtering, and pagination.
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration
 - [adawalli/nexus](https://github.com/adawalli/nexus) 📇 ☁️ - AI-powered web search server using Perplexity Sonar models with source citations. Zero-install setup via NPX.
 - [ananddtyagi/webpage-screenshot-mcp](https://github.com/ananddtyagi/webpage-screenshot-mcp) 📇 🏠 - A MCP server for taking screenshots of webpages to use as feedback during UI developement.


### PR DESCRIPTION
Adding [MCPSerp](https://github.com/AceDataCloud/MCPSerp) — a Google SERP search MCP server.

**Features:** web, image, news, video, places, maps, and Knowledge Graph search queries with multi-country localization, time filtering, and pagination (11 tools).

- ✅ [Glama listing](https://glama.ai/mcp/servers/AceDataCloud/MCPSerp) with passing checks
- ✅ [PyPI](https://pypi.org/project/mcp-serp/) published
- ✅ GitHub release (v0.1.0)
- ✅ MIT licensed
- ✅ Built with MCP SDK + httpx + pydantic 2 (Python)