### PR TITLE
Add Cellar — hybrid computer-use MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,7 +1755,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 Servers for controlling the desktop operating system: screenshots, window management, mouse/keyboard input injection, and system-level automation.
 
 - [sbuysse/gnome-desktop-mcp](https://github.com/sbuysse/gnome-desktop-mcp) [![gnome-desktop-mcp MCP server](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp) 🐍 🏠 🐧 - GNOME desktop automation for AI agents. 30 tools via D-Bus: screenshots, window management, mouse/keyboard injection, clipboard, workspaces, and system notifications. Works on any GNOME 45–49 Linux desktop.
-- [dimpagk92/cellar](https://github.com/dimpagk92/cellar) 🦀 📇 🏠 🍎 🐧 - Hybrid computer-use runtime. Fuses accessibility tree + Chrome DevTools Protocol + vision into structured context with per-element confidence. 4 MCP tools (see/act/think/perceive). Continuous awareness engine (Cortex) with freshness + side-effect detection. Works offline with Ollama + local models.
+- [dimpagk92/cellar](https://github.com/dimpagk92/cellar) [![dimpagk92/cellar MCP server](https://glama.ai/mcp/servers/dimpagk92/cellar/badges/score.svg)](https://glama.ai/mcp/servers/dimpagk92/cellar) 🦀 📇 🏠 🍎 🐧 - Hybrid computer-use runtime. Fuses accessibility tree + Chrome DevTools Protocol + vision into structured context with per-element confidence. 4 MCP tools (see/act/think/perceive). Continuous awareness engine (Cortex) with freshness + side-effect detection. Works offline with Ollama + local models.
 
 ### 📋 <a name="product-management"></a>Product Management
 

--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,7 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 Servers for controlling the desktop operating system: screenshots, window management, mouse/keyboard input injection, and system-level automation.
 
 - [sbuysse/gnome-desktop-mcp](https://github.com/sbuysse/gnome-desktop-mcp) [![gnome-desktop-mcp MCP server](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp) 🐍 🏠 🐧 - GNOME desktop automation for AI agents. 30 tools via D-Bus: screenshots, window management, mouse/keyboard injection, clipboard, workspaces, and system notifications. Works on any GNOME 45–49 Linux desktop.
+- [dimpagk92/cellar](https://github.com/dimpagk92/cellar) 🦀 📇 🏠 🍎 🐧 - Hybrid computer-use runtime. Fuses accessibility tree + Chrome DevTools Protocol + vision into structured context with per-element confidence. 4 MCP tools (see/act/think/perceive). Continuous awareness engine (Cortex) with freshness + side-effect detection. Works offline with Ollama + local models.
 
 ### 📋 <a name="product-management"></a>Product Management
 


### PR DESCRIPTION
Adds [Cellar](https://github.com/dimpagk92/cellar) to the OS Automation section.

## What it is

Cellar is an open-source computer-use runtime that ships as an MCP server. It reads the screen through accessibility trees, Chrome DevTools Protocol, and native APIs — not just screenshots — and falls back to vision only when structure fails. Four MCP tools: `cel_see`, `cel_act`, `cel_think`, `cel_perceive`.

## Why it fits this list

- **First-class MCP server** — designed from day one to be used via MCP, not bolted on
- **Hybrid runtime** — works across browsers AND native macOS apps in one toolset (the existing OS Automation entry is GNOME/Linux-only)
- **Structure-first perception** — fuses a11y + CDP + vision with per-element confidence scores, ~200x cheaper per action than vision-only
- **Continuous awareness** (Cortex) — tracks what *changed*, not just what's there; catches stale state and side effects
- **Model-agnostic** — works with OpenAI, Anthropic, Gemini, or fully offline via Ollama + Gemma 4
- **Apache 2.0** — no CLA, no patent traps

Added alphabetically after gnome-desktop-mcp (d-iff ordering → cellar comes before the existing entry, but positioning below preserves the general "GNOME first since it was first" convention in the section — happy to swap if you prefer strict alphabetical).

Thanks for maintaining this list!