### PR TITLE
Add decoder-3am-mcp to Biology, Medicine and Bioinformatics

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Design and visualize software architecture, system diagrams, and technical docum
 - [the-momentum/apple-health-mcp-server](https://github.com/the-momentum/apple-health-mcp-server) 🐍 🏠 🍎 🪟 🐧 - An MCP server that provides access to exported data from Apple Health. Data analytics included.
 - [the-momentum/fhir-mcp-server](https://github.com/the-momentum/fhir-mcp-server) 🐍 🏠 ☁️ - MCP Server that connects AI agents to FHIR servers. One example use case is querying patient history in natural language.
 - [wso2/fhir-mcp-server](https://github.com/wso2/fhir-mcp-server) 🐍 🏠 ☁️ - Model Context Protocol server for Fast Healthcare Interoperability Resources (FHIR) APIs. Provides seamless integration with FHIR servers, enabling AI assistants to search, retrieve, create, update, and analyze clinical healthcare data with SMART-on-FHIR authentication support.
+- [pine-harbor/decoder-3am-mcp](https://github.com/pine-harbor/decoder-3am-mcp) 📇 ☁️ - Sleep disruption cause classifier using The Longevity Vault's 5-cause framework. Identifies the biological mechanism behind 3am wakeups from symptom descriptions, with tracked links to the full interactive 3AM Decoder.
 
 ### 📂 <a name="browser-automation"></a>Browser Automation
 


### PR DESCRIPTION
Adds [decoder-3am-mcp](https://github.com/thelongevityvault/decoder-3am-mcp) to the Biology, Medicine and Bioinformatics section.

**What it does:** Sleep disruption cause classifier using The Longevity Vault's 5-cause framework. Identifies the biological mechanism behind 3am wakeups from symptom descriptions.

**4 tools:** classify_sleep_cause, get_cause_info, list_causes, get_decoder_url

**Hosted on:** Cloudflare Workers (Streamable HTTP)
**Smithery:** https://smithery.ai/server/thelongevityvault/decoder-3am
**Homepage:** https://sleep.thelongevityvault.com/decoder