### PR TITLE
Add subhatta123/twilize to Data Visualization 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ Interactive charts, dashboards, and visual data tools rendered inside AI convers
 - [Ratnaditya-J/csvglow](https://github.com/Ratnaditya-J/csvglow) [![csvglow MCP server](https://glama.ai/mcp/servers/Ratnaditya-J/csvglow/badges/score.svg)](https://glama.ai/mcp/servers/Ratnaditya-J/csvglow) 🐍 🏠 🍎 🪟 🐧 - Generate beautiful self-contained HTML dashboards from CSV/Excel files with interactive ECharts visualizations, dark gradient theme, and sortable data tables.
 
 - [nteract/semiotic](https://github.com/nteract/semiotic) [![nteract/semiotic MCP server](https://glama.ai/mcp/servers/nteract/semiotic/badges/score.svg)](https://glama.ai/mcp/servers/nteract/semiotic) 📇 🏠 🍎 🪟 🐧 - React data visualization MCP server with 30+ chart types. 5 tools: suggest charts for a dataset, render validated React configs to SVG, diagnose configuration anti-patterns, get component schemas, and report issues. 
+- [subhatta123/twilize](https://github.com/subhatta123/twilize) 🐍 🏠 🍎 🪟 🐧 - Programmatic Tableau workbook (.twb/.twbx) generation — 47 MCP tools for charts, dashboards, calculated fields, dashboard actions, workbook migration, and CSV-to-dashboard pipelines. Install via `uvx twilize`.
 
 ### 📟 <a name="embedded-system"></a>Embedded System
 


### PR DESCRIPTION
## Summary

Adds [twilize](https://github.com/subhatta123/twilize) to the **Data Visualization** section.

**twilize** is a Python MCP server for programmatic Tableau workbook (`.twb`/`.twbx`) generation with 47 MCP tools covering:

- 10+ chart types (Bar, Line, Area, Pie, Map, Scatter, Heatmap, TreeMap, Bubble, Text/KPI)
- Dual-axis charts + 6 recipe charts (Donut, Lollipop, Bullet, Bump, Butterfly, Calendar)
- Dashboard composition with filter and highlight actions
- Calculated fields, parameters, reference lines/bands/trend lines
- Workbook migration between datasources with fuzzy field matching
- CSV-to-dashboard end-to-end pipeline
- XSD schema validation against Tableau 2026.1 spec

**Install:** `pip install twilize` or `uvx twilize`  
**PyPI:** https://pypi.org/project/twilize/  
**License:** AGPL-3.0-or-later