### PR TITLE
Add MCPFind — open-source MCP server directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 ## Community
 
-* [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
+* [MCPFind](https://mcpfind.org) - Open-source directory of 7,299+ MCP servers with one-click install configs for Claude, Cursor, VS Code, and Windsurf.
+* [r/mcp Reddit](https://www.reddit.com/r/mcp)
 
 ## Legend
 


### PR DESCRIPTION
## Summary

Adds [MCPFind](https://mcpfind.org) to the Community section — an open-source directory for discovering MCP servers.

- 7,299+ servers across 21 categories
- One-click install configs for Claude Desktop, Cursor, VS Code, and Windsurf
- Search, filter, and explore community-built integrations
- Open source: https://github.com/MCPFind/mcp-find