### PR TITLE
Add MageMCP — Magento 2 / Adobe Commerce MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ MCP servers for learning management systems (LMS) and educational tools.
 MCP servers for e-commerce platforms and online store management.
 
 - [lofder/dsers-mcp-product](https://github.com/lofder/dsers-mcp-product) [![dsers-mcp-product MCP server](https://glama.ai/mcp/servers/lofder/dsers-mcp-product/badges/score.svg)](https://glama.ai/mcp/servers/lofder/dsers-mcp-product) 📇 ☁️ - Automate AliExpress/Alibaba dropshipping product import to Shopify or Wix via DSers. Bulk import, variant editing, pricing rules, and multi-store push with a single command.
+- [magendooro/magemcp](https://github.com/magendooro/magemcp) 🐍 🏠 🍎 🪟 🐧 - MCP server for Magento 2 / Adobe Commerce with 30+ tools across customer (GraphQL) and admin (REST) namespaces for catalog, cart, checkout, orders, customers, inventory, CMS, and promotions. Built-in PII redaction and confirmation prompts for write operations.
 - [the402ai/mcp-server](https://github.com/the402ai/mcp-server) [![the402ai/mcp-server MCP server](https://glama.ai/mcp/servers/the402ai/mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/the402ai/mcp-server) 📇 ☁️ 🍎 🪟 🐧 - AI agent service marketplace with x402 micropayments (USDC on Base). 30 tools for browsing services, purchasing, managing conversation threads, listing services as a provider, handling subscriptions, and tracking earnings. Install via `npx -y @the402/mcp-server`.
 
 ### 🌳 <a name="environment-and-nature"></a>Environment & Nature


### PR DESCRIPTION
## MageMCP

**Category:** E-Commerce

**Entry:**
- [magendooro/magemcp](https://github.com/magendooro/magemcp) 🐍 🏠 🍎 🪟 🐧 - MCP server for Magento 2 / Adobe Commerce with 30+ tools across customer (GraphQL) and admin (REST) namespaces for catalog, cart, checkout, orders, customers, inventory, CMS, and promotions. Built-in PII redaction and confirmation prompts for write operations.

**Why add this:**
- 30+ MCP tools covering the full Magento 2 API surface
- Dual namespace: `c_*` (customer/storefront via GraphQL) + `admin_*` (back-office via REST)
- Production safety: confirmation prompts for destructive operations, PII redaction, audit logging
- 490 tests (unit + integration)
- Docker support, works with Claude Desktop out of the box
- MIT licensed