### PR TITLE
Add mcp-server-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2602,6 +2602,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vinkius-labs/mcp-fusion](https://github.com/vinkius-labs/mcp-fusion) 📇 [![Glama](https://glama.ai/mcp/servers/badge/@vinkius-labs/mcp-fusion)](https://glama.ai/mcp/servers/@vinkius-labs/mcp-fusion) - A TypeScript framework for building production-ready MCP servers with automatic tool discovery, multi-transport support (stdio/SSE/HTTP), built-in validation, and zero-config setup.
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
+- [sarmakska/mcp-server-toolkit](https://github.com/sarmakska/mcp-server-toolkit) 🐍 🏠 ☁️ - Production-ready MCP server starter in Python + FastAPI. OAuth 2.1 with PKCE, OpenTelemetry traces, rate limiting, plugin-based tool registry, runs over stdio and streamable HTTP from the same code path.
 
 ## Tips and Tricks
 


### PR DESCRIPTION
Adds [mcp-server-toolkit](https://github.com/sarmakska/mcp-server-toolkit) under Frameworks. It is a production-ready Python + FastAPI starter for building Model Context Protocol servers, with OAuth 2.1 (PKCE), OpenTelemetry tracing, rate limiting, and a plugin-based tool registry. The same code path runs over both stdio for local agents and streamable HTTP for remote ones, which most reference servers do not handle.

MIT licensed, public repo, README with quick-start and architecture diagram.

Project page: https://sarmalinux.com/products/mcp-server-toolkit