### PR TITLE
Add Ham Radio category with oeradio-mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 > We now have a [web-based directory](https://glama.ai/mcp/servers) that is synced with the repository.
 
 * 🔗 - [Aggregators](#aggregators)
+* 📡 - [Ham Radio](#ham-radio)
 * 🎨 - [Art & Culture](#art-and-culture)
 * 📐 - [Architecture & Design](#architecture-and-design)
 * 📂 - [Browser Automation](#browser-automation)
@@ -196,6 +197,12 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [gregario/astronomy-oracle](https://github.com/gregario/astronomy-oracle) [![astronomy-oracle MCP server](https://glama.ai/mcp/servers/gregario/astronomy-oracle/badges/score.svg)](https://glama.ai/mcp/servers/gregario/astronomy-oracle) 📇 🏠 🍎 🪟 🐧 - Accurate astronomical catalog data and observing session planner. 13,000+ deep-sky objects from OpenNGC with deterministic visibility, rise/transit/set, and alt/az calculations. `npx astronomy-oracle`
 - [IO-Aerospace-software-community/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
+
+### 📡 <a name="ham-radio"></a>Ham Radio
+
+Tools for radio amateurs (ham radio operators) — band plans, antenna design, propagation data, RF calculators and reference information.
+
+- [achildrenmile/oeradio-mcp](https://github.com/achildrenmile/oeradio-mcp) 📇 ☁️ 🏠 🐧 - Amateur radio calculations and reference data for AI assistants. 11 tools covering IARU Region 1 band plans, dipole/EFHW/vertical antenna design, coax cable attenuation, EIRP calculations, battery runtime for portable operation and propagation. Live endpoint at `oeradio-mcp.oeradio.at/mcp`, self-hostable via Docker.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 


### PR DESCRIPTION
## Summary

Adds a new **📡 Ham Radio** category for MCP servers targeting radio amateurs, and adds the first entry: [`oeradio-mcp`](https://github.com/achildrenmile/oeradio-mcp).

## Why a new category?

Ham radio tooling doesn't fit neatly into existing categories like *Aerospace & Astrodynamics*, *Research* or *Education*. The amateur radio community has ~3 million licensed operators worldwide and distinct technical needs (band plans, antenna design, propagation, RF calculations) that are already covered by MCP tooling and likely to grow. A dedicated category keeps discovery easy for that audience and avoids diluting the Research section.

## About oeradio-mcp

Part of the [oeradio.at](https://oeradio.at) open source ham radio toolset. The MCP server gives Claude, ChatGPT and Gemini direct access to 11 amateur radio tools:

- IARU Region 1 band plans (HF / VHF / UHF with mode segments)
- Dipole, EFHW and vertical antenna dimension calculators
- Coax cable attenuation (RG-213, LMR-400, Aircom, Ecoflex, …)
- EIRP and ERP calculations
- Battery runtime estimation for portable / SOTA / POTA operation
- Propagation and wavelength references

**Live endpoint:** `https://oeradio-mcp.oeradio.at/mcp` (no registration)
**Source:** https://github.com/achildrenmile/oeradio-mcp (MIT, TypeScript)
**Self-hostable:** Docker image included

## Changes

- New TOC entry after Aggregators
- New `### 📡 Ham Radio` section after Aerospace & Astrodynamics
- One entry for `achildrenmile/oeradio-mcp`

No existing entries touched.