### PR TITLE
Add Zopaf Negotiation Engine (MILP optimization + Pareto frontier analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,6 +1117,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
+- [rjandino/zopaf](https://github.com/rjandino/zopaf) 🐍 ☁️ 🍎 🪟 🐧 - Quantitative negotiation engine with zero LLM token cost. MILP optimization, Pareto frontier analysis, and iso-utility counteroffer generation for any multi-issue negotiation (job offers, VC term sheets, real estate, vendor contracts). 9 tools covering the full negotiation lifecycle. Hosted MCP server — any agent connects via one URL.
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.
 - [@frihet/mcp-server](https://github.com/Frihet-io/frihet-mcp) [![frihet-mcp MCP server](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Frihet-io/frihet-mcp) 📇 ☁️ - AI-native business management — invoices, expenses, clients, products, and quotes. 31 tools for Claude, Cursor, Windsurf, and Cline.
 - [@iiatlas/hledger-mcp](https://github.com/iiAtlas/hledger-mcp) 📇 🏠 🍎 🪟 - Double entry plain text accounting, right in your LLM! This MCP enables comprehensive read, and (optional) write access to your local [HLedger](https://hledger.org/) accounting journals.


### PR DESCRIPTION
Adds Zopaf Negotiation Engine to the Finance & Fintech section.

Zopaf is a hosted MCP server that provides pure-math negotiation coaching -- MILP optimization, Pareto frontier analysis, and iso-utility counteroffer generation -- with zero internal LLM token cost.

- **Server URL:** https://zopaf-mcp-production.up.railway.app/mcp
- **GitHub:** https://github.com/rjandino/zopaf
- **9 tools** covering the full negotiation lifecycle
- **Zero LLM tokens** — pure math engine (PuLP, NumPy, SciPy)
- **Works with any MCP-compatible agent** (Claude, GPT, Llama, etc.)
- **Use cases:** Job offers, VC term sheets, real estate, vendor contracts, salary negotiations, business partnerships