### PR TITLE
Add localdata-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [c4pt0r/mcp-server-tidb](https://github.com/c4pt0r/mcp-server-tidb) 🐍 ☁️ - TiDB database integration with schema inspection and query capabilities
 - [Canner/wren-engine](https://github.com/Canner/wren-engine) 🐍 🦀 🏠 - The Semantic Engine for Model Context Protocol(MCP) Clients and AI Agents
 - [centralmind/gateway](https://github.com/centralmind/gateway) 🏎️ 🏠 🍎 🪟 - MCP and MCP SSE Server that automatically generate API based on database schema and data. Supports PostgreSQL, Clickhouse, MySQL, Snowflake, BigQuery, Supabase
+- [ChrisGVE/localdata-mcp](https://github.com/ChrisGVE/localdata-mcp) 📇 🏠 - 52 tools for databases (13 types), files (20+ formats), graphs, and 8 data science domains including statistics, regression, clustering, and time series.
 - [ChristianHinge/dicom-mcp](https://github.com/ChristianHinge/dicom-mcp) 🐍 ☁️ 🏠 - DICOM integration to query, read, and move medical images and reports from PACS and other DICOM compliant systems.
 - [chroma-core/chroma-mcp](https://github.com/chroma-core/chroma-mcp) 🎖️ 🐍 ☁️ 🏠 - Chroma MCP server to access local and cloud Chroma instances for retrieval capabilities
 - [ClickHouse/mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse) 🐍 ☁️ - ClickHouse database integration with schema inspection and query capabilities


### PR DESCRIPTION
Adds [LocalData MCP](https://github.com/ChrisGVE/localdata-mcp) to the Databases section.

LocalData MCP is an MCP server providing 52 tools for databases (13 types), files (20+ formats), graphs, and 8 data science domains including statistics, regression, clustering, and time series.