### PR TITLE
Add SocialBu MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1894,6 +1894,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🌐 <a name="social-media"></a>Social Media
 
+- [usamaejaz/socialbu-mcp](https://github.com/usamaejaz/socialbu-mcp) 📇 ☁️ - Social media management MCP server for SocialBu. Lets AI agents create, schedule, publish, analyze, and manage posts across supported social platforms via https://socialbu.com/mcp.
 Integration with social media platforms to allow posting, analytics, and interaction management. Enables AI-driven automation for social presence.
 
 - [anwerj/youtube-uploader-mcp](https://github.com/anwerj/youtube-uploader-mcp) 🏎️ ☁️ - AI‑powered YouTube uploader—no CLI, no YouTube Studio. Uploade videos directly from MCP clients with all AI capabilities.


### PR DESCRIPTION
## Summary
- add SocialBu MCP under Social Media
- include the public repo and hosted MCP endpoint

## Details
SocialBu MCP lets AI assistants create, schedule, publish, analyze, and manage social media content through SocialBu.

- Repo: https://github.com/usamaejaz/socialbu-mcp
- Hosted endpoint: https://socialbu.com/mcp
- Contact: usama.ejaz@socialbu.com