### PR TITLE
Add Career & Job Search category with Shortlisted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 📐 - [Architecture & Design](#architecture-and-design)
 * 📂 - [Browser Automation](#browser-automation)
 * 🧬 - [Biology Medicine and Bioinformatics](#bio)
+* 💼 - [Career & Job Search](#career-and-job-search)
 * ☁️ - [Cloud Platforms](#cloud-platforms)
 * 👨‍💻 - [Code Execution](#code-execution)
 * 🤖 - [Coding Agents](#coding-agents)
@@ -342,6 +343,12 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+
+### 💼 <a name="career-and-job-search"></a>Career & Job Search
+
+MCP servers for resume tailoring, cover letter generation, job matching, and application tracking.
+
+- [justinjamesmathew/jobagent](https://github.com/justinjamesmathew/jobagent/tree/main/mcp-server) 📇 ☁️ 🍎 🪟 🐧 - [Shortlisted](https://shortlisted.site) MCP server: search aggregated jobs across Greenhouse / Lever / Workday / Adzuna / USAJOBS / RemoteOK, score how well a resume fits a job, generate ATS-tailored resume PDFs, and write cover letters in professional / casual / formal tones. 6 tools, stdio transport. Install: `npx -y shortlisted-mcp-server`.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
## What

Adds a new category **💼 Career & Job Search** with one entry: the Shortlisted MCP server.

## Why a new category

There's no existing bucket for resume / cover-letter / job-matching servers. The closest sections (Marketing, Customer Data Platforms, Product Management) are all about B2B / sales / SEO — none cover the job-seeker side. With the rise of AI career tools, this seems like a useful new bucket that other authors will populate over time.

## The entry

Shortlisted MCP server (`shortlisted-mcp-server` on npm) exposes 6 tools:

- `search_jobs` — aggregated job search across Greenhouse / Lever / Workday / Adzuna / USAJOBS / RemoteOK / JSearch / web search
- `get_job` — read a full job description
- `get_profile` — read the user's stored resume + skills
- `match_resume_to_job` — fit score with strengths, gaps, suggestions
- `generate_resume` — ATS-tailored resume PDF (rewritten to the target job)
- `generate_cover_letter` — cover letter in professional / casual / formal tones

- npm: https://www.npmjs.com/package/shortlisted-mcp-server
- Source: https://github.com/justinjamesmathew/jobagent/tree/main/mcp-server
- Hosted product: https://shortlisted.site
- Setup docs: https://shortlisted.site/use-with-ai

The server runs over stdio (Claude Desktop, Claude Code, Cursor, etc.) and authenticates against the Shortlisted backend via a session token in `SHORTLISTED_SESSION`.

## Format check

- [x] Alphabetical position in TOC (between "Biology Medicine and Bioinformatics" and "Cloud Platforms")
- [x] Section uses `<a name="...">` anchor matching the TOC link
- [x] Entry uses the standard format: `[github_org/repo](url) <emojis> - description.`
- [x] Includes language emoji (📇 TypeScript/JavaScript), scope (☁️ cloud — backend is hosted), and OS (🍎 🪟 🐧 — npm package, runs anywhere Node 18+ runs)