### PR TITLE
Add ShipPage — zero-config HTML publishing for AI agents 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,8 @@ Tools and integrations that enhance the development workflow and environment man
 - [ztuskes/garmin-documentation-mcp-server](https://github.com/ztuskes/garmin-documentation-mcp-server) 📇 🏠 – Offline Garmin Connect IQ SDK documentation with comprehensive search and API examples
 - [drumst0ck/uploadkit](https://github.com/drumst0ck/uploadkit) [![drumst0ck/uploadkit MCP server](https://glama.ai/mcp/servers/drumst0ck/uploadkit/badges/score.svg)](https://glama.ai/mcp/servers/drumst0ck/uploadkit) 🎖️ 📇 🏠 🍎 🪟 🐧 – Official MCP server for [UploadKit](https://uploadkit.dev). Gives AI assistants first-class knowledge of 40+ React upload components, Next.js route handler scaffolds, BYOS setup (S3/R2/GCS/B2), and full-text search across 88+ docs pages. Runs locally via `npx -y @uploadkitdev/mcp`.
 
+- [jieshu666/ShipPage-Skill](https://github.com/jieshu666/ShipPage-Skill) 📇 ☁️ - Zero-config HTML publishing for AI agents. One HTTP POST turns any HTML or Markdown into a public URL at shippage.ai/p/{slug}. Auto-registers on first call — no account, no API keys to configure. Exposes `publish_html`, `publish_markdown`, `list_pages`, `delete_page` tools. Free tier: 20 publishes/month. Built on Cloudflare Workers. ([npm](https://www.npmjs.com/package/shippage-mcp) / [site](https://shippage.ai))
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)


### PR DESCRIPTION
Adds [ShipPage](https://shippage.ai) to the Developer Tools section.

**What it does**: ShipPage turns any HTML or Markdown into a public URL via a single `POST /v1/publish`. AI agents (Claude Code, Claude Desktop, Cursor, any HTTP client) auto-register on first call — no account, no API keys to configure. The MCP server ([`shippage-mcp`](https://www.npmjs.com/package/shippage-mcp)) exposes `publish_html`, `publish_markdown`, `list_pages`, and `delete_page` tools.

**Why it fits**: It's purpose-built for the agent workflow — `HTML in, URL out, zero config` — which none of the existing entries cover. Free tier: 20 publishes/month, 14-day retention, 500KB per page. Built on Cloudflare Workers for sub-100ms edge response.

- Repo: https://github.com/jieshu666/ShipPage-Skill
- Site: https://shippage.ai
- MCP package: https://www.npmjs.com/package/shippage-mcp
- License: MIT