### PR TITLE
Add zerabic/agentweb-mcp to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1555,6 +1555,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [TimLukaHorstmann/mcp-weather](https://github.com/TimLukaHorstmann/mcp-weather) 📇 ☁️  - Accurate weather forecasts via the AccuWeather API (free tier available).
 - [trackmage/trackmage-mcp-server](https://github.com/trackmage/trackmage-mcp-server) 📇 - Shipment tracking api and logistics management capabilities through the [TrackMage API] (https://trackmage.com/)
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
+- [zerabic/agentweb-mcp](https://github.com/zerabic/agentweb-mcp) 📇 ☁️ - Free business directory MCP server: search and contribute to 12M+ businesses across 231 countries with phone, email, hours, websites, and geo search. Two-way (read + write) so agents can also enrich existing listings and report bad data. Built on OpenStreetMap + schema.org JSON-LD, no Google Places dependency, no API costs.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
Adds [agentweb-mcp](https://github.com/zerabic/agentweb-mcp) to the **Location Services** section.

## What it is

Free, agent-first business directory MCP server. 12M+ businesses across 231 countries with phone, email, opening hours, websites, addresses, and geo search. Built on OpenStreetMap (ODbL) and direct schema.org JSON-LD scraping of business websites — no Google Places dependency, no API costs.

## Why it might be useful for the list

There are several geocoding / mapping / weather servers in the Location Services section but very little for *finding actual businesses* — the closest existing entries are:
- ``bamwor-dev/bamwor-mcp-server`` (geo data, no business POIs)
- ``discava/mcp-server`` (similar — businesses + geo)
- ``modelcontextprotocol/server-google-maps`` (paid Google Places dependency)

agentweb-mcp adds a free, open-data option, and uniquely exposes **two-way tools** so agents can also contribute new businesses and report bad data:

- ``search_businesses`` — text + geo search
- ``get_business`` — full details by ID
- ``contribute_business`` — add new or enrich existing (auto-deduplicates by name+location and phone)
- ``report_business`` — flag closed/wrong/spam (3+ closed reports auto-lower trust score)
- ``agentweb_health``
- ``agentweb_leaderboard`` — top contributing AI agents

## Format

- ``📇`` (TypeScript codebase)
- ``☁️`` (talks to api.agentweb.live)
- Inserted in alphabetical order at the end of the Location Services section
- Single-line addition

## Install

\`\`\`bash
npm install -g agentweb-mcp
\`\`\`

\`\`\`json
{
  "mcpServers": {
    "agentweb": {
      "command": "npx",
      "args": ["-y", "agentweb-mcp"],
      "env": { "AGENTWEB_API_KEY": "aw_live_your_key" }
    }
  }
}
\`\`\`

Free signup at https://agentweb.live/#signup. Thanks for maintaining this list!