### PR TITLE
Add Home & Local Services category + claw.cleaning 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 📂 - [File Systems](#file-systems)
 * 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
+* 🧹 - [Home & Local Services](#home-and-local-services)
 * 🏠 - [Home Automation](#home-automation)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * ⚖️ - [Legal](#legal)
@@ -1438,6 +1439,12 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
+
+### 🧹 <a name="home-and-local-services"></a>Home & Local Services
+
+Book and manage real-world services delivered to your home — cleaning, handyman, laundry, and other hyperlocal labor.
+
+- [claw.cleaning](https://github.com/GetColby/claw-cleaning) 🎖️ 📇 ☁️ - Book an SF apartment cleaning through any MCP agent. $40/hr, 8am–6pm PT, SF only. Pay the cleaner on site — no upfront payment.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adds `claw.cleaning`, a remote streamable-HTTP MCP server that books real San Francisco apartment cleanings. Listed in the official MCP registry as `io.github.cnnrobrn/claw-cleaning`. Three tools: `check_availability`, `initiate_booking`, `check_booking_status`. No auth, no API key — drop the URL (`https://claw.cleaning/mcp`) into any MCP client.

There isn't an existing category that fits real-world home services (Home Automation is smart-home devices, Location Services is geolocation/weather, Marketing is irrelevant), so this PR also adds a new **🧹 Home & Local Services** section. Seeded with the one entry; happy to rename or relocate if you have a different placement in mind.

Repo: https://github.com/GetColby/claw-cleaning

Legend symbols applied per the guide: 🎖️ official / 📇 TypeScript / ☁️ Cloud Service. TOC entry added.