### PR TITLE
Add content-calendar-ai-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2306,3 +2306,4 @@ Now Claude can answer questions about writing MCP servers and how they work
  </picture>
 </a>
 .
+- [content-calendar-ai-mcp](https://github.com/CSOAI-ORG/content-calendar-ai-mcp) - MEOK AI Labs — content calendar MCP Server


### PR DESCRIPTION
Adding content-calendar-ai-mcp.

MEOK AI Labs — content calendar MCP Server

**Repository**: https://github.com/CSOAI-ORG/content-calendar-ai-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*