### PR TITLE
Add aloha.fyi Hawaii MCP to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1529,6 +1529,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 Location-based services and mapping tools. Enables AI models to work with geographic data, weather information, and location-based analytics.
 
 - [bamwor-dev/bamwor-mcp-server](https://github.com/bamwor-dev/bamwor-mcp-server) [![bamwor-mcp-server MCP server](https://glama.ai/mcp/servers/bamwor-dev/bamwor-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/bamwor-dev/bamwor-mcp-server) 📇 ☁️ - World geographic data for AI agents. 261 countries with 20+ statistics and 13.4M cities with population, coordinates, and timezone. Powered by Bamwor API.
+- [baphometnxg/aloha-fyi-mcp](https://github.com/baphometnxg/aloha-fyi-mcp) 📇 ☁️ - First dedicated Hawaii tourism MCP server. 2,583 bookable tours from Viator, GetYourGuide, Klook, and Groupon, plus 579 events across 70+ venues on Oahu, Maui, Big Island, and Kauai. Results ship with affiliate booking links. Hosted Streamable HTTP endpoint — no install required. Powered by [aloha.fyi](https://aloha.fyi).
 - [briandconnelly/mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo) 🐍 ☁️  - IP address geolocation and network information using IPInfo API
 - [cqtrinv/trinvmcp](https://github.com/cqtrinv/trinvmcp) 📇 ☁️ - Explore French communes and cadastral parcels based on name and surface
 - [devilcoder01/weather-mcp-server](https://github.com/devilcoder01/weather-mcp-server) 🐍 ☁️ - Access real-time weather data for any location using the WeatherAPI.com API, providing detailed forecasts and current conditions.


### PR DESCRIPTION
Adds **aloha.fyi Hawaii MCP** to Location Services — first dedicated Hawaii tourism MCP server.

## What it does

Exposes 2,583 bookable Hawaii tours, activities, and experiences from Viator, GetYourGuide, Klook, and Groupon, plus 579 events across 70+ venues on Oahu, Maui, Big Island, and Kauai. Every result ships with an affiliate booking link.

Three tools: `search_hawaii_tours`, `get_hawaii_deals`, `search_hawaii_events`.

## Details

- **Language:** TypeScript 📇
- **Scope:** Cloud ☁️
- **Repo:** https://github.com/baphometnxg/aloha-fyi-mcp
- **Hosted endpoint:** https://mcp-server-nani-v3-20.up.railway.app/mcp
- **Transport:** Streamable HTTP (stateless), protocol `2025-03-26`
- **Auth:** none (public, read-only)
- **License:** MIT
- **Website:** https://aloha.fyi
- **Privacy:** https://www.aloha.fyi/privacy

Inserted alphabetically between `bamwor-dev/bamwor-mcp-server` and `briandconnelly/mcp-server-ipinfo`.

Thanks for maintaining this list!