### PR TITLE
Add JProfiler MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
 - [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) [![drumst0ck/uploadkit MCP server](https://glama.ai/mcp/servers/drumst0ck/uploadkit/badges/score.svg)](https://glama.ai/mcp/servers/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
+- [ej-technologies/jprofiler-mcp](https://github.com/ej-technologies/jprofiler-mcp) [![ej-technologies/jprofiler-mcp MCP server](https://glama.ai/mcp/servers/ej-technologies/jprofiler-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ej-technologies/jprofiler-mcp) 🎖️ 📇 ☕ 🏠 🍎 🪟 🐧 - Official JProfiler MCP wrapper for Java performance profiling. Analyze CPU hotspots, memory allocations, JDBC queries, HTTP calls, and heap dumps (HPROF, JFR, JProfiler snapshots) directly from AI coding assistants. Run via `npx -y @ej-technologies/jprofiler-mcp@latest`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
## JProfiler MCP Server                                                                                                                                                                                                                 
   
Added JProfiler to the Developer Tools section.                                                                                                                                                                                         
                                               
### About JProfiler

- Java performance profiler with AI agent integration via the Model Context Protocol
- MCP tools: CPU hotspots with back traces, memory allocation analysis, JDBC query profiling, HTTP call tracing, and thread state inspection
- Heap dump analysis across three snapshot formats: HPROF (the JVM standard), JFR (Java Flight Recorder), and JProfiler's own `.jps` snapshots
- Attach to running JVMs or prepare a fresh profiling session, the MCP server drives the JProfiler command-line tooling, so AI coding assistants can guide the entire workflow from "profile this" to "here's the hotspot and the back
  trace"
- Cross-platform: macOS, Windows, Linux
- Commercial product from ej-technologies, with a free 10-day evaluation, no signup required to start

  ### Links

  - Repo: https://github.com/ej-technologies/jprofiler-mcp
  - NPM: https://www.npmjs.com/package/@ej-technologies/jprofiler-mcp
  - Website: https://www.ej-technologies.com/jprofiler/mcp

  ### Checklist

  - [x] Entry follows the existing format
  - [x] Description is concise and informative
  - [x] Link is valid and working
