### PR TITLE
Add touch-grass to Environment & Nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,7 @@ MCP servers for e-commerce platforms and online store management.
 Provides access to environmental data and nature-related tools, services and information.
 
 - [aliafsahnoudeh/wildfire-mcp-server](https://github.com/aliafsahnoudeh/wildfire-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server for detecting, monitoring, and analyzing potential wildfires globally using multiple data sources including NASA FIRMS, OpenWeatherMap, and Google Earth Engine.
+- [nalediym/touch-grass](https://github.com/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
 
 ### 📂 <a name="file-systems"></a>File Systems
 

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ MCP servers for e-commerce platforms and online store management.
 Provides access to environmental data and nature-related tools, services and information.
 
 - [aliafsahnoudeh/wildfire-mcp-server](https://github.com/aliafsahnoudeh/wildfire-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server for detecting, monitoring, and analyzing potential wildfires globally using multiple data sources including NASA FIRMS, OpenWeatherMap, and Google Earth Engine.
-- [nalediym/touch-grass](https://github.com/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
+- [nalediym/touch-grass](https://github.com/nalediym/touch-grass) [![nalediym/touch-grass MCP server](https://glama.ai/mcp/servers/nalediym/touch-grass/badges/score.svg)](https://glama.ai/mcp/servers/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
 
 ### 📂 <a name="file-systems"></a>File Systems
 


### PR DESCRIPTION
touch-grass is a Claude Code plugin and MCP server that suggests outdoor breaks based on real-time weather, sunset timing, and session streaks, so coding agents (and their humans) get nudged to step away from the keyboard at sensible moments. It exposes four tools — `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, and `get_stats` — and tracks a local streak so the nudge adapts to recent behavior.

Filed under 🌳 Environment & Nature because the core value comes from reading environmental data (weather, daylight, local conditions) to recommend outdoor activity, which matches that section's stated scope.

TypeScript (📇) and fully local (🏠): no server to run, no API keys, no cloud storage — installs via the Claude Code plugin or as a standalone MCP server. Runs on macOS, Windows, and Linux.