### PR TITLE
Add whisper-windows-mcp to Speech-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)
 * 🎧 - [Text-to-Speech](#text-to-speech)
+* 🎙️ - [Speech-to-Text](#speech-to-text)
 * 🚆 - [Travel & Transportation](#travel-and-transportation)
 * 🔄 - [Version Control](#version-control)
 * 🏢 - [Workplace & Productivity](#workplace-and-productivity)
@@ -2299,6 +2300,10 @@ Translation tools and services to enable AI assistants to translate content betw
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
+
+### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
+
+- [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech
 


### PR DESCRIPTION
Adding whisper-windows-mcp, a Windows-native MCP server for local audio/video transcription using whisper.cpp.

Why it belongs here:
- The only whisper MCP that works natively on Windows without WSL, Python, or cloud APIs
- npm install + config, no build environment required
- Vulkan GPU acceleration (AMD, NVIDIA, Intel) — no vendor-specific SDK
- Batch processing, background jobs, model management (list/download/switch), multilingual support
- Active development, published on npm, listed on mcpservers.org and Glama

https://github.com/eviscerations/whisper-windows-mcp

[![whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp)