### PR TITLE
Add healthcare-fhir-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [healthcare-fhir-mcp](https://github.com/CSOAI-ORG/healthcare-fhir-mcp) - MEOK AI Labs — healthcare fhir MCP Server


### PR DESCRIPTION
Adding healthcare-fhir-mcp.

MEOK AI Labs — healthcare fhir MCP Server

**Repository**: https://github.com/CSOAI-ORG/healthcare-fhir-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*