### PR TITLE
Add systemprompt-template: Rust MCP server governance runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2386,6 +2386,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vinkius-labs/mcp-fusion](https://github.com/vinkius-labs/mcp-fusion) 📇 [![Glama](https://glama.ai/mcp/servers/badge/@vinkius-labs/mcp-fusion)](https://glama.ai/mcp/servers/@vinkius-labs/mcp-fusion) - A TypeScript framework for building production-ready MCP servers with automatic tool discovery, multi-transport support (stdio/SSE/HTTP), built-in validation, and zero-config setup.
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
+- [systempromptio/systemprompt-template](https://github.com/systempromptio/systemprompt-template) 🦀 🏠 🐧 🪟 🍎 - Rust infrastructure runtime for hosting and governing MCP servers. Built-in RBAC, secret detection, rate limiting, audit logging, OAuth 2.0. Single ~50MB binary, no Kubernetes. [BSL-1.1]
 
 ## Tips and Tricks
 


### PR DESCRIPTION
## systemprompt-template

Adding [systemprompt-template](https://github.com/systempromptio/systemprompt-template) to the Frameworks/Infrastructure section.

This is a Rust runtime for HOSTING and GOVERNING MCP servers — not an MCP server itself. Think of it as the governance layer between AI agents and the MCP servers they use.

Features:
- Hosts and governs multiple MCP servers from a single binary
- 6-tier RBAC, secret detection (35+ patterns), rate limiting (300 req/min)
- Audit logging, OAuth 2.0 + WebAuthn
- A2A agent orchestration support
- ~50MB, PostgreSQL only — no Kubernetes, Redis, microservices