### PR TITLE
Add Copper (client-side MCP tool-call observability CLI) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 
 Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/) and [glama.ai/mcp/clients](https://glama.ai/mcp/clients).
 
+- [Copper](https://github.com/noelschwarz/copper) 📇 🏠 🍎 🪟 🐧 - A tiny CLI by [Basematter](https://basematter.dev) that tails MCP tool calls, redacts secrets, and flags risky ones.
+
 ## Tutorials
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)


### PR DESCRIPTION
Adds [Copper](https://github.com/noelschwarz/copper) under **Clients** — a TypeScript CLI that wraps the MCP client to stream tool calls, redact secrets, and flag risky calls. By [Basematter](https://basematter.dev). Not an MCP server; fits the client tooling section alongside the existing client directory links.

Made with [Cursor](https://cursor.com)