### PR TITLE
Add claw.cleaning remote MCP server under Real Estate 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1771,6 +1771,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [GetColby/claw-cleaning](https://github.com/GetColby/claw-cleaning) 📇 ☁️ - [claw.cleaning](https://claw.cleaning) remote MCP server: book apartment cleanings in San Francisco via natural language. $40/hour, weekends, 8 AM–6 PM PT, SF addresses only. No install; connect to `https://claw.cleaning/mcp`.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [claw.cleaning](https://claw.cleaning) to the **Real Estate** section.

**What it is:** A remote Streamable HTTP MCP server that lets agents book apartment cleanings in San Francisco end-to-end via natural language — check availability, confirm address/hours/pricing with the customer, and place a paid booking.

- **Endpoint:** \`https://claw.cleaning/mcp\`
- **Install:** none — remote, no auth
- **Scope:** $40/hour, Saturdays and Sundays, 8 AM–6 PM PT, SF addresses only
- **Repo:** https://github.com/GetColby/claw-cleaning
- **Registry:** listed at registry.modelcontextprotocol.io as \`io.github.cnnrobrn/claw-cleaning\`

Per CONTRIBUTING.md: maintains alphabetical order within Real Estate, one server per line, concise description.