### PR TITLE
Add networklytics-mcp: YouTube comment network analysis MCP server

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -220,6 +220,7 @@
 데이터 통합, 변환 및 파이프라인 오케스트레이션을 위한 데이터 플랫폼.
 
 - [flowcore/mcp-flowcore-platform](https://github.com/flowcore-io/mcp-flowcore-platform) 🎖️📇☁️🏠 - Flowcore와 상호 작용하여 작업을 수행하고, 데이터를 수집하고, 데이터 코어나 공개 데이터 코어에 있는 모든 데이터를 분석, 교차 참조하고 활용할 수 있습니다. 이 모든 작업은 인간 언어를 사용합니다.
+- [networklytics-mcp](https://pypi.org/project/networklytics-mcp/) - YouTube 댓글 소셜 네트워크 분석(SNA): 인플루언서 중심성 순위, 커뮤니티 감지(Louvain), 감성 분석, AI 에이전트용 공개 JSON API
 
 
 ### 🗄️ <a name="databases"></a>데이터베이스

--- a/README-ko.md
+++ b/README-ko.md
@@ -220,7 +220,8 @@
 데이터 통합, 변환 및 파이프라인 오케스트레이션을 위한 데이터 플랫폼.
 
 - [flowcore/mcp-flowcore-platform](https://github.com/flowcore-io/mcp-flowcore-platform) 🎖️📇☁️🏠 - Flowcore와 상호 작용하여 작업을 수행하고, 데이터를 수집하고, 데이터 코어나 공개 데이터 코어에 있는 모든 데이터를 분석, 교차 참조하고 활용할 수 있습니다. 이 모든 작업은 인간 언어를 사용합니다.
-- [networklytics-mcp](https://pypi.org/project/networklytics-mcp/) - YouTube 댓글 소셜 네트워크 분석(SNA): 인플루언서 중심성 순위, 커뮤니티 감지(Louvain), 감성 분석, AI 에이전트용 공개 JSON API
+- [networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) - YouTube 댓글 소셜 네트워크 분석(SNA): 인플루언서 중심성 순위, 커뮤니티 감지(Louvain), 감성 분석, AI 에이전트용 공개 JSON API
+
 
 
 ### 🗄️ <a name="databases"></a>데이터베이스

--- a/README-ko.md
+++ b/README-ko.md
@@ -220,7 +220,7 @@
 데이터 통합, 변환 및 파이프라인 오케스트레이션을 위한 데이터 플랫폼.
 
 - [flowcore/mcp-flowcore-platform](https://github.com/flowcore-io/mcp-flowcore-platform) 🎖️📇☁️🏠 - Flowcore와 상호 작용하여 작업을 수행하고, 데이터를 수집하고, 데이터 코어나 공개 데이터 코어에 있는 모든 데이터를 분석, 교차 참조하고 활용할 수 있습니다. 이 모든 작업은 인간 언어를 사용합니다.
-- [networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) - YouTube 댓글 소셜 네트워크 분석(SNA): 인플루언서 중심성 순위, 커뮤니티 감지(Louvain), 감성 분석, AI 에이전트용 공개 JSON API
+-- [Leekangbum/networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) 🐍 - YouTube 댓글 소셜 네트워크 분석(SNA): 인플루언서 중심성 순위, 커뮤니티 감지(Louvain), 감성 분석, AI 에이전트용 공개 JSON API
 
 
 

--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 - [saikiyusuke/registep-mcp](https://github.com/saikiyusuke/registep-mcp) 📇 ☁️ - AI-powered POS & sales analytics MCP server with 67 tools for Airレジ, スマレジ, and BASE EC integration. Provides store management, sales data querying, AI chat analysis, and weather correlation features.
 - [vikramgorla/mcp-swiss](https://github.com/vikramgorla/mcp-swiss) [![mcp-swiss](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss/badges/score.svg)](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss) 📇 ☁️ - 68 tools for Swiss open data: transport, weather, geodata, companies, parliament, and more. Zero API keys required.
 - [yashshingvi/databricks-genie-MCP](https://github.com/yashshingvi/databricks-genie-MCP) 🐍 ☁️ - A server that connects to the Databricks Genie API, allowing LLMs to ask natural language questions, run SQL queries, and interact with Databricks conversational agents.
+- [networklytics-mcp](https://pypi.org/project/networklytics-mcp/) - YouTube comment social network analysis (SNA): influencer centrality ranking, community detection (Louvain), sentiment analysis, and public JSON API for AI agents
 
 
 ### 💻 <a name="developer-tools"></a>Developer Tools

--- a/README.md
+++ b/README.md
@@ -708,7 +708,8 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 - [saikiyusuke/registep-mcp](https://github.com/saikiyusuke/registep-mcp) 📇 ☁️ - AI-powered POS & sales analytics MCP server with 67 tools for Airレジ, スマレジ, and BASE EC integration. Provides store management, sales data querying, AI chat analysis, and weather correlation features.
 - [vikramgorla/mcp-swiss](https://github.com/vikramgorla/mcp-swiss) [![mcp-swiss](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss/badges/score.svg)](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss) 📇 ☁️ - 68 tools for Swiss open data: transport, weather, geodata, companies, parliament, and more. Zero API keys required.
 - [yashshingvi/databricks-genie-MCP](https://github.com/yashshingvi/databricks-genie-MCP) 🐍 ☁️ - A server that connects to the Databricks Genie API, allowing LLMs to ask natural language questions, run SQL queries, and interact with Databricks conversational agents.
-- [networklytics-mcp](https://pypi.org/project/networklytics-mcp/) - YouTube comment social network analysis (SNA): influencer centrality ranking, community detection (Louvain), sentiment analysis, and public JSON API for AI agents
+- [networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) - YouTube comment social network analysis (SNA): influencer centrality ranking, community detection (Louvain), sentiment analysis, and public JSON API for AI agents
+
 
 
 ### 💻 <a name="developer-tools"></a>Developer Tools

--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 - [saikiyusuke/registep-mcp](https://github.com/saikiyusuke/registep-mcp) 📇 ☁️ - AI-powered POS & sales analytics MCP server with 67 tools for Airレジ, スマレジ, and BASE EC integration. Provides store management, sales data querying, AI chat analysis, and weather correlation features.
 - [vikramgorla/mcp-swiss](https://github.com/vikramgorla/mcp-swiss) [![mcp-swiss](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss/badges/score.svg)](https://glama.ai/mcp/servers/vikramgorla/mcp-swiss) 📇 ☁️ - 68 tools for Swiss open data: transport, weather, geodata, companies, parliament, and more. Zero API keys required.
 - [yashshingvi/databricks-genie-MCP](https://github.com/yashshingvi/databricks-genie-MCP) 🐍 ☁️ - A server that connects to the Databricks Genie API, allowing LLMs to ask natural language questions, run SQL queries, and interact with Databricks conversational agents.
-- [networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) - YouTube comment social network analysis (SNA): influencer centrality ranking, community detection (Louvain), sentiment analysis, and public JSON API for AI agents
+- [Leekangbum/networklytics-mcp](https://github.com/Leekangbum/networklytics-mcp) 🐍 - YouTube comment social network analysis (SNA): influencer centrality ranking, community detection (Louvain), sentiment analysis, and public JSON API for AI agents
 
 
 


### PR DESCRIPTION
Adds a single MCP server for YouTube comment social network analysis.

- GitHub: https://github.com/Leekangbum/networklytics-mcp
- Analyzes influencer centrality, community detection (Louvain), sentiment analysis
- Public JSON API — no auth needed for shared links
- pip install networklytics-mcp

