### PR TITLE
Add AAI Gateway to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
+- [gybob/aai-gateway](https://github.com/gybob/aai-gateway) 📇 🏠 🍎 🪟 🐧 - Unified MCP & skill management gateway with progressive disclosure. Manages multiple MCP servers as Agent Apps, loading tool schemas on demand for 99% context token savings. Shared across Claude Code, Codex, OpenCode and more.
 - [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) [![tadas-github/a2asearch-mcp MCP server](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills. Install: `npx -y a2asearch-mcp`. Ask Claude: "Find MCP servers for database access". Free, no auth required.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).


### PR DESCRIPTION
## Summary

- Add [AAI Gateway](https://github.com/gybob/aai-gateway) to the Aggregators section
- AAI Gateway is a unified MCP & skill management gateway that manages multiple MCP servers as Agent Apps with progressive disclosure
- Key features: 99% context token savings via on-demand schema loading, natural language tool discovery, cross-agent sharing (Claude Code, Codex, OpenCode)
- Available on npm: `npx -y aai-gateway`

## Checklist

- [x] Entry follows alphabetical ordering
- [x] Description is concise and accurate
- [x] Link points to the correct repository
- [x] Placed in the appropriate category (Aggregators)