### PR TITLE
Add rustchain-mcp - RustChain blockchain MCP server for AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [weibaohui/k8m](https://github.com/weibaohui/k8m) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations, featuring a management interface, logging, and nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [weibaohui/kom](https://github.com/weibaohui/kom) 🏎️ ☁️/🏠 - Provides MCP multi-cluster Kubernetes management and operations. It can be integrated as an SDK into your own project and includes nearly 50 built-in tools covering common DevOps and development scenarios. Supports both standard and CRD resources.
 - [wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye) 🏎️ ☁️/🏠 - MCP Server for kubernetes management, and analyze your cluster, application health
+- [rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp) 🦀 ☁️ - RustChain MCP server for AI agent discovery, blockchain RPC, and PoPA consensus integration. Run Sophia Elya agent on Beacon network.
 
 ### 👨‍💻 <a name="code-execution"></a>Code Execution
 


### PR DESCRIPTION
## rustchain-mcp — RustChain Blockchain MCP Server

**rustchain-mcp** is the official RustChain MCP server that provides AI agents with blockchain RPC access, Proof-of-Physical-AI (PoPA) consensus integration, and access to the Beacon network for agent discovery.

### Why rustchain-mcp belongs in awesome-mcp-servers

- 🦀 **Rust** codebase — blazing fast, memory-safe
- ☁️ **Cloud-ready** MCP server for blockchain operations
- 🤖 **AI Agent Discovery** via Beacon protocol
- 🔗 **Sophia Elya** agent — live Elyan-class agent on Beacon network
- 💰 Active bounty program: 250+ issues, rewards in RTC tokens

### Links

- 🐙 GitHub: https://github.com/Scottcjn/rustchain-mcp
- 🌐 Website: https://rustchain.org
- 💰 Bounties: https://github.com/Scottcjn/rustchain-bounties

### Change

Added rustchain-mcp entry in **Cloud Platforms** section after wenhuwang/mcp-k8s-eye.

### Bounty Reference

https://github.com/Scottcjn/rustchain-bounties/issues/2862
