### PR TITLE
Add IOX Cloud to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 
 Cloud platform service integration. Enables management and interaction with cloud infrastructure and services.
 
+- [meruada/iox-cloud](https://github.com/meruada/iox-cloud) 📇 ☁️ - Deploy MCP servers and AI agents in seconds. AI generates code from natural language, deploys to 300+ edge locations with per-tenant V8 isolation, built-in auth, and instant preview via Dynamic Workers.
 - [4everland/4everland-hosting-mcp](https://github.com/4everland/4everland-hosting-mcp) 🎖️ 📇 🏠 🍎 🐧 - An MCP server implementation for 4EVERLAND Hosting enabling instant deployment of AI-generated code to decentralized storage networks like Greenfield, IPFS, and Arweave.
 - [aashari/mcp-server-aws-sso](https://github.com/aashari/mcp-server-aws-sso) 📇 ☁️ 🏠 - AWS Single Sign-On (SSO) integration enabling AI systems to securely interact with AWS resources by initiating SSO login, listing accounts/roles, and executing AWS CLI commands using temporary credentials.
 - [alexbakers/mcp-ipfs](https://github.com/alexbakers/mcp-ipfs) 📇 ☁️ - upload and manipulation of IPFS storage


### PR DESCRIPTION
## IOX Cloud

**[iox.cloud](https://iox.cloud)** — Deploy MCP servers and AI agents in seconds.

### What it does
- AI generates MCP server code from natural language descriptions
- Deploys to 300+ edge locations via Cloudflare Workers for Platforms
- Per-tenant V8 isolation (same model as Shopify)
- Instant preview via Dynamic Workers (~6ms execution)
- Built-in auth, rate limiting, usage tracking
- Marketplace to share and fork MCP servers
- BYOK (bring your own Claude API key)

### Links
- Website: https://iox.cloud
- GitHub: https://github.com/meruada/iox-cloud
- MCP Registry: `cloud.iox/iox-cloud`
- Live demo server: `https://iox-dispatch.matt-merutech.workers.dev/mcp?worker=test-tenant`

### Categories
- ☁️ Cloud Platform
- 📇 TypeScript