### PR TITLE
Add agentmindsdev/mcp-server to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,6 +1819,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.
 
+- [agentmindsdev/mcp-server](https://github.com/agentmindsdev/mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - AgentMinds: cross-site collective intelligence for production AI agents. Push agent reports (metrics, learned_patterns, warnings) + pull personalised recommendations / benchmarks / network position from a pool of solved patterns. ARP v1.1 spec, MCP-aware. `npx agentminds-mcp`.
 - [alilxxey/openobserve-community-mcp](https://github.com/alilxxey/openobserve-community-mcp) [![alilxxey/openobserve-community-mcp MCP server](https://glama.ai/mcp/servers/alilxxey/openobserve-community-mcp/badges/score.svg)](https://glama.ai/mcp/servers/alilxxey/openobserve-community-mcp) 🐍 🏠 🍎 🪟 🐧 - Read-only MCP server for OpenObserve Community Edition via REST API. Search logs, traces, stream schemas, and dashboards without requiring the Enterprise license.
 - [Alog/alog-mcp](https://github.com/saikiyusuke/alog-mcp) 📇 ☁️ - AI agent activity logger & monitor MCP server with 20 tools. Post logs, create articles, manage social interactions, and monitor AI agent activities on the Alog platform.
 - [avivsinai/langfuse-mcp](https://github.com/avivsinai/langfuse-mcp) 🐍 ☁️ - Query Langfuse traces, debug exceptions, analyze sessions, and manage prompts. Full observability toolkit for LLM applications.


### PR DESCRIPTION
## What this adds

[agentmindsdev/mcp-server](https://github.com/agentmindsdev/mcp-server) — official MCP server for [AgentMinds](https://agentminds.dev), a cross-site collective intelligence pool for production AI agents.

### Tools exposed

| Tool | What it does |
|---|---|
| `agentminds_connect` | Pull data + recommendations |
| `agentminds_push` | Push agent reports (metrics, learned_patterns, warnings) into the network |
| `agentminds_actions` | Prioritised action plan for your site |
| `agentminds_agent_detail` | Per-agent metrics + warnings + patterns |
| `agentminds_site_overview` | Full site state across agents |
| `agentminds_status` | System health |
| `agentminds_register` | Register a new site, receive API key |

### Why Monitoring section

Sits alongside Sentry MCP, Langfuse MCP, Logfire MCP — error/perf monitoring access for AI agents — with the additional cross-site recommendation surface (the "what did peer sites running my stack solve" pull side).

### Production status

- **npm**: [`agentminds-mcp`](https://www.npmjs.com/package/agentminds-mcp), MIT, `@modelcontextprotocol/sdk@^1.29.0`
- **Install**: `npx agentminds-mcp` (zero config — auto-detects `.agentminds.json` or `.env`)
- **Spec**: [`agentmindsdev/profile`](https://github.com/agentmindsdev/profile) — AgentMinds Reporting Profile (ARP) v1.1 published, lineage from Sentry / OTel GenAI / OASF / MCP / OpenInference.
- **Standards engagement**: with the MCP extensions-wg around the agent-report envelope

Inserted at the top of Monitoring (alphabetically `agentmindsdev` < `alilxxey`). Happy to adjust badges, wording, or category if a different home fits better.