### PR TITLE
🤖🤖🤖 Add Zenii MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,7 +1983,9 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vasylenko/claude-desktop-extension-bear-notes](https://github.com/vasylenko/claude-desktop-extension-bear-notes) 📇 🏠 🍎 - Search, read, create, and update Bear Notes directly from Claude. Local-only with complete privacy.
 - [wyattjoh/calendar-mcp](https://github.com/wyattjoh/calendar-mcp) 📇 🏠 🍎 - MCP server for accessing macOS Calendar events
 - [yuvalsuede/claudia](https://github.com/yuvalsuede/claudia) 📇 🏠 🍎 🪟 🐧 - AI-native task management system for Claude agents. Hierarchical tasks, dependencies, sprints, acceptance criteria, multi-agent coordination, and MCP server integration.
+- [sprklai/zenii](https://github.com/sprklai/zenii) 🦀 🏠 - Local AI backend with persistent memory, 18 tools, and 114 API routes via MCP over stdio.
 
+  
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.


### PR DESCRIPTION
Zenii is a 20 MB Rust binary providing a local AI backend with persistent semantic memory, 18 tools, and 114 API routes. The MCP server exposes all tools via stdio transport for Claude Code, Cursor, and any MCP client.

- Transport: stdio
- Command: zenii-mcp-server --transport stdio
- License: MIT
- Language: Rust