### PR TITLE
Add Basalt Design System MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 
 
 ### 💻 <a name="developer-tools"></a>Developer Tools
+- [Basalt](https://basalt.run) 📇 ☁️ - Design system MCP server. Query tokens, components, icons, and WCAG contrast data from Git-backed design systems. 9 tools including get_token, get_component, check_contrast. Works with Claude Design. ([docs](https://github.com/basalt-run/design-system/blob/main/MCP.md))
 - [sapph1re/mcp-billing-gateway-sdk](https://github.com/sapph1re/mcp-billing-gateway-sdk) [![sapph1re/mcp-billing-gateway-sdk MCP server](https://glama.ai/mcp/servers/sapph1re/mcp-billing-gateway-sdk/badges/score.svg)](https://glama.ai/mcp/servers/sapph1re/mcp-billing-gateway-sdk) 📇 ☁️ - Billing infrastructure for MCP server operators. Add Stripe subscriptions, per-call credits, tiered pricing, and x402 crypto micropayments to any MCP server without writing billing code. Operator dashboard included.
 - [agenticempire/axint](https://github.com/agenticempire/axint) [![agenticempire/axint MCP server](https://glama.ai/mcp/servers/agenticempire/axint/badges/score.svg)](https://glama.ai/mcp/servers/agenticempire/axint) 📇 🏠 - Apple-native execution layer for AI agents. Compiles TypeScript to validated Swift — App Intents, SwiftUI views, WidgetKit widgets, and full apps. 13 MCP tools, 150 diagnostics, 500 tests.
 


### PR DESCRIPTION
Adds Basalt to Developer Tools. Hosted MCP server for design system data — tokens (DTCG format), component specs, icons, and contrast checking. 9 tools, API key auth. Free at basalt.run.

Docs: https://github.com/basalt-run/design-system/blob/main/MCP.md
Registry: https://registry.modelcontextprotocol.io (search "basalt")