### PR TITLE
Add NYC Property & Venue APIs server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,6 +1666,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [MATCHUP-LABS/nycapi](https://github.com/MATCHUP-LABS/nycapi) 📇 ☁️ 🍎 🪟 🐧 - NYC property, building, and venue intelligence. Resolve addresses to BBL/BIN, pull ownership and zoning data, DOB/HPD/OATH violations, and DOHMH restaurant health grades for any NYC address. Streamable HTTP transport with Bearer auth.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## Summary

Adds [NYC Property & Venue APIs](https://github.com/MATCHUP-LABS/nycapi) to the **Real Estate** category.

- **Server URL:** https://nycapi.app/api/mcp (Streamable HTTP with Bearer auth)
- **Tools:** resolve_property_identifier, get_property_intelligence, get_building_violations, get_restaurant_venue_intel
- **Data:** NYC property ownership, zoning, tax assessments, DOB/HPD/OATH violations, DOHMH restaurant health grades
- **Language:** TypeScript
- **Scope:** Cloud service

🤖 Generated with [Claude Code](https://claude.com/claude-code)