### PR TITLE
Add LukeLamb/claude-ollama-mcp to Other Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2490,6 +2490,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
 - [SPL-BGU/PlanningCopilot](https://github.com/SPL-BGU/PlanningCopilot) [![planning-copilot MCP server](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot/badges/score.svg)](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot) 🐍🏠 - A tool-augmented LLM system for the full PDDL planning pipeline, improving reliability without domain-specific training.
 - [yyyhy/nash-arena](https://github.com/yyyhy/nash-arena) [![yyyhy/nash-arena MCP server](https://glama.ai/mcp/servers/yyyhy/nash-arena/badges/score.svg)](https://glama.ai/mcp/servers/yyyhy/nash-arena) 🐍 ☁️ - A Chess and Card Game Arena For LLM, Agents can battle in game by mcp
+- [LukeLamb/claude-ollama-mcp](https://github.com/LukeLamb/claude-ollama-mcp) [![LukeLamb/claude-ollama-mcp MCP server](https://glama.ai/mcp/servers/LukeLamb/claude-ollama-mcp/badges/score.svg)](https://glama.ai/mcp/servers/LukeLamb/claude-ollama-mcp) 📇 🏠 🐧 🍎 🪟 - Lets Claude query and manage a local Ollama server: list/show/pull/delete models, run generate/chat completions. Zero npm deps, pure Node over the HTTP API.
 ## Frameworks
 
 > [!NOTE]


### PR DESCRIPTION
Adds [claude-ollama-mcp](https://github.com/LukeLamb/claude-ollama-mcp) to the Other Tools and Integrations section.

Lets Claude Desktop query and manage a local [Ollama](https://ollama.com/) server over its HTTP API. Eight tools: `ollama_status`, `list_models`, `list_running`, `show_model`, `generate`, `chat`, `pull_model`, `delete_model`. Zero npm dependencies — pure Node over the HTTP API. Default endpoint `http://localhost:11434`, configurable via the `ollama_url` user_config.

Useful for comparing Claude's output to a local model on the same prompt, running cheap bulk completions against a quantized model, or managing custom training-checkpoint models you've imported into Ollama.

Glama scores: **security A / license A / quality A**.
Server page: https://glama.ai/mcp/servers/LukeLamb/claude-ollama-mcp