### PR TITLE
Add AIMLPM/markcrawl - web crawler MCP server for RAG pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1694,7 +1694,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.
 - [Aas-ee/open-webSearch](https://github.com/Aas-ee/open-webSearch) 🐍 📇 ☁️ - Web search using free multi-engine search (NO API KEYS REQUIRED) — Supports Bing, Baidu, DuckDuckGo, Brave, Exa, and CSDN.
-- [AIMLPM/markcrawl](https://github.com/AIMLPM/markcrawl) 🐍 🏠 - Crawl websites into clean Markdown, search pages, and extract structured data with LLMs. Built-in MCP server for web research and RAG pipelines.
+- [AIMLPM/markcrawl](https://github.com/AIMLPM/markcrawl) [![AIMLPM/markcrawl MCP server](https://glama.ai/mcp/servers/AIMLPM/markcrawl/badges/score.svg)](https://glama.ai/mcp/servers/AIMLPM/markcrawl) 🐍 🏠 - Crawl websites into clean Markdown, search pages, and extract structured data with LLMs. Built-in MCP server for web research and RAG pipelines.
 - [ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi) 📇 ☁️ - Kagi search API integration
 - [adawalli/nexus](https://github.com/adawalli/nexus) 📇 ☁️ - AI-powered web search server using Perplexity Sonar models with source citations. Zero-install setup via NPX.
 - [ananddtyagi/webpage-screenshot-mcp](https://github.com/ananddtyagi/webpage-screenshot-mcp) 📇 🏠 - A MCP server for taking screenshots of webpages to use as feedback during UI developement.


### PR DESCRIPTION
## Summary

Adds [AIMLPM/markcrawl](https://github.com/AIMLPM/markcrawl) to the Search & Data Extraction section.

MarkCrawl is a Python MCP server that crawls websites into clean Markdown and provides tools for searching, reading, and extracting structured data from crawled pages.

**MCP Tools:** `crawl_site`, `list_pages`, `read_page`, `search_pages`, `extract_data`

**Category:** Search & Data Extraction
**Language:** Python (🐍)
**Scope:** Local (🏠)

Install: `pip install markcrawl[mcp]`