### PR TITLE
Add mcpkit to Frameworks section 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2247,6 +2247,8 @@ Interact with Git repositories and version control platforms. Enables repository
 > More frameworks, utilities, and other developer tools are available at https://github.com/punkpeye/awesome-mcp-devtools
 > - [Nyrok/flompt](https://github.com/Nyrok/flompt) [![flompt MCP server](https://glama.ai/mcp/servers/@nyrok/flompt/badges/score.svg)](https://glama.ai/mcp/servers/@nyrok/flompt) 🐍 ☁️ - Visual AI prompt builder MCP server. Decompose any prompt into 12 semantic blocks and compile to Claude-optimized XML. Tools: `decompose_prompt`, `compile_prompt`. Setup: `claude mcp add flompt https://flompt.dev/mcp/`
 
+- [BenihDev/mcpkit](https://github.com/BenihDev/mcpkit) [![BenihDev/mcpkit MCP server](https://glama.ai/mcp/servers/BenihDev/mcpkit/badges/score.svg)](https://glama.ai/mcp/servers/BenihDev/mcpkit) 📇 ☁️ 🏠 🍎 🪟 🐧 - Generate ready-to-use MCP servers from OpenAPI specs, databases, or YAML descriptions in a single command. MIT licensed.
+
 - [escapeboy/agent-fleet-o](https://github.com/escapeboy/agent-fleet-o) [![escapeboy/agent-fleet-o MCP server](https://glama.ai/mcp/servers/escapeboy/agent-fleet-o/badges/score.svg)](https://glama.ai/mcp/servers/escapeboy/agent-fleet-o) ☁️ 🏠 - AI Agent Mission Control with 200+ MCP tools. Manage agents, experiments, workflows, crews, skills, and more via stdio + HTTP/SSE. Self-hosted, open-source (AGPL-3.0). Remote server: `https://fleetq.net/mcp`
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python


### PR DESCRIPTION
## What

Adding [mcpkit](https://github.com/BenihDev/mcpkit) to the Frameworks section.

## Why

mcpkit is a CLI tool that generates ready-to-use MCP servers from OpenAPI specs, databases, or YAML descriptions in a single command. It's a TypeScript framework/generator for creating MCP servers, which fits naturally in the Frameworks category alongside similar tools like FastMCP and mcp-fusion.

## Details

- **Repo:** https://github.com/BenihDev/mcpkit
- **Language:** TypeScript 📇
- **License:** MIT
- **npm:** @fanioz/mcpkit
- **Install:** `npx @fanioz/mcpkit`
- Works locally and with cloud APIs (☁️ 🏠)