### PR TITLE
Add Lipdog/fossick-mcp to Developer Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
+- [Lipdog/fossick-mcp](https://github.com/Lipdog/fossick-mcp) 🐍 🏠 - Search all of GitHub, PyPI, and npm from your AI agent. Find libraries, drill into any repo (browse, read, goto-definition), and search code patterns across every public file.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [Lipdog/fossick-mcp](https://github.com/Lipdog/fossick-mcp) — an MCP server for prospecting across GitHub, PyPI, and npm from an AI agent.

Seven read-only tools covering the full discovery workflow: multi-query search across 200M+ repos, drill into any public repo (browse trees, read files at any branch/tag, AST-based goto-definition) without cloning, and full-text code search across every public file on GitHub.

Lean by design: 7 tools (vs 30+ in tools-everything servers), formatted-markdown outputs, TTL caching, hint-chained next-step suggestions. Published on PyPI as \`fossick-mcp\`, install with \`uvx fossick-mcp\`. MIT licensed.

- Repo: https://github.com/Lipdog/fossick-mcp
- PyPI: https://pypi.org/project/fossick-mcp/
- MCP Registry: \`io.github.Lipdog/fossick\` — already listed at https://registry.modelcontextprotocol.io/

Added to the **Developer Tools** section following the existing format (🐍 Python, 🏠 self-hosted).