### PR TITLE
Add acamolese/google-search-console-mcp under Marketing 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,6 +1617,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 
+- [acamolese/google-search-console-mcp](https://github.com/acamolese/google-search-console-mcp) 🐍 ☁️ - Google Search Console MCP server: query performance data, inspect URLs, check indexing, and generate brandable HTML SEO audit reports with a 30/60/90-day roadmap. Read-only OAuth scope, installable via `uvx mcp-google-search-console`.
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
 - [alexey-pelykh/lhremote](https://github.com/alexey-pelykh/lhremote) 📇 🏠 - Open-source CLI and MCP server for LinkedHelper automation — 32 tools for campaign management, messaging, and profile queries via Chrome DevTools Protocol.
 - [BlockRunAI/x-grow](https://github.com/BlockRunAI/x-grow) 📇 ☁️ - X/Twitter algorithm optimizer with post drafting, review scoring, and AI image generation for maximum engagement.

--- a/README.md
+++ b/README.md
@@ -1617,7 +1617,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 
-- [acamolese/google-search-console-mcp](https://github.com/acamolese/google-search-console-mcp) 🐍 ☁️ - Google Search Console MCP server: query performance data, inspect URLs, check indexing, and generate brandable HTML SEO audit reports with a 30/60/90-day roadmap. Read-only OAuth scope, installable via `uvx mcp-google-search-console`.
+- [acamolese/google-search-console-mcp](https://github.com/acamolese/google-search-console-mcp) [![Glama MCP server badge](https://glama.ai/mcp/servers/acamolese/google-search-console-mcp/badge)](https://glama.ai/mcp/servers/acamolese/google-search-console-mcp) 🐍 ☁️ - Google Search Console MCP server: query performance data, inspect URLs, check indexing, and generate brandable HTML SEO audit reports with a 30/60/90-day roadmap. Read-only OAuth scope, installable via `uvx mcp-google-search-console`.
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
 - [alexey-pelykh/lhremote](https://github.com/alexey-pelykh/lhremote) 📇 🏠 - Open-source CLI and MCP server for LinkedHelper automation — 32 tools for campaign management, messaging, and profile queries via Chrome DevTools Protocol.
 - [BlockRunAI/x-grow](https://github.com/BlockRunAI/x-grow) 📇 ☁️ - X/Twitter algorithm optimizer with post drafting, review scoring, and AI image generation for maximum engagement.


### PR DESCRIPTION
Adds [`acamolese/google-search-console-mcp`](https://github.com/acamolese/google-search-console-mcp) to the Marketing section.

**What it does**: open-source MCP server for Google Search Console. Exposes 8 tools (sites, performance queries, URL Inspection, indexing checks, sitemaps) and a one-call `gsc_audit` that generates a self-contained HTML SEO audit report with Chart.js graphs, issue detection, and a 30/60/90-day roadmap. Branding is customizable via `branding.json` (logo, fonts, colors) which makes it useful for agencies producing white-label client audits.

**Why Marketing section**: this is primarily an SEO tool. Existing SEO entries like `Citedy/citedy-seo-agent` and `SearchAtlas` are already in Marketing.

**Legend**: 🐍 Python, ☁️ Cloud (talks to the Google Search Console API).

**Ordering**: inserted alphabetically at the top of the Marketing section (before `AdsMCP/tiktok-ads-mcp-server`).

**Other details**:
- PyPI: https://pypi.org/project/mcp-google-search-console/
- MIT licensed
- Read-only OAuth scope (`webmasters.readonly`)
- Zero setup via `uvx mcp-google-search-console`

Title includes `🤖🤖🤖` per the CONTRIBUTING.md automated-agent fast track.