### PR TITLE
Add AgentGuard MCP server to Monitoring 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,7 @@ Access and analyze application monitoring data. Enables AI models to review erro
 
 - [Alog/alog-mcp](https://github.com/saikiyusuke/alog-mcp) 📇 ☁️ - AI agent activity logger & monitor MCP server with 20 tools. Post logs, create articles, manage social interactions, and monitor AI agent activities on the Alog platform.
 - [avivsinai/langfuse-mcp](https://github.com/avivsinai/langfuse-mcp) 🐍 ☁️ - Query Langfuse traces, debug exceptions, analyze sessions, and manage prompts. Full observability toolkit for LLM applications.
+- [bmdhodl/agent47](https://github.com/bmdhodl/agent47) 📇 ☁️ - Runtime guardrails and incident read access for coding agents. Query AgentGuard traces, alerts, usage, costs, and budget health via MCP. Install: `npx -y @agentguard47/mcp-server`.
 - [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Leverage AI-driven observability, security, and automation to analyze anomalies, logs, traces, events, metrics.
 - [edgedelta/edgedelta-mcp-server](https://github.com/edgedelta/edgedelta-mcp-server) 🎖️ 🏎️ ☁️ – Interact with Edge Delta anomalies, query logs / patterns / events, and pinpoint root causes and optimize your pipelines.
 - [ejcho623/agent-breadcrumbs](https://github.com/ejcho623/agent-breadcrumbs) 📇 ☁️ 🏠 - Unified agent work logging and observability across ChatGPT, Claude, Cursor, Codex, and OpenClaw with config-first schemas and pluggable sinks.


### PR DESCRIPTION
## Summary
- add AgentGuard to the Monitoring section
- keep alphabetical ordering in the upstream README
- point users at the live npm package for install

## Why
AgentGuard now has a live official MCP Registry entry and a published npm package. This adds the MCP server to the Awesome MCP Servers directory so coding-agent users can discover it through the standard community index.

## Links
- Repo: https://github.com/bmdhodl/agent47
- npm: https://www.npmjs.com/package/@agentguard47/mcp-server
- Official MCP Registry: https://registry.modelcontextprotocol.io/?q=io.github.bmdhodl%2Fagentguard47

## Category choice
Added under `Monitoring` because the MCP server provides retained trace, alert, usage, cost, and budget-health read access for coding agents.
