### PR TITLE
Add RustChain MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [zolo-ryan/MarketAuxMcpServer](https://github.com/Zolo-Ryan/MarketAuxMcpServer) 📇 ☁️ - MCP server for comprehensive market and financial news search with advanced filtering by symbols, industries, countries, and date ranges.
 - [mnemox-ai/tradememory-protocol](https://github.com/mnemox-ai/tradememory-protocol) [Glama](https://glama.ai/mcp/servers/mnemox-ai/tradememory-protocol) 🐍 🏠 - Structured 3-layer memory system (trades → patterns → strategy) for AI trading agents. Supports MT5, Binance, and Alpaca.
 - [thoughtproof/thoughtproof-mcp](https://github.com/ThoughtProof/thoughtproof-mcp) [![thoughtproof-mcp MCP server](https://glama.ai/mcp/servers/ThoughtProof/thoughtproof-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ThoughtProof/thoughtproof-mcp) 📇 ☁️ - Adversarial multi-model reasoning verification for AI agents before trades execute. Claude, Grok, and DeepSeek challenge each decision — returns ALLOW or HOLD with JWKS-signed attestation. x402-gated on Base (USDC). Part of the 4-issuer Combined Attestation Standard with InsumerAPI, RNWY, and Maiat.
+- [RustChain](https://github.com/Scottcjn/Rustchain) - MCP server for RustChain blockchain. Connect AI agents to a Proof-of-Antiquity blockchain where old hardware earns more.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
## Add RustChain MCP Server to Finance & Fintech

RustChain provides an MCP server that connects AI agents to a Proof-of-Antiquity blockchain, fitting perfectly in the Finance & Fintech section.

### Entry Added

\\\markdown
- [RustChain](https://github.com/Scottcjn/Rustchain) - MCP server for RustChain blockchain. Connect AI agents to a Proof-of-Antiquity blockchain where old hardware earns more.
\\\