### PR TITLE
Add playwright-sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
 - [fradser/mcp-server-apple-reminders](https://github.com/FradSer/mcp-server-apple-reminders) 📇 🏠 🍎 - An MCP server for interacting with Apple Reminders on macOS
 - [freema/firefox-devtools-mcp](https://github.com/freema/firefox-devtools-mcp) 📇 🏠 - Firefox browser automation via WebDriver BiDi for testing, scraping, and browser control. Supports snapshot/UID-based interactions, network monitoring, console capture, and screenshots.
+- [gabrielantonyxaviour/playwright-sessions](https://github.com/gabrielantonyxaviour/playwright-sessions) 📇 🏠 - Persistent browser sessions for AI agents — save/restore auth, clone safely, detect expired logins, manage multiple isolated contexts. Fork of microsoft/playwright-mcp.
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 📇 🏠 - Extract structured data from any website. Just prompt and get JSON.
 - [hanzili/comet-mcp](https://github.com/hanzili/comet-mcp) 📇 🏠 🍎 - Connect to Perplexity Comet browser for agentic web browsing, deep research, and real-time task monitoring.
 - [LarryWalkerDEV/mcp-immostage](https://github.com/LarryWalkerDEV/mcp-immostage) 📇 ☁️ - AI virtual staging for real estate. Stage empty rooms, beautify floor plans into 3D renders, classify room images, generate property descriptions, and get style recommendations.


### PR DESCRIPTION
## Summary

Adds [playwright-sessions](https://github.com/gabrielantonyxaviour/playwright-sessions) to the **Browser Automation** section.

**playwright-sessions** is a session management layer on top of [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) that adds persistent browser sessions for AI agents:

- **Save/restore auth** — persist logged-in browser state across agent restarts
- **Safe cloning** — clone sessions without mutating the original
- **Expired login detection** — detect when saved sessions need re-authentication
- **Multiple isolated contexts** — manage several independent browser sessions simultaneously

Published on npm as [`playwright-sessions`](https://www.npmjs.com/package/playwright-sessions).

## Checklist

- [x] Entry added to the correct section (Browser Automation)
- [x] Alphabetical order maintained
- [x] Format matches existing entries
- [x] Correct language (📇 TypeScript) and scope (🏠 Local) icons