### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ Provides access to customer profiles inside of customer data platforms
 
 ### 🗄️ <a name="databases"></a>Databases
 
+- [REG-Vault](https://regvault.org/docs/api) - Open retro-gaming metadata for 91k games across 99 systems (box art, manuals, screenshots, gameplay previews). Free MCP at `api.regvault.org/mcp`.
+
 Secure database access with schema inspection capabilities. Enables querying and analyzing data with configurable security controls including read-only access.
 
 - [Aiven-Open/mcp-aiven](https://github.com/Aiven-Open/mcp-aiven) - 🐍 ☁️ 🎖️ -  Navigate your [Aiven projects](https://go.aiven.io/mcp-server) and interact with the PostgreSQL®, Apache Kafka®, ClickHouse® and OpenSearch® services

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ Provides access to customer profiles inside of customer data platforms
 
 ### 🗄️ <a name="databases"></a>Databases
 
-- [REG-Vault](https://regvault.org/docs/api) - Open retro-gaming metadata for 91k games across 99 systems (box art, manuals, screenshots, gameplay previews). Free MCP at `api.regvault.org/mcp`.
+- [rtissera/regvault-mcp](https://github.com/rtissera/regvault-mcp) [![rtissera/regvault-mcp MCP server](https://glama.ai/mcp/servers/rtissera/regvault-mcp/badges/score.svg)](https://glama.ai/mcp/servers/rtissera/regvault-mcp) - Open retro-gaming metadata — 91k+ games across 99 systems with box art, manuals, screenshots, gameplay previews. Hosted MCP at `api.regvault.org/mcp`.
 
 Secure database access with schema inspection capabilities. Enables querying and analyzing data with configurable security controls including read-only access.
 

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ Provides access to customer profiles inside of customer data platforms
 
 ### 🗄️ <a name="databases"></a>Databases
 
-- [rtissera/regvault-mcp](https://github.com/rtissera/regvault-mcp) [![rtissera/regvault-mcp MCP server](https://glama.ai/mcp/servers/rtissera/regvault-mcp/badges/score.svg)](https://glama.ai/mcp/servers/rtissera/regvault-mcp) - Open retro-gaming metadata — 91k+ games across 99 systems with box art, manuals, screenshots, gameplay previews. Hosted MCP at `api.regvault.org/mcp`.
+- [rtissera/regvault-mcp](https://github.com/rtissera/regvault-mcp) 📇 ☁️ [![rtissera/regvault-mcp MCP server](https://glama.ai/mcp/servers/rtissera/regvault-mcp/badges/score.svg)](https://glama.ai/mcp/servers/rtissera/regvault-mcp) - Open retro-gaming metadata — 91k+ games across 99 systems with box art, manuals, screenshots, gameplay previews. Hosted MCP at `api.regvault.org/mcp`.
 
 Secure database access with schema inspection capabilities. Enables querying and analyzing data with configurable security controls including read-only access.
 


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
