### PR TITLE
Add muckaway-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [muckaway-ai-mcp](https://github.com/CSOAI-ORG/muckaway-ai-mcp) - MEOK AI Labs — muckaway MCP Server


### PR DESCRIPTION
Adding muckaway-ai-mcp.

MEOK AI Labs — muckaway MCP Server

**Repository**: https://github.com/CSOAI-ORG/muckaway-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*