### PR TITLE
Add rendoc MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1980,6 +1980,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vakharwalad23/google-mcp](https://github.com/vakharwalad23/google-mcp) 📇 ☁️ - Collection of Google-native tools (Gmail, Calendar, Drive, Tasks) for MCP with OAuth management, automated token refresh, and auto re-authentication capabilities.
 - [vasylenko/claude-desktop-extension-bear-notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) 📇 🏠 🍎 - Search, read, create, and update Bear Notes directly from Claude. Local-only with complete privacy.
 - [wyattjoh/calendar-mcp](https://github.com/wyattjoh/calendar-mcp) 📇 🏠 🍎 - MCP server for accessing macOS Calendar events
+- [yoryocoruxo-ai/rendoc](https://github.com/yoryocoruxo-ai/rendoc) 📇 ☁️ 🏠 🍎 🪟 🐧 - Generate PDF documents from HTML templates and data. Supports custom templates, multiple paper sizes, and two rendering engines. Install: `npx @rendoc/mcp-server`.
 - [yuvalsuede/claudia](https://github.com/yuvalsuede/claudia) 📇 🏠 🍎 🪟 🐧 - AI-native task management system for Claude agents. Hierarchical tasks, dependencies, sprints, acceptance criteria, multi-agent coordination, and MCP server integration.
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations


### PR DESCRIPTION
## Summary

- Adds [rendoc](https://github.com/yoryocoruxo-ai/rendoc) to the **Workplace & Productivity** section
- rendoc is an MCP server for generating PDF documents from HTML templates and data
- Supports custom templates, multiple paper sizes, and two rendering engines
- Available on npm as `@rendoc/mcp-server`

## Details

- **Name**: rendoc
- **Repository**: https://github.com/yoryocoruxo-ai/rendoc
- **npm**: [@rendoc/mcp-server](https://www.npmjs.com/package/@rendoc/mcp-server)
- **Language**: TypeScript
- **Scope**: Cloud & Local
- **Platforms**: macOS, Windows, Linux