### PR TITLE
Add budget-planner-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [budget-planner-ai-mcp](https://github.com/CSOAI-ORG/budget-planner-ai-mcp) - MEOK AI Labs — budget planner MCP Server


### PR DESCRIPTION
Adding budget-planner-ai-mcp.

MEOK AI Labs — budget planner MCP Server

**Repository**: https://github.com/CSOAI-ORG/budget-planner-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*