### PR TITLE
Add property-comps-mcp-server to Real Estate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [Tianning-lab/property-comps-mcp-server](https://github.com/Tianning-lab/property-comps-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - Comparable property sales data across 11 global markets (UK, France, Dubai, Singapore, Taiwan, NYC, Miami, Connecticut, Philadelphia, Ireland, Chicago). 4.2M+ government-recorded transactions.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [Tianning-lab/property-comps-mcp-server](https://github.com/Tianning-lab/property-comps-mcp-server) to the Real Estate section.

**What it does:** MCP server that gives AI agents access to comparable property sales data across 11 global markets — UK, France, Dubai, Singapore, Taiwan, NYC, Miami, Connecticut, Philadelphia, Ireland, and Chicago. 4.2M+ government-recorded transactions from official registries (HM Land Registry, DVF, Dubai Land Department, etc.).

**Tools:** `search_property_comps`, `get_area_stats`, `list_markets`

**Tech:** Python, FastMCP SDK, stdio transport. Works with Claude Desktop, Claude Code, and any MCP-compatible client.

**API docs:** https://api.nwc-advisory.com/docs