### PR TITLE
Add concierge MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2284,6 +2284,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [alphajew420/concierge-mcp](https://github.com/alphajew420/concierge-mcp) 📇 ☁️ - Discord-native customer support platform. 200+ MCP tools covering full ticket lifecycle (claim, snooze, reopen, transfer, merge, etc.), AI summarization/sentiment/suggested replies, knowledge base, panel deployment, customer profiles, blacklist, webhooks, CRM sync, analytics, and Discord channel/DM communication. Install with `npx concierge-mcp`.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.


### PR DESCRIPTION
Adding **concierge-mcp** — Discord-native customer support platform — to the **Support & Service Management** section.

## Project

- **Repo (this listing)**: https://github.com/alphajew420/concierge-mcp
- **npm package**: https://www.npmjs.com/package/concierge-mcp
- **Site**: https://conciergetickets.net
- **Docs**: https://conciergetickets.net/docs
- **Public OpenAPI**: https://api.conciergetickets.net/api/v1/public/openapi.json

## Why it belongs in this list

200+ MCP tools covering:

- **Tickets**: full lifecycle (claim, unclaim, snooze, reopen, complete, transfer, merge, split, lock, escalate, deescalate, etc.) plus bulk operations
- **AI ops**: `summarize_ticket`, `analyze_ticket_sentiment`, `detect_ticket_intent`, `suggest_reply`, `regenerate_ai_response`, `translate_text`
- **Knowledge base**: full CRUD + GitBook import + search
- **Customers**: aggregate profiles, VIP toggle, notes CRUD, time-limited blacklist
- **Panels**: full CRUD + deploy/redeploy + bootstrap presets
- **Configuration**: every TicketPanel and Guild field is writable via generic `update_panel_config` / `update_guild_config` tools, with `get_schema` for live model introspection
- **Discord**: send channel messages, DMs, reactions, multicast announcements, look up live channels/roles/members
- **Analytics**: full overview, peak hours heatmap, agent leaderboard, CSV export
- **Webhooks/CRM/GitHub/team/audit/billing/cron run-now triggers**

## Install

```json
{
  "mcpServers": {
    "concierge": {
      "command": "npx",
      "args": ["-y", "concierge-mcp"],
      "env": {
        "CONCIERGE_GUILD_ID": "your-discord-guild-id",
        "CONCIERGE_MCP_KEY": "your-mcp-api-key"
      }
    }
  }
}
```

The `concierge-mcp` package is a thin stdio proxy to the hosted MCP server — tool definitions are fetched live, so new tools released by Concierge appear automatically without re-installing.

## Flags

📇 (TypeScript) ☁️ (cloud-hosted)

Both transports (HTTP+SSE for partner integrations, stdio via npm for desktop clients), uses the official `@modelcontextprotocol/sdk`, MIT licensed.