### PR TITLE
Add DataLayer MCP Server (B2B data enrichment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [ConechoAI/openai-websearch-mcp](https://github.com/ConechoAI/openai-websearch-mcp/) 🐍 🏠 ☁️ - This is a Python-based MCP server that provides OpenAI `web_search` built-in tool.
 - [Crawleo/Crawleo-MCP](https://github.com/Crawleo/Crawleo-MCP) ☁️ 🐍 – Crawleo Search & Crawl API
 - [czottmann/kagi-ken-mcp](https://github.com/czottmann/kagi-ken-mcp) 📇 ☁️ - Work with Kagi *without* API access (you'll need to be a customer, tho). Searches and summarizes. Uses Kagi session token for easy authentication.
+- [datalayer-sh/mcp](https://github.com/datalayer-sh/mcp) 📇 ☁️ - B2B data enrichment for AI agents — enrich companies and contacts, find work emails and phone numbers, search 60M+ companies and 300M+ contacts, discover tech stacks, and identify buying intent signals. Licensed data, GDPR/CCPA compliant.
 - [DappierAI/dappier-mcp](https://github.com/DappierAI/dappier-mcp) 🐍 ☁️ - Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.
 - [deadletterq/mcp-opennutrition](https://github.com/deadletterq/mcp-opennutrition) 📇 🏠 - Local MCP server for searching 300,000+ foods, nutrition facts, and barcodes from the OpenNutrition database.
 - [dealx/mcp-server](https://github.com/DealExpress/mcp-server) ☁️ - MCP Server for DealX platform


### PR DESCRIPTION
## DataLayer MCP Server

**Repository**: https://github.com/datalayer-sh/mcp
**npm**: [@datalayer-sh/mcp](https://www.npmjs.com/package/@datalayer-sh/mcp)
**Category**: Search & Data Extraction

### What it does
B2B data enrichment for AI agents — 11 tools covering:
- Enrich companies and contacts by domain, email, LinkedIn URL
- Find work emails and phone numbers
- Search 60M+ companies and 300M+ contacts with rich filters
- Discover tech stacks across 16 categories
- Identify buying intent signals (Google ad spend, hiring velocity, employee growth, funding)

### Why it's useful
Developers building AI-powered sales pipelines, GTM automation, and CRM enrichment need a way for their agents to access B2B data. This MCP server makes that possible with natural language — no HTTP requests needed.

### Details
- **Language**: TypeScript (📇)
- **Transport**: stdio
- **Install**: `npx -y @datalayer-sh/mcp`
- **License**: MIT
- **Data**: Licensed, GDPR/CCPA compliant (not scraped)