### PR TITLE
Add dotfiles-mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2137,6 +2137,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
 - [growilabs/growi-mcp-server](https://github.com/growilabs/growi-mcp-server) 🎖️ 📇 ☁️ - Official MCP Server to integrate with GROWI APIs.
 - [gwbischof/free-will-mcp](https://github.com/gwbischof/free-will-mcp) 🐍 🏠 - Give your AI free will tools. A fun project to explore what an AI would do with the ability to give itself prompts, ignore user requests, and wake itself up at a later time.
+- [hairglasses-studio/dotfiles-mcp](https://github.com/hairglasses-studio/dotfiles-mcp) 🏎️ 🏠 🐧 - Linux desktop environment management with 86 tools for Hyprland, GLSL shaders, Bluetooth, MIDI, input devices, and fleet operations.
 - [Harry-027/JotDown](https://github.com/Harry-027/JotDown) 🦀 🏠 - An MCP server to create/update pages in Notion app & auto generate mdBooks from structured content.
 - [henilcalagiya/mcp-apple-notes](https://github.com/henilcalagiya/mcp-apple-notes) 🐍 🏠 - Powerful tools for automating Apple Notes using Model Context Protocol (MCP). Full CRUD support with HTML content, folder management, and search capabilities.
 - [HenryHaoson/Yuque-MCP-Server](https://github.com/HenryHaoson/Yuque-MCP-Server) - 📇 ☁️ A Model-Context-Protocol (MCP) server for integrating with Yuque API, allowing AI models to manage documents, interact with knowledge bases, search content, and access analytics data from the Yuque platform.


### PR DESCRIPTION
## New MCP Server: dotfiles-mcp

**Name:** dotfiles-mcp
**URL:** https://github.com/hairglasses-studio/dotfiles-mcp
**Language:** Go
**Transport:** stdio
**Framework:** [mcpkit](https://github.com/hairglasses-studio/mcpkit)
**Tool count:** 86 across 10 modules
**License:** MIT

### Description
MCP server for Linux desktop environment management. 86 tools spanning Hyprland window management, Ghostty GLSL shader pipeline, Bluetooth device management, MIDI controllers, input device configuration, GitHub org lifecycle, fleet auditing, and open-source readiness scoring. Uses deferred tool loading by default -- exposes 4 discovery tools (search, schema, catalog, stats) and loads the remaining 82 on demand. All batch operations are dry-run by default.

### Installation
```bash
go install github.com/hairglasses-studio/dotfiles-mcp@latest
```

### Key Modules
- **Hyprland Desktop** (12 tools) -- Window/workspace management, screenshots, monitor config
- **Shader Pipeline** (13 tools) -- GLSL shader lifecycle for Ghostty terminal
- **Bluetooth** (9 tools) -- BLE-safe pairing, battery status, trust management
- **Input Devices** (13 tools) -- Logitech, gamepad, Solaar configuration
- **GitHub Org** (12 tools) -- Bulk repo operations, fleet sync, fork management
- **Open-Source Readiness** (2 tools) -- Score repos 0-100 across 8 categories

### Checklist
- [x] Open source (MIT license)
- [x] README has installation instructions
- [x] README has tool list with descriptions
- [x] Runs on stdio transport
- [x] One server per PR
- [x] Alphabetical ordering maintained