### PR TITLE
Add Perspective AI MCP server + new Conversational AI category

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🤖 - [Coding Agents](#coding-agents)
 * 🖥️ - [Command Line](#command-line)
 * 💬 - [Communication](#communication)
+* 🗣️ - [Conversational AI](#conversational-ai)
 * 👤 - [Customer Data Platforms](#customer-data-platforms)
 * 🗄️ - [Databases](#databases)
 * 📊 - [Data Platforms](#data-platforms)
@@ -571,6 +572,12 @@ Integration with communication platforms for message management and channel oper
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - A Model Context Protocol (MCP) server with built-in Feishu OAuth authentication, supporting remote connections and providing comprehensive Feishu document management tools including block creation, content updates, and advanced features.
 - [loglux/whatsapp-mcp-stream](https://github.com/loglux/whatsapp-mcp-stream) [![whatsapp-mcp-stream MCP server](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream/badges/score.svg)](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream) 📇 🏠 🍎 🪟 🐧 - WhatsApp MCP server over Streamable HTTP with web admin UI (QR/status/settings), bidirectional media upload/download, and SQLite persistence.
 
+
+### 🗣️ <a name="conversational-ai"></a>Conversational AI
+
+Tools for building and operating AI conversation agents that hold structured dialogues with end users.
+
+- [Perspective-AI/mcp](https://github.com/Perspective-AI/mcp) 🎖️ 📇 ☁️ - Official MCP server for [Perspective AI](https://getperspective.ai). An AI Concierge replaces static forms with adaptive AI conversations for lead qualification, customer research, onboarding feedback, and advocacy. Design conversation agents (Concierge, Interviewer, Evaluator, Advocate), analyze conversations, deploy embeds, and automate follow-ups (webhook, email, Slack, HubSpot).
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Integration with communication platforms for message management and channel oper
 
 Tools for building and operating AI conversation agents that hold structured dialogues with end users.
 
-- [Perspective-AI/mcp](https://github.com/Perspective-AI/mcp) 🎖️ 📇 ☁️ - Official MCP server for [Perspective AI](https://getperspective.ai). An AI Concierge replaces static forms with adaptive AI conversations for lead qualification, customer research, onboarding feedback, and advocacy. Design conversation agents (Concierge, Interviewer, Evaluator, Advocate), analyze conversations, deploy embeds, and automate follow-ups (webhook, email, Slack, HubSpot).
+- [Perspective-AI/mcp](https://github.com/Perspective-AI/mcp) [![Perspective-AI/mcp MCP server](https://glama.ai/mcp/servers/Perspective-AI/mcp/badges/score.svg)](https://glama.ai/mcp/servers/Perspective-AI/mcp) 🎖️ 📇 ☁️ - Official MCP server for [Perspective AI](https://getperspective.ai). An AI Concierge replaces static forms with adaptive AI conversations for lead qualification, customer research, onboarding feedback, and advocacy. Design conversation agents (Concierge, Interviewer, Evaluator, Advocate), analyze conversations, deploy embeds, and automate follow-ups (webhook, email, Slack, HubSpot).
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms
 


### PR DESCRIPTION
Adds [Perspective-AI/mcp](https://github.com/Perspective-AI/mcp) under a new **Conversational AI** category (placed between Communication and Customer Data Platforms, alphabetically).

## Why a new category

Conversational AI (AI agents that hold structured dialogues with end users) is a distinct category that doesn't fit existing sections cleanly:

- **Research** skews toward scientific/literature tools
- **Support & Service Management** frames everything as helpdesk
- **Customer Data Platforms** is for accessing existing profiles
- **Communication** is for chat infra (Slack, Telegram, etc.)

## About Perspective AI

Official MCP server for [Perspective AI](https://getperspective.ai). An AI Concierge replaces static forms with adaptive AI conversations for lead qualification, customer research, onboarding feedback, and advocacy. 17 tools across four agent types (Concierge, Interviewer, Evaluator, Advocate) covering design, deploy, analyze, and automate.

- Repo: https://github.com/Perspective-AI/mcp
- MCP Registry: [`ai.getperspective/mcp`](https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.getperspective/mcp)
- Glama connector: https://glama.ai/mcp/connectors/ai.getperspective/mcp
- Remote HTTP endpoint: `https://getperspective.ai/mcp`

## Checklist

- [x] Entry follows existing format with 🎖️ 📇 ☁️ markers
- [x] TOC updated with new category link (alphabetical position)
- [x] New category tagline is neutral (same register as adjacent categories)
- [x] Alphabetical placement preserved
- [x] Listed on Glama as a connector (this is a remote-hosted HTTP server, not a Docker-packaged one; the servers-style badge URL is only issued for packaged servers, consistent with other remote-only entries already in the list such as `peek-travel/mcp-intro`, `idosal/git-mcp`, `aarsiv-groups/shipi-mcp-server`)