### PR TITLE
Add axterminator — macOS Accessibility + vision-fallback computer use MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,7 +1754,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 
 Servers for controlling the desktop operating system: screenshots, window management, mouse/keyboard input injection, and system-level automation.
 
-- [MikkoParkkola/axterminator](https://github.com/MikkoParkkola/axterminator) 🦀 🍎 - macOS GUI automation: AX-tree first, vision fallback when AX is unavailable. 30 tools covering windowing, audio capture, camera, virtual desktops. Alternative to pure-vision computer use.
+- [MikkoParkkola/axterminator](https://github.com/MikkoParkkola/axterminator) [![MikkoParkkola/axterminator MCP server](https://glama.ai/mcp/servers/MikkoParkkola/axterminator/badges/score.svg)](https://glama.ai/mcp/servers/MikkoParkkola/axterminator) 🦀 🍎 - macOS GUI automation: AX-tree first, vision fallback when AX is unavailable. 30 tools covering windowing, audio capture, camera, virtual desktops. Alternative to pure-vision computer use.
 - [sbuysse/gnome-desktop-mcp](https://github.com/sbuysse/gnome-desktop-mcp) [![gnome-desktop-mcp MCP server](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp) 🐍 🏠 🐧 - GNOME desktop automation for AI agents. 30 tools via D-Bus: screenshots, window management, mouse/keyboard injection, clipboard, workspaces, and system notifications. Works on any GNOME 45–49 Linux desktop.
 
 ### 📋 <a name="product-management"></a>Product Management

--- a/README.md
+++ b/README.md
@@ -1754,6 +1754,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 
 Servers for controlling the desktop operating system: screenshots, window management, mouse/keyboard input injection, and system-level automation.
 
+- [MikkoParkkola/axterminator](https://github.com/MikkoParkkola/axterminator) 🦀 🍎 - macOS GUI automation: AX-tree first, vision fallback when AX is unavailable. 30 tools covering windowing, audio capture, camera, virtual desktops. Alternative to pure-vision computer use.
 - [sbuysse/gnome-desktop-mcp](https://github.com/sbuysse/gnome-desktop-mcp) [![gnome-desktop-mcp MCP server](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp) 🐍 🏠 🐧 - GNOME desktop automation for AI agents. 30 tools via D-Bus: screenshots, window management, mouse/keyboard injection, clipboard, workspaces, and system notifications. Works on any GNOME 45–49 Linux desktop.
 
 ### 📋 <a name="product-management"></a>Product Management


### PR DESCRIPTION
# Add axterminator — macOS Accessibility + vision-fallback computer use MCP

## Summary

Adds [axterminator](https://github.com/MikkoParkkola/axterminator) — a macOS GUI automation MCP server that uses the Accessibility (AX) tree as the primary interaction layer and falls back to vision only when AX is unavailable. This is an alternative to pure-vision computer-use servers (cheaper, faster, more reliable on well-formed macOS UIs).

## README.md change

One line, alphabetized under the relevant category (e.g. Browser Automation / OS Automation / Computer Use), single server per PR:

```markdown
- [MikkoParkkola/axterminator](https://github.com/MikkoParkkola/axterminator) 🦀 🍎 - macOS GUI automation: AX-tree first, vision fallback when AX is unavailable. 30 tools covering windowing, audio capture, camera, virtual desktops. Alternative to pure-vision computer use.
```

## Server details

- **Repo:** https://github.com/MikkoParkkola/axterminator
- **Primary language:** Rust (Swift + Objective-C bridges for macOS AX / AppKit APIs)
- **Scope:** macOS-only at the full-tier (AX + input synthesis). The iOS tier was scoped down to screenshot + vision only per issue [#43](https://github.com/MikkoParkkola/axterminator/issues/43).
- **Interface:** MCP server exposing 30 tools (window management, input synthesis, screenshot, audio capture, camera, virtual-desktop switching, etc.)
- **Design thesis:** AX queries are orders of magnitude faster and more deterministic than pixel inspection; use vision only when AX returns nothing.
- **License:** Apache-2.0
- **Local / self-hosted:** yes — runs entirely on the user's Mac

## Policy compliance

- Single server per PR (per previous guidance on #4520 / #4521)
- Follows CONTRIBUTING.md: alphabetical order within category, one server per line, concise description, accurate link
- New server addition only; no unrelated changes to README.md

## Checklist

- [x] Server is publicly available at the linked repo
- [x] One server per PR
- [x] Entry placed in alphabetical order within its category
- [x] Description is concise and accurate
- [x] License information verified (Apache-2.0)
