### PR TITLE
Add mcp-lint (schema linter + preflight firewall) to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2386,6 +2386,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vinkius-labs/mcp-fusion](https://github.com/vinkius-labs/mcp-fusion) 📇 [![Glama](https://glama.ai/mcp/servers/badge/@vinkius-labs/mcp-fusion)](https://glama.ai/mcp/servers/@vinkius-labs/mcp-fusion) - A TypeScript framework for building production-ready MCP servers with automatic tool discovery, multi-transport support (stdio/SSE/HTTP), built-in validation, and zero-config setup.
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
+- [robert19001-cmyk/mcp-lint](https://github.com/robert19001-cmyk/mcp-lint) 📇 - Linter + runtime preflight firewall for MCP tool schemas. Catches cross-client compatibility issues across 8 MCP clients (Claude, Cursor, Gemini, VS Code, Windsurf, Cline, OpenAI, Continue.dev) and scores agent tool calls before execution with YAML policy enforcement.
 
 ## Tips and Tricks
 


### PR DESCRIPTION
### What
Adds [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint) to the **Frameworks** section.

### Why it's a fit
mcp-lint is a developer tool for MCP server authors that covers two related needs:

1. **Schema linter** — catches cross-client compatibility issues in MCP tool schemas across 8 clients (Claude, Cursor, Gemini, VS Code Copilot, Windsurf, Cline, OpenAI Agents SDK, Continue.dev). A schema that works in Claude can silently break elsewhere — this catches it before your users do. 17 rules.

2. **Preflight firewall** (v0.4.0) — runtime SDK + CLI that intercepts agent tool calls before execution and returns allow/deny/require_approval/allow_with_rewrite with deterministic risk scoring and YAML policy. Embeddable in any MCP server or agent runtime.

```
$ mcp-lint check tools.json
$ mcp-lint preflight action.json --policy preflight.yml
```

### Stats
- 277 tests, MIT licensed, TypeScript, Node ≥20
- Published on npm as `mcp-lint`
- 7 CLI commands, subpath SDK export (`mcp-lint/preflight`)

### Note
Also submitted to [awesome-mcp-devtools](https://github.com/punkpeye/awesome-mcp-devtools) which seems the primary home for devtools — happy to close this one if you'd rather keep the Frameworks section tight, or to keep both entries for discoverability. Your call.

### Checklist
- [x] Added to the correct section
- [x] Entry follows the existing format
- [x] Link is valid