### PR TITLE
Add Hybirdss/smartest-tv - smart TV control with content deep linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,7 @@ Integration with gaming related data, game engines, and services
 Control smart home devices, home network equipment, and automation systems.
 
 - [apiarya/wemo-mcp-server](https://github.com/apiarya/wemo-mcp-server) - [![wemo-mcp-server MCP server](https://glama.ai/mcp/servers/@apiarya/wemo-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/@apiarya/wemo-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Control WeMo smart home devices via AI assistants using natural language. Built on pywemo for 100% local control — no cloud dependency. Supports dimmer brightness, device rename, HomeKit codes, and multi-phase discovery.
+- [Hybirdss/smartest-tv](https://github.com/Hybirdss/smartest-tv) 🐍 🏠 🍎 🪟 🐧 - Talk to your TV. Play Netflix episodes, YouTube videos, Spotify music by name — AI resolves content IDs and deep links to LG, Samsung, Android TV, and Roku. Built-in cache + community cache for instant lookups.
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
## smartest-tv

Talk to your TV. Play Netflix episodes, YouTube videos, Spotify music by name.

- **Repo**: https://github.com/Hybirdss/smartest-tv
- **PyPI**: https://pypi.org/project/stv/
- **License**: MIT
- **Language**: Python
- **Transport**: stdio

### What it does

MCP server + CLI for controlling smart TVs with AI-powered content resolution:

- **Deep link by name**: `stv play netflix "Frieren" s2e8` → finds the episode ID, deep links to TV
- **4 platforms**: LG webOS, Samsung Tizen, Android TV/Fire TV, Roku
- **3 streaming services**: Netflix (episode-level), YouTube (yt-dlp search), Spotify (web search)
- **Community cache**: shared content IDs across all users via GitHub CDN — instant lookups
- **20 MCP tools**: `tv_play_content`, `tv_resolve`, `tv_next`, `tv_history`, `tv_status`, `tv_volume`, etc.

### How it's different

Existing smart home MCP servers (Home Assistant, Homey) control devices. smartest-tv resolves *content* — it finds the Netflix episode ID for "Frieren S2E8" and deep links directly to playback.

### Category

Home Automation (added alphabetically)