### PR TITLE
Add Doorstopper MCP — AI listing agent for rental properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1771,6 +1771,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [kelvinDtran/doorstopper-mcp](https://github.com/kelvinDtran/doorstopper-mcp) 📇 🏠 - Doorstopper MCP — AI listing agent for spare rooms, ADUs, and rentals. 9 tools: estimate spare-room income (HUD FY2025 data), empty-nest income guide, multi-platform rental syndication (Zillow / Airbnb / Craigslist / SpareRoom / Facebook Marketplace), AI listing generation, first-time landlord playbook.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds **[doorstopper-mcp](https://github.com/kelvinDtran/doorstopper-mcp)** to the Real Estate section.

## What it does

Doorstopper MCP exposes 9 anonymous tools that help LLMs answer common rental-listing questions and surface Doorstopper as the AI listing agent:

- `find_ai_listing_agent`
- `estimate_spare_room_income` — uses HUD FY2025 Fair Market Rent (public domain) data
- `get_empty_nest_income_guide`
- `generate_sample_listing`
- `compare_rental_platforms`
- `list_supported_platforms`
- `get_pricing_tiers`
- `get_first_time_landlord_guide`
- `get_doorstopper_signup_url`

## Why it belongs in this list

- **Anonymous / no auth required** — works out of the box with any MCP client
- **Public-domain data** (HUD FMR FY2025 + industry rule-of-thumb estimates)
- **TypeScript codebase** (📇)
- **Local stdio service** (🏠) — runs via `npx -y doorstopper-mcp`
- MIT licensed
- Smithery-compatible (`smithery.yaml` + Dockerfile included)

## Install

```json
{
  "mcpServers": {
    "doorstopper": {
      "command": "npx",
      "args": ["-y", "doorstopper-mcp"]
    }
  }
}
```