### PR TITLE
Add sthan-io/mcp-server to Location Services 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,6 +1552,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [SaintDoresh/Weather-MCP-ClaudeDesktop](https://github.com/SaintDoresh/Weather-MCP-ClaudeDesktop.git) 🐍 ☁️ - An MCP tool that provides real-time weather data, forecasts, and historical weather information using the OpenWeatherMap API.
 - [SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver) 🐍 🏠 - Access the time in any timezone and get the current local time
 - [stadiamaps/stadiamaps-mcp-server-ts](https://github.com/stadiamaps/stadiamaps-mcp-server-ts) 📇 ☁️ - A MCP server for Stadia Maps' Location APIs - Lookup addresses, places with geocoding, find time zones, create routes and static maps
+- [sthan-io/mcp-server](https://github.com/sthan-io/mcp-server) 📇 ☁️ - US address verification, parsing, autocomplete, forward/reverse geocoding, and IP geolocation via sthan.io APIs. 8 tools, free tier available. `npx @sthan/mcp-server`
 - [TimLukaHorstmann/mcp-weather](https://github.com/TimLukaHorstmann/mcp-weather) 📇 ☁️  - Accurate weather forecasts via the AccuWeather API (free tier available).
 - [trackmage/trackmage-mcp-server](https://github.com/trackmage/trackmage-mcp-server) 📇 - Shipment tracking api and logistics management capabilities through the [TrackMage API] (https://trackmage.com/)
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing


### PR DESCRIPTION
Adds [sthan-io/mcp-server](https://github.com/sthan-io/mcp-server) to the Location Services category.

[![sthan-io/mcp-server MCP server](https://glama.ai/mcp/servers/sthan-io/mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/sthan-io/mcp-server)

**What it does:** MCP server for sthan.io — US address verification, parsing, autocomplete, forward/reverse geocoding, and IP geolocation. 8 tools, TypeScript, stdio transport.

**Install:** `npx @sthan/mcp-server`

**npm:** https://www.npmjs.com/package/@sthan/mcp-server
**Repo:** https://github.com/sthan-io/mcp-server
**Free tier:** Yes, no credit card required.