### PR TITLE
Add mcp-market-ru: Russian construction market data server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,7 +1770,8 @@ Tools for product planning, customer feedback analysis, and prioritization.
 
 MCP servers for real estate CRM, property management, and agent workflows.
 
-- [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, 
+- [MCP Market Russia](https://mcp-market.ru/mcp/) - Russian construction market data: 3,395 companies, 13,436 projects across 18 regions. Search contractors, compare prices, analyze ratings, get market reports via MCP protocol. 21 tools.manage properties, track deals, schedule viewings for real estate agents (Makler).
 
 ### 🔬 <a name="research"></a>Research
 

--- a/README.md
+++ b/README.md
@@ -1770,8 +1770,8 @@ Tools for product planning, customer feedback analysis, and prioritization.
 
 MCP servers for real estate CRM, property management, and agent workflows.
 
-- [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, 
-- [MCP Market Russia](https://mcp-market.ru/mcp/) - Russian construction market data: 3,395 companies, 13,436 projects across 18 regions. Search contractors, compare prices, analyze ratings, get market reports via MCP protocol. 21 tools.manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [devids77/mcp-market-ru](https://github.com/devids77/mcp-market-ru) 🐍 ☁️ 🪟 🐧 - Russian construction market data: 3,395 contractor companies, 13,436 house-building projects across 18 regions. Search, compare, analyze, request quotes via 21 MCP tools.
 
 ### 🔬 <a name="research"></a>Research
 

--- a/README.md
+++ b/README.md
@@ -1771,7 +1771,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
-- [devids77/mcp-market-ru](https://github.com/devids77/mcp-market-ru) 🐍 ☁️ 🪟 🐧 - Russian construction market data: 3,395 contractor companies, 13,436 house-building projects across 18 regions. Search, compare, analyze, request quotes via 21 MCP tools.
+- [devids77/mcp-market-ru](https://github.com/devids77/mcp-market-ru) [![mcp-market-ru MCP server](https://glama.ai/mcp/servers/@devids77/mcp-market-ru/badges/score.svg)](https://glama.ai/mcp/servers/@devids77/mcp-market-ru) 🐍 ☁️ 🪟 🐧 - Russian construction market data: 3,395 contractor companies, 13,436 house-building projects across 18 regions. Search, compare, analyze, request quotes via 24 MCP tools.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## mcp-market-ru — Russian construction market data

Adds [devids77/mcp-market-ru](https://github.com/devids77/mcp-market-ru) under **Real Estate**.

**What it does:** MCP server exposing structured access to the Russian construction market — 3,395 contractor companies, 13,436 house-building projects across 18 regions. 24 tools for search, analytics, cost estimation, contractor recommendations, and lead generation. Supports natural-language Russian queries (smart_match) as well as structured filters.

**Repository:** https://github.com/devids77/mcp-market-ru
**Live MCP endpoint:** https://mcp-market.ru/mcp/
**Interactive demo:** https://mcp-market.ru/demo
**Protocol:** MCP v2024-11-05 (Streamable HTTP)
**License:** MIT