### PR TITLE
feat: add macwhisper-mcp-server (local MacWhisper transcription for Claude Desktop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2218,6 +2218,7 @@ Translation tools and services to enable AI assistants to translate content betw
 Tools for converting text-to-speech and vice-versa
 
 - [daisys-ai/daisys-mcp](https://github.com/daisys-ai/daisys-mcp) 🐍 🏠 🍎 🪟 🐧 - Generate high-quality text-to-speech and text-to-voice outputs using the [DAISYS](https://www.daisys.ai/) platform and make it able to play and store audio generated.
+- [docdyhr/macwhisper-mcp-server](https://github.com/docdyhr/macwhisper-mcp-server) 🐍 🏠 🍎 - Local MacWhisper transcription for Claude Desktop — fully private, no cloud, audio stays on your Mac. `pip install macwhisper-mcp-server`
 - [fasuizu-br/brainiall-mcp-server](https://github.com/fasuizu-br/brainiall-mcp-server) [![brainiall-mcp-server MCP server](https://glama.ai/mcp/servers/fasuizu-br/brainiall-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/fasuizu-br/brainiall-mcp-server) 🐍 ☁️ - AI-powered speech tools: pronunciation assessment with phoneme-level feedback, speech-to-text with language detection, and text-to-speech with multiple voices.
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration
 - [mberg/kokoro-tts-mcp](https://github.com/mberg/kokoro-tts-mcp) 🐍 🏠 - MCP Server that uses the open weight Kokoro TTS models to convert text-to-speech. Can convert text to MP3 on a local driver or auto-upload to an S3 bucket.


### PR DESCRIPTION
## Summary

Adds [macwhisper-mcp-server](https://github.com/docdyhr/macwhisper-mcp-server) to the **Text-to-Speech** section (covers "text-to-speech and vice-versa" per the section description).

**Entry added:**
```
- [docdyhr/macwhisper-mcp-server](https://github.com/docdyhr/macwhisper-mcp-server) 🐍 🏠 🍎 - Local MacWhisper transcription for Claude Desktop — fully private, no cloud, audio stays on your Mac. `pip install macwhisper-mcp-server`
```

## About the server

- Bridges [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) to Claude Desktop via MCP stdio
- 7 tools: `transcribe_audio`, `cancel_transcription`, `list_allowed_paths`, `start_watch`, `stop_watch`, `get_watch_results`
- Fully local — zero network calls, no cloud APIs
- macOS only (MacWhisper is macOS-only)
- Published on PyPI: `pip install macwhisper-mcp-server`
- v1.0.0, MIT licence, 33 tests, CI on GitHub Actions