### PR TITLE
Add i18n Agent to Translation Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ Translation tools and services to enable AI assistants to translate content betw
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
+- [loking/mcp-client](https://github.com/loking/mcp-client) 📇 ☁️ - AI-powered translation management for developers via MCP. Translates JSON, YAML, Markdown, PO files with multi-model AI pipeline, regional sensitivity, and cultural adaptation. Works with Claude Code, Cursor, VS Code.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech
 


### PR DESCRIPTION
Adds [i18n Agent](https://github.com/loking/mcp-client) to the Translation Services section.

**i18n Agent** is an AI-powered translation management MCP server for developers. It translates JSON, YAML, Markdown, PO files with a multi-model AI pipeline, regional sensitivity, and cultural adaptation. Works with Claude Code, Cursor, VS Code, and any MCP-compatible tool.

- Website: https://i18nagent.ai
- GitHub: https://github.com/loking/mcp-client