### PR TITLE
Add fmr8-mcp-server to Real Estate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [nikvb/fmr8-mcp-server](https://github.com/nikvb/fmr8-mcp-server) 📇 ☁️ 🍎 🪟 🐧 - Look up Section 8 Fair Market Rent (FMR) values by ZIP code, state, county, or city. Covers 30,000+ US ZIP codes with HUD SAFMR data, historical year-over-year trends, and HUD/Section 8 terminology glossary.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## Summary

Adds [fmr8-mcp-server](https://github.com/nikvb/fmr8-mcp-server) to the **Real Estate** section.

MCP server for Section 8 Fair Market Rent (FMR) lookups — ZIP code search, state/county browsing, historical trends, and HUD glossary. Powered by HUD's official FMR data via the fmr8.com API.

## Server details

- **Repo**: https://github.com/nikvb/fmr8-mcp-server
- **npm**: https://www.npmjs.com/package/fmr8-mcp-server
- **License**: MIT
- **Transport**: stdio + Streamable HTTP (https://fmr8.com/mcp)
- **Tools**: 10 (ZIP lookup, state/county browse, year trends, glossary, etc.)