### PR TITLE
Add maiife-toolkit — 14 AI governance MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 
 Tools and integrations that enhance the development workflow and environment management.
 
+- [sakthivelchan89/maiife-toolkit](https://github.com/sakthivelchan89/maiife-toolkit) 📇 🏠 🍎 🪟 🐧 - AI governance toolkit with 14 MCP servers for scanning AI environments, auditing MCP security, scoring prompts, evaluating agent outputs, tracking AI spend, and more. Each tool works standalone or together as a governance mesh.
 - [LWTlong/ai-dev-analytics](https://github.com/LWTlong/ai-dev-analytics) [![glama.ai](https://glama.ai/mcp/servers/LWTlong/ai-dev-analytics/badges/score.svg)](https://glama.ai/mcp/servers/LWTlong/ai-dev-analytics) 📇 🏠 - An open-source observability layer for AI coding. Silently tracks dev tokens/time and auto-codifies AI deviations into persistent project rules.
 - [3KniGHtcZ/codebeamer-mcp](https://github.com/3KniGHtcZ/codebeamer-mcp) [![codebeamer-mcp MCP server](https://glama.ai/mcp/servers/3KniGHtcZ/codebeamer-mcp/badges/score.svg)](https://glama.ai/mcp/servers/3KniGHtcZ/codebeamer-mcp) 📇 ☁️ 🍎 🪟 🐧 - Codebeamer ALM integration for managing work items, trackers, and projects. Provides 17 tools for reading and writing items, associations, references, comments, and risk management data via Codebeamer REST API v3.
 - [21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp) - Create crafted UI components inspired by the best 21st.dev design engineers.


### PR DESCRIPTION
Adds [maiife-toolkit](https://github.com/sakthivelchan89/maiife-toolkit) to Developer Tools.

[![maiife-toolkit MCP server](https://glama.ai/mcp/servers/sakthivelchan89/maiife-toolkit/badges/score.svg)](https://glama.ai/mcp/servers/sakthivelchan89/maiife-toolkit)

14 open-source MCP servers for AI governance, all published on npm under `@maiife-ai-pub`:

- **probe** — scan AI environment (IDE extensions, MCP servers, API keys, local models)
- **mcp-audit** — security-score MCP server configs
- **mcp-doctor** — health check & auto-fix broken MCP setups
- **prompt-score** — analyze and improve prompt quality
- **eval** — LLM-as-judge evaluation with structured rubrics
- **trace** — agent workflow tracing and analysis
- **cost** — AI spend tracking and optimization
- Plus 7 more (ai-stack, ai-journal, context-sync, prompt-craft, sub-audit, model-match, weekly-ai-report)

TypeScript, works on macOS/Windows/Linux. Apache 2.0 licensed.