### PR TITLE
Add stripe-billing-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [stripe-billing-mcp](https://github.com/CSOAI-ORG/stripe-billing-mcp) - MEOK AI Labs — stripe billing MCP Server


### PR DESCRIPTION
Adding stripe-billing-mcp.

MEOK AI Labs — stripe billing MCP Server

**Repository**: https://github.com/CSOAI-ORG/stripe-billing-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*