### PR TITLE
Add royalmail-mcp (Royal Mail + Parcelforce shipping) to Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)
 - [aarsiv-groups/shipi-mcp-server](https://github.com/aarsiv-groups/shipi-mcp-server) 📇 ☁️ - Shipi MCP server to create shipments, track packages, and compare rates with 18 tools for various carriers. Supports [remote MCP](https://mcp.myshipi.com/api/mcp).
 - [arthurpanhku/DragonMCP](https://github.com/arthurpanhku/DragonMCP) [![dragon-mcp MCP server](https://glama.ai/mcp/servers/arthurpanhku/dragon-mcp/badges/score.svg)](https://glama.ai/mcp/servers/arthurpanhku/dragon-mcp) 📇 🏠 ☁️ 🍎   - MCP server for Greater China local life services: Meituan/Ele.me food delivery, Didi/Meituan ride-hailing, WeChat Pay/Alipay, Amap/Baidu Maps, 12306 high-speed rail, Taobao/JD/Xianyu e-commerce, Hong Kong government e-services, and more.
+- [catrinmdonnelly/royalmail-mcp](https://github.com/catrinmdonnelly/royalmail-mcp) 📇 ☁️ - Book, label, track and cancel Royal Mail and Parcelforce shipments. 33 UK and international services via friendly keys or raw Service Register codes. `npx royalmail-mcp`.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 

--- a/README.md
+++ b/README.md
@@ -1044,7 +1044,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)
 - [aarsiv-groups/shipi-mcp-server](https://github.com/aarsiv-groups/shipi-mcp-server) 📇 ☁️ - Shipi MCP server to create shipments, track packages, and compare rates with 18 tools for various carriers. Supports [remote MCP](https://mcp.myshipi.com/api/mcp).
 - [arthurpanhku/DragonMCP](https://github.com/arthurpanhku/DragonMCP) [![dragon-mcp MCP server](https://glama.ai/mcp/servers/arthurpanhku/dragon-mcp/badges/score.svg)](https://glama.ai/mcp/servers/arthurpanhku/dragon-mcp) 📇 🏠 ☁️ 🍎   - MCP server for Greater China local life services: Meituan/Ele.me food delivery, Didi/Meituan ride-hailing, WeChat Pay/Alipay, Amap/Baidu Maps, 12306 high-speed rail, Taobao/JD/Xianyu e-commerce, Hong Kong government e-services, and more.
-- [catrinmdonnelly/royalmail-mcp](https://github.com/catrinmdonnelly/royalmail-mcp) 📇 ☁️ - Book, label, track and cancel Royal Mail and Parcelforce shipments. 33 UK and international services via friendly keys or raw Service Register codes. `npx royalmail-mcp`.
+- [catrinmdonnelly/royalmail-mcp](https://github.com/catrinmdonnelly/royalmail-mcp) [![catrinmdonnelly/royalmail-mcp MCP server](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp/badges/score.svg)](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp) 📇 ☁️ - Book, label, track and cancel Royal Mail and Parcelforce shipments. 33 UK and international services via friendly keys or raw Service Register codes. `npx royalmail-mcp`.
 
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 


### PR DESCRIPTION
Adds `royalmail-mcp` to the Delivery category.

## What it does

Book, label, track and cancel Royal Mail and Parcelforce shipments from any MCP-compatible AI. Covers 33 UK and international services (Royal Mail 1st/2nd Class, Tracked 24/48, Special Delivery, Parcelforce express, international tracked).

## Links

- npm: https://www.npmjs.com/package/royalmail-mcp
- GitHub: https://github.com/catrinmdonnelly/royalmail-mcp
- Install: `npx royalmail-mcp`

## Notes

- Built on the official MCP SDK (TypeScript/JavaScript codebase, talks to the remote Click & Drop API, hence 📇 ☁️).
- Verified end-to-end against the live Royal Mail Click & Drop API.
- MIT licence.