### PR TITLE
Add Zacccck/Claude-MCP-Read-Email-Attachments to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Integration with communication platforms for message management and channel oper
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) 📇 ☁️ - An MCP server to Manage Google Tasks
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.
 - [loglux/whatsapp-mcp-stream](https://github.com/loglux/whatsapp-mcp-stream) [![whatsapp-mcp-stream MCP server](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream/badges/score.svg)](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream) 📇 🏠 🍎 🪟 🐧 - WhatsApp MCP server over Streamable HTTP with web admin UI (QR/status/settings), bidirectional media upload/download, and SQLite persistence.
+- [Zacccck/Claude-MCP-Read-Email-Attachments](https://github.com/Zacccck/Claude-MCP-Read-Email-Attachments) 📇 ☁️ 🏠 🪟 - Remote HTTP MCP server that reads Outlook email attachments via Microsoft Graph. Parses PDF, Word (with embedded image extraction for multimodal analysis), Excel, and text files in-memory and returns structured content directly to Claude.
 
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms


### PR DESCRIPTION
## What is this?

A remote HTTP MCP server that lets Claude read and deeply parse Outlook email attachments (PDF, Word, Excel, CSV, plain text) via Microsoft Graph API.

**Key differentiator:** Extracts embedded images from DOCX files and sends them as MCP image content blocks for multimodal analysis — Claude can see charts, diagrams, and figures inside Word documents.

**Why it matters:** Claude's built-in M365 connector can list emails and read message bodies, but cannot access attachment content. This server fills that gap.

GitHub: https://github.com/Zacccck/Claude-MCP-Read-Email-Attachments