### PR TITLE
Add tailscale-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [weibaohui/k8m](https://github.com/weibaohui/k8m) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations, featuring a management interface, logging, and nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [weibaohui/kom](https://github.com/weibaohui/kom) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations. It can be integrated as an SDK into your own project and includes nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye) 🏎️ ☁️/🏠 - MCP Server for kubernetes management, and analyze your cluster, application health
+- [YawLabs/tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) 📇 ☁️ - Manage Tailscale tailnets with 52 tools covering devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs.
 
 ### 👨‍💻 <a name="code-execution"></a>Code Execution
 


### PR DESCRIPTION
[tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) is an open-source MCP server (MIT license) for managing Tailscale tailnets from AI assistants.

It provides 52 tools covering devices, ACL policies, DNS, auth keys, users, webhooks, and audit logs. Built with TypeScript, available on npm as `@yawlabs/tailscale-mcp`.

Added to the **Cloud Platforms** section in alphabetical order.