### PR TITLE
Add churn-predictor-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [churn-predictor-ai-mcp](https://github.com/CSOAI-ORG/churn-predictor-ai-mcp) - MEOK AI Labs — churn predictor MCP Server


### PR DESCRIPTION
Adding churn-predictor-ai-mcp.

MEOK AI Labs — churn predictor MCP Server

**Repository**: https://github.com/CSOAI-ORG/churn-predictor-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*