### PR TITLE
Add planthire-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [planthire-ai-mcp](https://github.com/CSOAI-ORG/planthire-ai-mcp) - MEOK AI Labs — planthire MCP Server


### PR DESCRIPTION
Adding planthire-ai-mcp.

MEOK AI Labs — planthire MCP Server

**Repository**: https://github.com/CSOAI-ORG/planthire-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*