### PR TITLE
Add The MCP Handbook to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [The MCP Handbook](https://github.com/ypollak2/mcp-handbook) - The missing developer guide for MCP — from hello world to production. Covers architecture patterns, security, testing, and deployment with runnable TypeScript and Python examples.
 
 ## Community
 


### PR DESCRIPTION
## What

Adds [The MCP Handbook](https://github.com/ypollak2/mcp-handbook) to the **Tutorials** section.

## Why

The Tutorials section currently has 2 entries. The MCP Handbook is a comprehensive, open-source developer guide covering:

- **8 in-depth guides** — from getting started to production deployment
- **4 runnable examples** — Database Explorer, REST API Wrapper, File Search, Web Scraper
- **Both TypeScript and Python** — with copy-paste templates
- **Production topics** — security, testing, error handling, performance

It fills a gap: there are 1,000+ MCP servers listed here, but almost no guidance on how to build them well. This handbook provides that missing guide.

## Details

- Added to: Tutorials section (alphabetical order maintained)
- One line, follows existing format
- Links to: https://github.com/ypollak2/mcp-handbook
- License: MIT