### PR TITLE
Add peter-products/pads-mcp to Real Estate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [peter-products/pads-mcp](https://github.com/peter-products/pads-mcp) 📇 ☁️ 🍎 🪟 🐧 - Free fair-value verdicts and parcel address lookup for King County, Washington single-family homes. Three tools: `analyze_property` (one-shot address-to-verdict), `lookup_address`, `get_verdict`. Computed from King County's published bulk property records; no auth required. Install with `npx -y pads-mcp`.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [`pads-mcp`](https://github.com/peter-products/pads-mcp) under the Real Estate category.

PADS — Property Appeal Data Services — is a free King County, Washington property-tax fair-value tool. The MCP server exposes three read-only tools that wrap the documented public API at https://pads.tax/api/:

- `analyze_property(address)` — one-shot: free-text address in, full verdict out (KC's assessed value, comp-implied fair value, dollar gap, recommendation tier).
- `lookup_address(query)` — partial address or 10-digit parcel ID → up to 10 canonical King County parcels.
- `get_verdict(parcel_id)` — fair-value verdict for one parcel.

Every tool response includes a one-line `summary`, pre-formatted dollar figures, a `data_source` attribution (computed from King County's published bulk property records), and a `full_report_url` deep link to the interactive view.

**Coverage:** King County, WA, single-family homes only.
**Auth:** none. Read-only.
**Install:** `npx -y pads-mcp`.

Tested with Claude Desktop, Claude Code, and the MCP Inspector against the live API.