### PR TITLE
Add three observability MCPs: jaeger-mcp, kibana-mcp, prometheus-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,6 +1040,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) [![drumst0ck/uploadkit MCP server](https://glama.ai/mcp/servers/drumst0ck/uploadkit/badges/score.svg)](https://glama.ai/mcp/servers/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
 - [mshegolev/jaeger-mcp](https://github.com/mshegolev/jaeger-mcp) 🐍 🏠 ☁️ – MCP server for [Jaeger](https://www.jaegertracing.io/) distributed tracing. Read-only tools to list services and operations, search traces with tag/duration/time filters, retrieve full traces with execution tree, and map service-to-service dependencies.
 - [mshegolev/kibana-mcp](https://github.com/mshegolev/kibana-mcp) 🐍 🏠 ☁️ – MCP server for Kibana / Elasticsearch. Read-only tools to list indices, search logs (Query String syntax + time ranges), run terms aggregations with count/avg/sum/min/max, and browse Kibana saved dashboards.
+- [mshegolev/prometheus-mcp](https://github.com/mshegolev/prometheus-mcp) 🐍 🏠 ☁️ – MCP server for [Prometheus](https://prometheus.io/) metrics. Read-only tools to list metrics, run PromQL instant and range queries, inspect active alerts, and list scrape targets with health status.
 
 ### 🔒 <a name="delivery"></a>Delivery
 

--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,8 @@ Tools and integrations that enhance the development workflow and environment man
 - [zillow/auto-mobile](https://github.com/zillow/auto-mobile) 📇 🏠 🐧  - Tool suite built around an MCP server for Android automation for developer workflow and testing
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
 - [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) [![drumst0ck/uploadkit MCP server](https://glama.ai/mcp/servers/drumst0ck/uploadkit/badges/score.svg)](https://glama.ai/mcp/servers/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
+- [mshegolev/jaeger-mcp](https://github.com/mshegolev/jaeger-mcp) 🐍 🏠 ☁️ – MCP server for [Jaeger](https://www.jaegertracing.io/) distributed tracing. Read-only tools to list services and operations, search traces with tag/duration/time filters, retrieve full traces with execution tree, and map service-to-service dependencies.
+- [mshegolev/kibana-mcp](https://github.com/mshegolev/kibana-mcp) 🐍 🏠 ☁️ – MCP server for Kibana / Elasticsearch. Read-only tools to list indices, search logs (Query String syntax + time ranges), run terms aggregations with count/avg/sum/min/max, and browse Kibana saved dashboards.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds three read-only observability MCPs (traces + logs + metrics) to Developer Tools.

**jaeger-mcp** [![jaeger-mcp MCP server](https://glama.ai/mcp/servers/bnq90qvt0g/badges/score.svg)](https://glama.ai/mcp/servers/bnq90qvt0g) — Jaeger distributed tracing
- GitHub: https://github.com/mshegolev/jaeger-mcp
- PyPI: https://pypi.org/project/jaeger-mcp/
- 5 tools: list_services / list_operations / search_traces / get_trace / get_dependencies
- 133 tests, 94% coverage, MIT

**kibana-mcp** — Kibana / Elasticsearch log search
- GitHub: https://github.com/mshegolev/kibana-mcp
- PyPI: https://pypi.org/project/kibana-mcp/
- 5 tools: list_indices / search_logs / aggregate_logs / list_dashboards / get_dashboard
- 151 tests, ruff clean, MIT

**prometheus-mcp** — Prometheus metrics & alerting
- GitHub: https://github.com/mshegolev/prometheus-mcp
- PyPI: https://pypi.org/project/prometheus-mcp/
- 5 tools: list_metrics / query / query_range / list_alerts / list_targets
- 136 tests, 92% coverage, MIT

All Python 3.10+, FastMCP stdio, MCP Registry published.
Glama badges for kibana / prometheus pending (~1h after PyPI indexing).