### PR TITLE
Add hive-pheromones and hive-rosetta to Other Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2518,6 +2518,9 @@ Interact with Git repositories and version control platforms. Enables repository
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
 - [SPL-BGU/PlanningCopilot](https://github.com/SPL-BGU/PlanningCopilot) [![planning-copilot MCP server](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot/badges/score.svg)](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot) 🐍🏠 - A tool-augmented LLM system for the full PDDL planning pipeline, improving reliability without domain-specific training.
 - [yyyhy/nash-arena](https://github.com/yyyhy/nash-arena) [![yyyhy/nash-arena MCP server](https://glama.ai/mcp/servers/yyyhy/nash-arena/badges/score.svg)](https://glama.ai/mcp/servers/yyyhy/nash-arena) 🐍 ☁️ - A Chess and Card Game Arena For LLM, Agents can battle in game by mcp
+- [srotzin/hive-pheromones](https://github.com/srotzin/hive-pheromones) 📇 ☁️ - Public pull surfaces for the Hive Civilization x402 fleet — Hive Index (top-paying agent endpoints), Hall of Fame (top earners by DID), Pulse SSE (live commit feed), Prospector bounty board, and embeddable Hive Certified SVG badge. Wraps live a2amev, x402-index, gamification, and trust upstreams.
+- [srotzin/hive-rosetta](https://github.com/srotzin/hive-rosetta) 📇 ☁️ - Universal x402 adapter cookbook — wire 30+ agent SDKs and Web3 toolchains (AgentKit, GOAT, LangGraph, AutoGen, CrewAI, ADK, ElizaOS, Mastra, Vercel AI, OpenAI Agents, MCP, viem, wagmi, ethers, RainbowKit, thirdweb, MetaMask Snap, Foundry, and more) to USDC EIP-3009 settlement on Base.
+
 ## Frameworks
 
 > [!NOTE]


### PR DESCRIPTION
Adding two new MCP-adjacent entries to **Other Tools and Integrations**:

### 1. [srotzin/hive-pheromones](https://github.com/srotzin/hive-pheromones) — public pull surfaces

Five free public surfaces wrapping the Hive Civilization x402 agent fleet:

- **Hive Index** — top-paying agent endpoints (free top-10 preview of the paid index)
- **Hall of Fame** — top earners by DID
- **Pulse** — live SSE commit feed across the fleet
- **Prospector** — public bounty board
- **Hive Certified badge** — embeddable SVG (`/badge/{did}.svg`) any project can drop into a README

11 endpoints, all live and smoke-tested. Wraps existing upstreams (a2amev, x402-index, gamification, trust). Apache-2.0.

### 2. [srotzin/hive-rosetta](https://github.com/srotzin/hive-rosetta) — universal x402 adapter cookbook

A one-stop cookbook for wiring **30+ agent SDKs and Web3 toolchains** to USDC EIP-3009 settlement on Base via the x402 protocol. Frameworks covered include:

AgentKit, GOAT, LangGraph, AutoGen, CrewAI, Google ADK, ElizaOS, Mastra, Vercel AI, OpenAI Agents, MCP, transformers, smolagents, AutoGPT, LiteLLM, assistant-ui, pydantic-ai, Cline, SuperAGI, E2B, Qwen-Agent, viem, wagmi, ethers, RainbowKit, thirdweb, Alchemy aa-sdk, WalletConnect, MetaMask Snap, Safe, Ape, Foundry.

Apache-2.0. Targets the gap where every framework reimplements payment plumbing in a slightly incompatible way.

### Why these belong here

Both repos are MCP-discoverable, agent-facing, and serve the same audience as the rest of *Other Tools and Integrations* — production tools developers wire into AI agent workflows. Entries follow the alphabetical-by-author pattern used in the section and use the standard `📇 ☁️` legend for TypeScript + cloud.

Happy to split into two PRs if preferred.
