### PR TITLE
Add Synter Ads MCP server to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
   brand visibility monitoring via 16 specialized tools.
 - [stape-io/google-tag-manager-mcp-server](https://github.com/stape-io/google-tag-manager-mcp-server) 📇 ☁️ – This server supports remote MCP connections, includes built-in Google OAuth, and provide an interface to the Google Tag Manager API.
 - [stape-io/stape-mcp-server](https://github.com/stape-io/stape-mcp-server) 📇 ☁️ – This project implements an MCP (Model Context Protocol) server for the Stape platform. It allows interaction with the Stape API using AI assistants like Claude or AI-powered IDEs like Cursor.
+- [Synter-Media-AI/mcp-server](https://github.com/Synter-Media-AI/mcp-server) 📇 ☁️ - 29-tool MCP server for managing ad campaigns across Google, Meta, LinkedIn, Reddit, TikTok, and more. Create campaigns, pull metrics, update budgets, and generate creatives.
 - [tomba-io/tomba-mcp-server](https://github.com/tomba-io/tomba-mcp-server) 📇 ☁️ - Email discovery, verification, and enrichment tools. Find email addresses, verify deliverability, enrich contact data, discover authors and LinkedIn profiles, validate phone numbers, and analyze technology stacks.
 
 ### 📊 <a name="monitoring"></a>Monitoring


### PR DESCRIPTION
Adds [Synter Ads](https://github.com/Synter-Media-AI/mcp-server) to the Marketing section.

29-tool MCP server for managing ad campaigns across Google, Meta, LinkedIn, Reddit, TikTok, and more. Create campaigns, pull metrics, update budgets, and generate creatives.

- **npm:** `@synterai/mcp-server`
- **Remote server:** `https://mcp.syntermedia.ai/mcp/`
- **Docs:** https://docs.syntermedia.ai