### PR TITLE
Add Pilot MCP - local-first MCP server for Mac apps 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 > [Awesome MCP Servers](https://glama.ai/mcp/servers) web directory.
 
 A curated list of awesome Model Context Protocol (MCP) servers.
-
 * [What is MCP?](#what-is-mcp)
 * [Clients](#clients)
 * [Tutorials](#tutorials)
@@ -2029,6 +2028,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [nicolascroce/keepsake-mcp](https://github.com/nicolascroce/keepsake-mcp) 📇 ☁️ - Personal CRM — manage contacts, interactions, tasks, notes, daily journal, and tags through 42 MCP tools
 - [n24q02m/better-notion-mcp](https://github.com/n24q02m/better-notion-mcp) [![better-notion-mcp MCP server](https://glama.ai/mcp/servers/@n24q02m/better-notion-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@n24q02m/better-notion-mcp) 📇 ☁️ 🍎 🪟 🐧 - Markdown-first Notion MCP server with 9 composite tools and 39 actions. ~77% token reduction via tiered docs. Auto-pagination and bulk operations.
 - [khaoss85/mcp-orchestro](https://github.com/khaoss85/mcp-orchestro) 📇 ☁️ 🍎 🪟 🐧 - Trello for Claude Code: AI-powered task management with 60 MCP tools, visual Kanban board, and intelligent orchestration for product teams and developers.
+- [lanchuske/local-mcp-releases](https://github.com/lanchuske/local-mcp-releases) 📇 🏠 🍎 - Pilot MCP — 82 tools for Mail, Calendar, Contacts, Microsoft Teams, OneDrive, Notes, Reminders, OmniFocus, iMessage, and more. 100% local, no cloud, no API keys. macOS only.
 - [louis030195/toggl-mcp](https://github.com/louis030195/toggl-mcp) 📇 ☁️ 🍎 🪟 🐧 - Time tracking integration with Toggl Track. Start/stop timers, manage time entries, track project time, and get today's summary. Perfect for productivity tracking and billing workflows.
 - [MarceauSolutions/amazon-seller-mcp](https://github.com/MarceauSolutions/amazon-seller-mcp) 🐍 ☁️ - Amazon Seller Central operations via SP-API - manage inventory, track orders, analyze sales, and optimize listings
 - [MarceauSolutions/hvac-quotes-mcp](https://github.com/MarceauSolutions/hvac-quotes-mcp) 🐍 🏠 ☁️ - HVAC equipment RFQ management for contractors - submit quotes to distributors, track responses, and compare pricing


### PR DESCRIPTION
Adds **Pilot MCP** to the 🏢 Workplace & Productivity section.

- **Repo:** https://github.com/lanchuske/local-mcp-releases
- - **82 MCP tools** for Mail, Calendar, Contacts, Microsoft Teams, OneDrive, Notes, Reminders, OmniFocus, iMessage, Office docs (Word/Excel/PPT/PDF), Finder, Safari, and more
- - **100% local** — no cloud, no API keys, no OAuth tokens. Data never leaves the Mac
- - **GDPR/CCPA compliant** by architecture
- - Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Zed
- - macOS 12+ (Apple Silicon & Intel)