### PR TITLE
Add mario-hernandez/google-search-console-mcp-claude-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ Provides access to customer profiles inside of customer data platforms
 - [sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server) 📇 ☁️ - An MCP server to access and updates profiles on an Apache Unomi CDP server.
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
 - [lionkiii/google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) [![google-searchconsole-mcp MCP server](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp) 📇 🏠 - Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.
+- [mario-hernandez/google-search-console-mcp-claude-code](https://github.com/mario-hernandez/google-search-console-mcp-claude-code) 🐍 🏠 - Google Search Console MCP for Claude Code & Cursor with built-in SEO intelligence: traffic-drop diagnosis, quick wins, content decay, cannibalization, ranking alerts. Read-only by default with anti-hallucination provenance metadata on every response.
 - [saurabhsharma2u/search-console-mcp](https://github.com/saurabhsharma2u/search-console-mcp)  - An MCP server to interact with Google Search Console and Bing Webmasters.
 
 ### 🗄️ <a name="databases"></a>Databases


### PR DESCRIPTION
Adds a new MCP server entry under **Customer Data Platforms** (alongside the other Search Console servers).

**Repo:** https://github.com/mario-hernandez/google-search-console-mcp-claude-code

**Description:** Google Search Console MCP for Claude Code & Cursor with built-in SEO intelligence: traffic-drop diagnosis, quick wins, content decay, cannibalization, ranking alerts. Read-only by default with anti-hallucination provenance metadata on every response.

Tags applied:
- 🐍 Python
- 🏠 Local (runs locally; calls Google APIs with the user's own OAuth credentials)

Entry placed between the existing `lionkiii/google-searchconsole-mcp` and `saurabhsharma2u/search-console-mcp` lines so all GSC servers are grouped together.