### PR TITLE
Add google-searchconsole-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Provides access to customer profiles inside of customer data platforms
 - [QuackbackIO/quackback](https://github.com/QuackbackIO/quackback) 📇 ☁️ - Open-source customer feedback platform with built-in MCP server. Agents can search feedback, triage posts, update statuses, create and comment on posts, vote, manage roadmaps, merge duplicates, and publish changelogs.
 - [sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server) 📇 ☁️ - An MCP server to access and updates profiles on an Apache Unomi CDP server.
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
+- [lionkiii/google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) [![google-searchconsole-mcp MCP server](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp) 📇 🏠 - Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.
 - [saurabhsharma2u/search-console-mcp](https://github.com/saurabhsharma2u/search-console-mcp)  - An MCP server to interact with Google Search Console and Bing Webmasters.
 
 ### 🗄️ <a name="databases"></a>Databases


### PR DESCRIPTION
Adds [google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) to the Data Platforms section.

**What it does:** Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.

- **Glama listing:** https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp
- **Glama scores:** Security A, License A, Quality A
- **npm:** https://www.npmjs.com/package/google-searchconsole-mcp
- **License:** MIT
- **Language:** TypeScript
- **Scope:** Local