### PR TITLE
Add BlazeDocs - PDF to Markdown MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [98lukehall/renoun-mcp](https://github.com/98lukehall/renoun-mcp) [![renoun-mcp MCP server](https://glama.ai/mcp/servers/@98lukehall/renoun-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@98lukehall/renoun-mcp) 🐍 ☁️ - Structural observability for AI conversations. Detects loops, stuck states, breakthroughs, and convergence across 17 channels without analyzing content.
 - [subelsky/bundler_mcp](https://github.com/subelsky/bundler_mcp) 💎 🏠 - Enables agents to query local information about dependencies in a Ruby project's `Gemfile`.
 - [zcaceres/markdownify-mcp](https://github.com/zcaceres/markdownify-mcp) 📇 🏠 - An MCP server to convert almost any file or web content into Markdown
+- [kyle93afc/blazedocs](https://github.com/kyle93afc/blazedocs/tree/main/packages/mcp-server) 📇 ☁️ 🏠 - Convert PDFs to Markdown with AI-powered OCR. Supports tables, formulas, handwriting, and 50+ languages. Install via `npx blazedocs-mcp`.
 
 ### 📊 <a name="data-visualization"></a>Data Visualization
 


### PR DESCRIPTION
## BlazeDocs MCP Server

Convert PDFs to Markdown using AI-powered OCR.

**Tools:**
- `convert_pdf` - Convert a full PDF to Markdown (local path or URL)
- `convert_pdf_pages` - Convert specific pages from a PDF
- `get_usage` - Check API usage and remaining quota

**Features:**
- Tables stay as tables (no broken formatting)
- Formulas become LaTeX
- Handwriting recognition
- 50+ languages supported
- Works with Claude Desktop, Cursor, Windsurf, VS Code, and any MCP client

**Install:**
```bash
npx blazedocs-mcp
```

**Config:**
```json
{
  "mcpServers": {
    "blazedocs": {
      "command": "npx",
      "args": ["blazedocs-mcp"],
      "env": {
        "BLAZEDOCS_API_KEY": "bd_live_..."
      }
    }
  }
}
```

**Links:**
- Homepage: https://blazedocs.io/mcp
- Source: https://github.com/kyle93afc/blazedocs/tree/main/packages/mcp-server
- npm: https://www.npmjs.com/package/blazedocs-mcp (pending publish)