### PR TITLE
Add color-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [color-ai-mcp](https://github.com/CSOAI-ORG/color-ai-mcp) - MEOK AI Labs — color MCP Server


### PR DESCRIPTION
Adding color-ai-mcp.

MEOK AI Labs — color MCP Server

**Repository**: https://github.com/CSOAI-ORG/color-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*