### PR TITLE
Add Hybirdss/smartest-tv — smart TV control with content deep linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1361,6 +1361,7 @@ Integration with gaming related data, game engines, and services
 Control smart home devices, home network equipment, and automation systems.
 
 - [apiarya/wemo-mcp-server](https://github.com/apiarya/wemo-mcp-server) - [![wemo-mcp-server MCP server](https://glama.ai/mcp/servers/@apiarya/wemo-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/@apiarya/wemo-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Control WeMo smart home devices via AI assistants using natural language. Built on pywemo for 100% local control — no cloud dependency. Supports dimmer brightness, device rename, HomeKit codes, and multi-phase discovery.
+- [Hybirdss/smartest-tv](https://github.com/Hybirdss/smartest-tv) [![Hybirdss/smartest-tv MCP server](https://glama.ai/mcp/servers/Hybirdss/smartest-tv/badges/score.svg)](https://glama.ai/mcp/servers/Hybirdss/smartest-tv) 🐍 🏠 🍎 🪟 🐧 - Control any smart TV with natural language. Play Netflix, YouTube, Spotify by name with deep linking, cast URLs, scene presets, multi-room audio, and multi-TV sync. Supports LG, Samsung, Android TV, Roku. 21 MCP tools, no cloud required.
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
## What

Adds [smartest-tv](https://github.com/Hybirdss/smartest-tv) to the **Home Automation** section.

## Server

- **Repository**: https://github.com/Hybirdss/smartest-tv
- **Glama**: https://glama.ai/mcp/servers/Hybirdss/smartest-tv
- **Badge**: [![Hybirdss/smartest-tv MCP server](https://glama.ai/mcp/servers/Hybirdss/smartest-tv/badges/score.svg)](https://glama.ai/mcp/servers/Hybirdss/smartest-tv)
- **PyPI**: https://pypi.org/project/stv/
- **Language**: Python
- **Scope**: Local (no cloud required)
- **Platforms**: macOS, Windows, Linux

## Description

Control any smart TV with natural language. 21 MCP tools for playing content by name (Netflix, YouTube, Spotify) with deep linking, casting URLs, scene presets, multi-room audio, and multi-TV sync. Supports LG webOS, Samsung Tizen, Android TV/Fire TV, and Roku. No cloud dependency.