### PR TITLE
Add UploadKit MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
-- [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
+- [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) [![drumst0ck/uploadkit MCP server](https://glama.ai/mcp/servers/drumst0ck/uploadkit/badges/score.svg)](https://glama.ai/mcp/servers/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 

--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zenml-io/mcp-zenml](https://github.com/zenml-io/mcp-zenml) 🐍 🏠 ☁️ - An MCP server to connect with your [ZenML](https://www.zenml.io) MLOps and LLMOps pipelines
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
+- [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [UploadKit](https://uploadkit.dev) — the file-uploads platform for developers — to the **Developer Tools** section.

**Official MCP server for UploadKit.** Gives AI coding assistants (Claude Code, Cursor, Windsurf, Zed) first-class knowledge of:

- UploadKit's 40+ open-source React upload components (by name, category, usage)
- Next.js route handler scaffolding (`createUploadKitHandler`)
- `<UploadKitProvider>` wiring
- BYOS (Bring Your Own Storage) configuration for S3, R2, GCS, and Backblaze B2
- Full-text search across 88+ docs pages

Runs locally via \`npx -y @uploadkitdev/mcp\` — no API key, no telemetry, no network calls.

**Links:**
- Source: https://github.com/drumst0ck/uploadkit/tree/master/packages/mcp
- npm: https://www.npmjs.com/package/@uploadkitdev/mcp
- Docs: https://docs.uploadkit.dev/docs/guides/mcp
- Registered in the [Official MCP Registry](https://registry.modelcontextprotocol.io) as \`io.github.drumst0ck/uploadkit\`.

License: MIT.