### PR TITLE
🤖🤖🤖 Add Inday - Public Holiday API MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2022,7 +2022,7 @@ Tools for converting text-to-speech and vice-versa
 
 Access to travel and transportation information. Enables querying schedules, routes, and real-time travel data.
 
-- [gokhanibrikci/inday-mcp-server](https://github.com/gokhanibrikci/inday-mcp-server) 📇 ☁️ - Public holiday API for 30+ countries. Check holidays, count working days, and get full year calendars. Supports check_holiday, get_calendar, list_countries, next_holiday, count_working_days. Free tier available.
+- [gokhanibrikci/inday-mcp-server](https://github.com/gokhanibrikci/inday-mcp-server) [![Inday MCP Server](https://glama.ai/mcp/servers/gokhanibrikci/inday-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/gokhanibrikci/inday-mcp-server) 📇 ☁️ - Public holiday API for 30+ countries. Check holidays, count working days, and get full year calendars. Supports check_holiday, get_calendar, list_countries, next_holiday, count_working_days. Free tier available.
 
 - [alcylu/nightlife-mcp](https://github.com/alcylu/nightlife-mcp) [![nightlife](https://glama.ai/mcp/servers/alcylu/nightlife-mcp/badges/score.svg)](https://glama.ai/mcp/servers/alcylu/nightlife-mcp) 📇 ☁️ - MCP server for Tokyo nightlife event discovery, venue search, performer info, AI recommendations, and VIP table booking.
 - [campertunity/mcp-server](https://github.com/campertunity/mcp-server) 🎖️ 📇 🏠 - Search campgrounds around the world on campertunity, check availability, and provide booking links

--- a/README.md
+++ b/README.md
@@ -2022,6 +2022,8 @@ Tools for converting text-to-speech and vice-versa
 
 Access to travel and transportation information. Enables querying schedules, routes, and real-time travel data.
 
+- [gokhanibrikci/inday-mcp-server](https://github.com/gokhanibrikci/inday-mcp-server) 📇 ☁️ - Public holiday API for 30+ countries. Check holidays, count working days, and get full year calendars. Supports check_holiday, get_calendar, list_countries, next_holiday, count_working_days. Free tier available.
+
 - [alcylu/nightlife-mcp](https://github.com/alcylu/nightlife-mcp) [![nightlife](https://glama.ai/mcp/servers/alcylu/nightlife-mcp/badges/score.svg)](https://glama.ai/mcp/servers/alcylu/nightlife-mcp) 📇 ☁️ - MCP server for Tokyo nightlife event discovery, venue search, performer info, AI recommendations, and VIP table booking.
 - [campertunity/mcp-server](https://github.com/campertunity/mcp-server) 🎖️ 📇 🏠 - Search campgrounds around the world on campertunity, check availability, and provide booking links
 - [cobanov/teslamate-mcp](https://github.com/cobanov/teslamate-mcp) 🐍 🏠 - A Model Context Protocol (MCP) server that provides access to your TeslaMate database, allowing AI assistants to query Tesla vehicle data and analytics.


### PR DESCRIPTION
## Description

Adding **Inday** — a remote MCP server that provides public holiday data for 30+ countries.

## Server Details

- **MCP Endpoint:** `https://inday.co/api/mcp`
- **Transport:** Streamable HTTP
- **Auth:** `X-API-KEY` header (free tier at inday.co/signup)
- **GitHub:** https://github.com/gokhanibrikci/inday-mcp-server
- **Published on Official MCP Registry:** `io.github.gokhanibrikci/inday-holiday-api`

## Tools (5)

| Tool | Description |
|------|-------------|
| `check_holiday` | Check if a date is a public holiday |
| `get_calendar` | Full year holiday calendar for a country |
| `list_countries` | List all supported countries |
| `next_holiday` | Find the next upcoming holiday |
| `count_working_days` | Count working days between two dates |

## Category

Added to **Travel & Transportation** section (public holidays are essential for travel, payroll, and scheduling use cases).

## Checklist

- [x] Server is publicly accessible and working
- [x] Free tier available (100 req/month, no credit card)
- [x] Published on Official MCP Registry
- [x] README with setup instructions for Claude Desktop, Cursor, VS Code