### PR TITLE
Add lazymac/mcp and lazymac/k-mcp (42-tool unified MCP + Korean wedge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 Servers for accessing many apps and tools through a single MCP server.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
+- [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp, ...) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
+- [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance scan, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. English JSON. `npx -y @lazymac/k-mcp`
 - [tadas-github/a2asearch-mcp](https://github.com/tadas-github/a2asearch-mcp) [![tadas-github/a2asearch-mcp MCP server](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/tadas-github/a2asearch-mcp) 📇 ☁️ - MCP server to search 4,800+ MCP servers, AI agents, CLI tools and agent skills. Install: `npx -y a2asearch-mcp`. Ask Claude: "Find MCP servers for database access". Free, no auth required.
 - [Aganium/agenium](https://github.com/Aganium/agenium) 📇 ☁️ 🍎 🪟 🐧 - Bridge any MCP server to the agent:// network — DNS-like identity, discovery, and trust for AI agents. Makes your tools discoverable and callable by other agents via `agent://` URIs with mTLS, trust scores, and capability search.
 - [espadaw/Agent47](https://github.com/espadaw/Agent47) 📇 ☁️ - Unified job aggregator for AI agents across 9+ platforms (x402, RentAHuman, Virtuals, etc).


### PR DESCRIPTION
## What

Adds two MCP servers I shipped this week:

- **`@lazymac/mcp`** — unified MCP server exposing 42 developer tools backed by [api.lazy-mac.com](https://api.lazy-mac.com) (Cloudflare Workers, sub-200ms p95). Free 100/day tier. One install gives you `qr_generate`, `url_shorten`, `ip_geo`, `tech_stack_detect`, `ai_cost_calculator`, `llm_router`, `seo_analyzer`, `email_validator`, K-MCP tools, etc.
- **`@lazymac/k-mcp`** — Korean wedge MCP for PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, Korean address geocoding, NLP. English JSON.

## Why

Most MCP servers expose 1-3 tools. `lazymac/mcp` aggregates 42 production tools through one install, so any agent can access the full toolbox without configuring 30 servers.

## Links

- npm: https://www.npmjs.com/package/@lazymac/mcp
- npm: https://www.npmjs.com/package/@lazymac/k-mcp
- Smithery: https://smithery.ai/server/lazymac/mcp
- Source: https://github.com/lazymac2x/lazymac-mcp

Both packages are MIT, both indexed on Smithery, both work with Claude Code / Cursor / Windsurf out of the box.
