### PR TITLE
Add sitemd MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [shadcn/studio MCP](https://shadcnstudio.com/mcp) - Integrate shadcn/studio MCP Server directly into your favorite IDE and craft stunning shadcn/ui Components, Blocks and Pages inspired by shadcn/studio.
 - [SimplyLiz/CodeMCP](https://github.com/SimplyLiz/CodeMCP) 🏎️ 🏠 🍎 🪟 🐧 - Code intelligence MCP server with 80+ tools for semantic code search, impact analysis, call graphs, ownership detection, and architectural understanding. Supports Go, TypeScript, Python, Rust, Java via SCIP indexing.
 - [simplypixi/bugbug-mcp-server](https://github.com/simplypixi/bugbug-mcp-server) ☁️ - MCP for BugBug API, to manage test and suites on BugBug
+- [sitemd-cc/sitemd](https://github.com/sitemd-cc/sitemd) 📇 🏠 🍎 🪟 🐧 - Build websites from Markdown. MCP server with 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [skullzarmy/vibealive](https://github.com/skullzarmy/vibealive) 📇 🏠 🍎 🪟 🐧 — Full-featured utility to test Next.js projects for unused files and APIs, with an MCP server that exposes project analysis tools to AI assistants.
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Connect any HTTP/REST API server using an Open API spec (v3)
 - [softvoyagers/linkshrink-api](https://github.com/softvoyagers/linkshrink-api) 📇 ☁️ - Free privacy-first URL shortener API with analytics and link management. No API key required.


### PR DESCRIPTION
Adds [sitemd-cc/sitemd](https://github.com/sitemd-cc/sitemd) under **Developer Tools**.

sitemd is an MCP server (and Claude Code / Cursor / Codex / Gemini plugin) that lets AI agents build, manage, and deploy websites from Markdown. 22 tools covering page creation, content validation, SEO audits, settings management, and Cloudflare Pages deployment.

- Repo: https://github.com/sitemd-cc/sitemd
- Site: https://sitemd.cc
- Insertion point: alphabetical, between `simplypixi/bugbug-mcp-server` and `skullzarmy/vibealive`