### PR TITLE
feat: add IndieStack MCP server to Aggregators 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 Servers for accessing many apps and tools through a single MCP server.
 
+- [IndieStack](https://github.com/Pattyboi101/indiestack) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Search 7,500+ curated developer tools so agents find existing solutions instead of building from scratch. Covers auth, payments, databases, email, caching, monitoring, and more. No API key required. Install: `uvx --from indiestack indiestack-mcp`
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) [![tadas-github/a2asearch-mcp MCP server](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills. Install: `npx -y a2asearch-mcp`. Ask Claude: "Find MCP servers for database access". Free, no auth required.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.


### PR DESCRIPTION
Adds IndieStack to the Aggregators section — an MCP server that lets agents search 7,500+ curated developer tools (auth, payments, databases, email, caching, monitoring, etc.) before writing infrastructure from scratch. No API key required, 10k+ PyPI installs. Install: `uvx --from indiestack indiestack-mcp`

[![Pattyboi101/indiestack MCP server](https://glama.ai/mcp/servers/Pattyboi101/indiestack/badges/score.svg)](https://glama.ai/mcp/servers/Pattyboi101/indiestack)