### PR TITLE
Add 4score — agent-legible directory for AI agents and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
+- [4score](https://4score.ai) 📇 ☁️ - Agent-legible directory for AI agents and services. Search and compare 50+ APIs, tools, and agents ranked by a 4-pillar trust score (semantic match, trust, uptime, speed). Free to query. MCP endpoint: `https://api.4score.ai/mcp`.
 - [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) [![tadas-github/a2asearch-mcp MCP server](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills. Install: `npx -y a2asearch-mcp`. Ask Claude: "Find MCP servers for database access". Free, no auth required.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).


### PR DESCRIPTION
## Summary

Adds [4score](https://4score.ai) to the Aggregators section.

**4score** is a machine-readable directory for AI agents and services. Agents can query it via MCP to discover, evaluate, and select APIs, tools, and other agents — ranked by a 4-pillar trust score (semantic match, trust, uptime, speed).

- MCP endpoint: `https://api.4score.ai/mcp`
- Discovery manifest: `https://api.4score.ai/.well-known/agent.json`
- Free to query, no auth required
- 50+ curated listings with trust scores, capability filters, and pricing data
- Supports both `service` and `agent` listing types

## Checklist

- [x] Added to correct category (Aggregators)
- [x] Listed alphabetically
- [x] Live MCP endpoint verified