### PR TITLE
Add Promptibus MCP — model intelligence for 67+ generative AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Access and explore art collections, cultural heritage, and museum databases. Ena
 - [TwelveTake-Studios/reaper-mcp](https://github.com/TwelveTake-Studios/reaper-mcp) 🐍 🏠 🍎 🪟 🐧 - MCP server enabling AI assistants to control REAPER DAW for mixing, mastering, MIDI composition, and full music production with 129 tools
 - [yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp) 📇 ☁️ - A MCP server integrating AniList API for anime and manga information
 - [yuvalsuede/agent-media](https://github.com/yuvalsuede/agent-media) 📇 ☁️ 🍎 🪟 🐧 - CLI and MCP server for AI video and image generation with unified access to 7 models (Kling, Veo, Sora, Seedance, Flux, Grok Imagine). Provides 9 tools for generating, managing, and browsing media.
+- [promptibus/mcp](https://github.com/promptibus/mcp) 📇 ☁️ - Model intelligence for AI agents — syntax, parameters, pricing, and routing for 67+ generative AI models (Midjourney, Flux, Suno, Runway, DALL-E, Stable Diffusion). 7 tools including `get_pricing` and `optimize_prompt`.
 
 
 ### 📐 <a name="architecture-and-design"></a>Architecture & Design


### PR DESCRIPTION
Adds `@promptibus/mcp` — an MCP server that exposes structured knowledge about 67+ generative AI models (Midjourney, Flux, Suno, Runway, DALL-E, Stable Diffusion, and more) to AI agents.

### What it does

Your AI agent can write Python, but it doesn't know that Midjourney V7 deprecated `--v 5`, that Flux 2 Pro wants `guidance_scale: 3.5` for photography, or how much 500 DALL-E 3 images will cost. This server fills that gap.

### 7 tools

- `recommend_model` — task-to-model matching with reasoning + params
- `optimize_prompt` — model-specific prompt rewriting
- `lint_prompt` — deprecated-flag and parameter validation
- `compare_models` — side-by-side capability + pricing comparison
- `get_parameters` — recommended params per model and task type
- `get_model_profile` — full capability sheet with community tips
- `get_pricing` — USD pricing with volume estimates

### Links

- **npm:** https://www.npmjs.com/package/@promptibus/mcp
- **Official MCP Registry:** `com.promptibus/mcp` (DNS-verified)
- **Source:** https://github.com/promptibus/mcp (MIT)
- **Docs:** https://promptibus.com/mcp

### Tier

Anonymous tier works without signup: 25 calls/day, 10 most-used models. Paid plans raise limits and unlock all 67+ models.
