### PR TITLE
Add RepairXpertAI IndAutomation (Industrial fault diagnosis MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,6 +1381,11 @@ Control smart home devices, home network equipment, and automation systems.
 - [Hybirdss/smartest-tv](https://github.com/Hybirdss/smartest-tv) [![Hybirdss/smartest-tv MCP server](https://glama.ai/mcp/servers/Hybirdss/smartest-tv/badges/score.svg)](https://glama.ai/mcp/servers/Hybirdss/smartest-tv) 🐍 🏠 🍎 🪟 🐧 - Control any smart TV with natural language. Play Netflix, YouTube, Spotify by name with deep linking, cast URLs, scene presets, multi-room audio, and multi-TV sync. Supports LG, Samsung, Android TV, Roku. 21 MCP tools, no cloud required.
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
+
+### 🏭 <a name="industrial-and-manufacturing"></a>Industrial & Manufacturing
+
+- [RepairXpertAI IndAutomation](https://github.com/RepairXpert/indautomation) 🐍 🏠 - AI-powered industrial fault diagnosis with 313 fault codes covering Allen-Bradley, Siemens, ABB, Mitsubishi, Fanuc. 8 MCP tools: diagnose faults, search parts, decode VINs, get equipment profiles.
+
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.

--- a/README.md
+++ b/README.md
@@ -1384,7 +1384,7 @@ Control smart home devices, home network equipment, and automation systems.
 
 ### 🏭 <a name="industrial-and-manufacturing"></a>Industrial & Manufacturing
 
-- [RepairXpertAI IndAutomation](https://github.com/RepairXpert/indautomation) 🐍 🏠 - AI-powered industrial fault diagnosis with 313 fault codes covering Allen-Bradley, Siemens, ABB, Mitsubishi, Fanuc. 8 MCP tools: diagnose faults, search parts, decode VINs, get equipment profiles.
+- [RepairXpert/indautomation](https://github.com/RepairXpert/indautomation) [![RepairXpert/indautomation MCP server](https://glama.ai/mcp/servers/RepairXpert/indautomation/badges/score.svg)](https://glama.ai/mcp/servers/RepairXpert/indautomation) 🐍 🏠 - AI-powered industrial fault diagnosis with 313 fault codes covering Allen-Bradley, Siemens, ABB, Mitsubishi, Fanuc. 8 MCP tools: diagnose faults, search parts, decode VINs, get equipment profiles.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
 * 🏠 - [Home Automation](#home-automation)
+* 🏭 - [Industrial & Manufacturing](#industrial--manufacturing)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * ⚖️ - [Legal](#legal)
 * 🗺️ - [Location Services](#location-services)
@@ -1381,10 +1382,11 @@ Control smart home devices, home network equipment, and automation systems.
 - [Hybirdss/smartest-tv](https://github.com/Hybirdss/smartest-tv) [![Hybirdss/smartest-tv MCP server](https://glama.ai/mcp/servers/Hybirdss/smartest-tv/badges/score.svg)](https://glama.ai/mcp/servers/Hybirdss/smartest-tv) 🐍 🏠 🍎 🪟 🐧 - Control any smart TV with natural language. Play Netflix, YouTube, Spotify by name with deep linking, cast URLs, scene presets, multi-room audio, and multi-TV sync. Supports LG, Samsung, Android TV, Roku. 21 MCP tools, no cloud required.
 - [kambriso/fritzbox-mcp-server](https://github.com/kambriso/fritzbox-mcp-server) 🏎️ 🏠 - Control AVM FRITZ!Box routers - manage devices, WiFi, network settings, parental controls, and schedule time-delayed actions
 
+### 🏭 <a name="industrial--manufacturing"></a>Industrial & Manufacturing
 
-### 🏭 <a name="industrial-and-manufacturing"></a>Industrial & Manufacturing
+AI-powered tools for industrial automation, fault diagnosis, and manufacturing operations.
 
-- [RepairXpert/indautomation](https://github.com/RepairXpert/indautomation) [![RepairXpert/indautomation MCP server](https://glama.ai/mcp/servers/RepairXpert/indautomation/badges/score.svg)](https://glama.ai/mcp/servers/RepairXpert/indautomation) 🐍 🏠 - AI-powered industrial fault diagnosis with 313 fault codes covering Allen-Bradley, Siemens, ABB, Mitsubishi, Fanuc. 8 MCP tools: diagnose faults, search parts, decode VINs, get equipment profiles.
+- [RepairXpert/indautomation](https://github.com/RepairXpert/indautomation) [![RepairXpert/indautomation MCP server](https://glama.ai/mcp/servers/RepairXpert/indautomation/badges/score.svg)](https://glama.ai/mcp/servers/RepairXpert/indautomation) 🐍 🏠 🪟 🐧 - AI-powered industrial fault diagnosis with 78+ fault codes covering Allen-Bradley PLCs, conveyors, AS/RS, packaging lines. 8 MCP tools: diagnose faults, search parts, decode VINs, get equipment profiles.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds RepairXpertAI IndAutomation to a new "Industrial & Manufacturing" category.

- **8 MCP tools**: diagnose_fault, search_parts, get_equipment_profile, list_fault_codes, get_fault_detail, search_faults, decode_vin, get_diagnosis_history
- **313 fault codes** covering Allen-Bradley, Siemens, ABB, Mitsubishi, Fanuc PLCs and drives
- **AI vision**: Photo-based fault diagnosis via local LLM
- Python (FastAPI), runs locally on Windows/Linux

This is the first industrial automation MCP server in the list.