### PR TITLE
Add Ethereum Swarm MCP server to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Cloud platform service integration. Enables management and interaction with clou
 - [elementfm/mcp](https://gitlab.com/elementfm/mcp) 🎖️ 🐍 📇 🏠 ☁️ - Open source podcast hosting platform
 - [elevy99927/devops-mcp-webui](https://github.com/elevy99927/devops-mcp-webui) 🐍 ☁️/🏠 - MCP Server for Kubernetes integrated with Open-WebUI, bridging the gap between DevOps and non-technical teams. Supports `kubectl` and `helm` operations through natural-language commands.
 - [erikhoward/adls-mcp-server](https://github.com/erikhoward/adls-mcp-server) 🐍 ☁️/🏠 - MCP Server for Azure Data Lake Storage. It can perform manage containers, read/write/upload/download operations on container files and manage file metadata.
+- [ethersphere/swarm-mcp](https://github.com/ethersphere/swarm-mcp) 📇 ☁️ 🏠 - MCP server for Ethereum Swarm decentralized storage — upload, download, manage postage stamps and feeds via the Bee API.
 - [espressif/esp-rainmaker-mcp](https://github.com/espressif/esp-rainmaker-mcp) 🎖️ 🐍 🏠 ☁️ 📟 - Official Espressif MCP Server to manage and control ESP RainMaker Devices.
 - [flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes) 📇 ☁️/🏠 - Typescript implementation of Kubernetes cluster operations for pods, deployments, services.
 - [hardik-id/azure-resource-graph-mcp-server](https://github.com/hardik-id/azure-resource-graph-mcp-server) 📇 ☁️/🏠 - A Model Context Protocol server for querying and analyzing Azure resources at scale using Azure Resource Graph, enabling AI assistants to explore and monitor Azure infrastructure.


### PR DESCRIPTION
Adds [ethersphere/swarm-mcp](https://github.com/ethersphere/swarm-mcp) to the Cloud Platforms category.

Ethereum Swarm is a decentralized storage network. The swarm-mcp server provides 12 MCP tools for interacting with Swarm via the Bee API — uploading/downloading data and files, managing postage stamps, and working with feeds.

- TypeScript codebase, published on npm as `swarm-mcp`
- Works with the public Swarm gateway (cloud) or a local Bee node
- Placed alphabetically in Cloud Platforms, alongside similar decentralized storage entries (4EVERLAND, IPFS)