### PR TITLE
Add mcplab - MCP developer toolkit (CLI scaffolding + hot reload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp) 📇 🏠 - An MCP server to flexibly fetch JSON, text, and HTML data
 - [zelentsov-dev/asc-mcp](https://github.com/zelentsov-dev/asc-mcp) 🏠 🍎 - App Store Connect API server with 208 tools for managing apps, builds, TestFlight, subscriptions, reviews, and more — directly from any MCP client.
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
+- [zgc37359-lang/mcplab](https://github.com/zgc37359-lang/mcplab) 📇 🏠 🍎 🪟 🐧 - MCP developer toolkit: project scaffolding (`mcplab init`), hot-reload dev server (`mcplab dev`), interactive tool testing (`mcplab inspect`). Includes templates for OpenAPI, database, web scraping, and Feishu/Lark integration.
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
 


### PR DESCRIPTION
## Description

Adding **mcplab** — a developer toolkit for building MCP Servers, similar to what Vite is for frontend development.

**GitHub**: https://github.com/zgc37359-lang/mcplab
**npm**: https://www.npmjs.com/package/@zgc37359/mcplab

### What it does

mcplab is not an MCP Server itself, but a **development toolkit** for building MCP Servers:

- `mcplab init` — Interactive project scaffolding with 5 templates
- `mcplab dev` — Hot-reload development server (watches `.ts` files, auto-restarts)  
- `mcplab inspect` — Interactive tool testing in terminal (auto-discovers tools, lets you call them with custom params)
- `mcplab doctor` — Project health diagnostics (7 checks)

### Templates included

| Template | Description |
|----------|-------------|
| blank | Minimal starter with example tools |
| openapi | Auto-generate MCP tools from OpenAPI spec |
| database | MySQL/PostgreSQL query MCP with SQL injection protection |
| scraper | Web page fetching MCP |
| feishu | Feishu/Lark integration (send messages, create docs, query sheets) |

### Why this fits

mcplab is a **Developer Tools** entry — it helps developers build MCP Servers more efficiently. It's the only toolkit in this space with Chinese-language support and Feishu/Lark integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)