### PR TITLE
Add AIR SDK to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,6 +1617,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.
 - [Aas-ee/open-webSearch](https://github.com/Aas-ee/open-webSearch) 🐍 📇 ☁️ - Web search using free multi-engine search (NO API KEYS REQUIRED) — Supports Bing, Baidu, DuckDuckGo, Brave, Exa, and CSDN.
+- [ArcedeDev/air-sdk](https://github.com/ArcedeDev/air-sdk) 📇 ☁️ 🍎 🪟 🐧 - Collective web intelligence for AI agents. Extract structured data from any URL (SPAs, JSON-LD, RSS), discover verified actions on any website with CSS selectors and macros, and execute browser automation. 260 tests, up to 7,000x cost reduction vs frontier models. Also on the [MCP Registry](https://registry.modelcontextprotocol.io/servers/@ArcedeDev/air-sdk).
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration
 - [adawalli/nexus](https://github.com/adawalli/nexus) 📇 ☁️ - AI-powered web search server using Perplexity Sonar models with source citations. Zero-install setup via NPX.
 - [ananddtyagi/webpage-screenshot-mcp](https://github.com/ananddtyagi/webpage-screenshot-mcp) 📇 🏠 - A MCP server for taking screenshots of webpages to use as feedback during UI developement.


### PR DESCRIPTION
Adds [AIR SDK](https://github.com/ArcedeDev/air-sdk) (`@arcede/air-sdk`) to the Search & Data Extraction section.

**What it does:** Collective web intelligence for AI agents. Three tools: extract structured data from any URL (handles SPAs, JSON-LD, RSS), discover verified actions on any website (CSS selectors, macros, confidence scores), and execute browser automation.

**Why it fits:** MCP server (TypeScript, `@modelcontextprotocol/sdk`), available on the [MCP Registry](https://registry.modelcontextprotocol.io/servers/@ArcedeDev/air-sdk). 260 tests, MIT licensed.

Placed in alphabetical order under Search & Data Extraction.