### PR TITLE
Add semantix-ai under Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 
 
 ### 💻 <a name="developer-tools"></a>Developer Tools
+- [labrat-akhona/semantix-ai](https://github.com/labrat-akhona/semantix-ai) 🐍 🏠 🍎 🪟 🐧 - Validates LLM outputs against semantic intents via local NLI inference. Exposes `verify_text_intent` as an MCP tool — deterministic scores, ~15 ms per call, zero API cost, tamper-evident audit trail. Useful for compliance-sensitive agent workflows.
 - [sapph1re/mcp-billing-gateway-sdk](https://github.com/sapph1re/mcp-billing-gateway-sdk) [![sapph1re/mcp-billing-gateway-sdk MCP server](https://glama.ai/mcp/servers/sapph1re/mcp-billing-gateway-sdk/badges/score.svg)](https://glama.ai/mcp/servers/sapph1re/mcp-billing-gateway-sdk) 📇 ☁️ - Billing infrastructure for MCP server operators. Add Stripe subscriptions, per-call credits, tiered pricing, and x402 crypto micropayments to any MCP server without writing billing code. Operator dashboard included.
 - [agenticempire/axint](https://github.com/agenticempire/axint) [![agenticempire/axint MCP server](https://glama.ai/mcp/servers/agenticempire/axint/badges/score.svg)](https://glama.ai/mcp/servers/agenticempire/axint) 📇 🏠 - Apple-native execution layer for AI agents. Compiles TypeScript to validated Swift — App Intents, SwiftUI views, WidgetKit widgets, and full apps. 13 MCP tools, 150 diagnostics, 500 tests.
 


### PR DESCRIPTION
Adds semantix-ai to the Developer Tools section. It's a Python MCP server (`semantix.mcp.server`) that exposes `verify_text_intent` — any MCP client can validate LLM outputs against a plain-English intent using local NLI inference, no API calls, deterministic scores, and a hash-chained audit trail of every validation.

- Repo: https://github.com/labrat-akhona/semantix-ai
- PyPI: https://pypi.org/project/semantix-ai/
- Docs: https://labrat-akhona.github.io/semantix-ai/
- MCP install: `pip install "semantix-ai[mcp]"`
- License: MIT

Placed under 💻 Developer Tools.
