### PR TITLE
Add Digital Signage category and CastHub MCP server entry 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🛠️ - [Developer Tools](#developer-tools)
 * 🧮 - [Data Science Tools](#data-science-tools)
 * 📊 - [Data Visualization](#data-visualization)
+* 📺 - [Digital Signage](#digital-signage)
 * 📟 - [Embedded system](#embedded-system)
 * 🎓 - [Education](#education)
 * 🛒 - [E-Commerce](#e-commerce)
@@ -1151,6 +1152,12 @@ Interactive charts, dashboards, and visual data tools rendered inside AI convers
 
 - [nteract/semiotic](https://github.com/nteract/semiotic) [![nteract/semiotic MCP server](https://glama.ai/mcp/servers/nteract/semiotic/badges/score.svg)](https://glama.ai/mcp/servers/nteract/semiotic) 📇 🏠 🍎 🪟 🐧 - React data visualization MCP server with 30+ chart types. 5 tools: suggest charts for a dataset, render validated React configs to SVG, diagnose configuration anti-patterns, get component schemas, and report issues. 
 - [subhatta123/twilize](https://github.com/subhatta123/twilize) [![subhatta123/twilize MCP server](https://glama.ai/mcp/servers/subhatta123/twilize/badges/score.svg)](https://glama.ai/mcp/servers/subhatta123/twilize) 🐍 🏠 🍎 🪟 🐧 - Programmatic Tableau workbook (.twb/.twbx) generation — 47 MCP tools for charts, dashboards, calculated fields, dashboard actions, workbook migration, and CSV-to-dashboard pipelines. Install via `uvx twilize`.
+
+### 📺 <a name="digital-signage"></a>Digital Signage
+
+Manage TV fleets, presentations, schedules, and emergency alerts on physical screens through natural language.
+
+- [Cast-Hub/mcp-server](https://github.com/Cast-Hub/mcp-server) 📇 ☁️ - Hosted MCP server for digital signage. 30+ tools for managing TV fleets, presentations, schedules, and emergency alerts. Includes governance layer (preview, confirm, rollback) and native Amazon Signage Stick support. Available as a hosted endpoint or via the `@cast-hub/mcp` npm package.
 
 ### 📟 <a name="embedded-system"></a>Embedded System
 


### PR DESCRIPTION
Adding the CastHub MCP server to the list, and creating a new "Digital Signage" category for it.

CastHub is a digital signage platform with a Model Context Protocol server for AI-driven fleet management. The server exposes 30+ tools covering devices, presentations, schedules, alerts, and groups. Differentiators against existing MCP-capable signage platforms (Fugo, Revel Digital, Screenly):

- Hosted MCP endpoint (no local CLI install required for the basic path)
- Governance layer with preview, confirm, and rollback for safe agent use
- Native Amazon Signage Stick integration
- Flat-rate pricing tiers

I created a new "Digital Signage" category because no existing category fits — the closest options (Marketing, Embedded System, Communication) are all materially different in scope. The category is slotted alphabetically between Data Visualization and Embedded System, with a TOC entry added accordingly. CONTRIBUTING.md explicitly invites new categories ("If a new category is needed, please create one and maintain alphabetical order"). Other MCP-capable signage platforms (Fugo, Revel Digital, Screenly) can land in the same category if/when their entries are submitted.

Repo: https://github.com/Cast-Hub/mcp-server
Marketing page: https://cast-hub.com/mcp
NPM package: https://www.npmjs.com/package/@cast-hub/mcp
License: MIT

Happy to adjust category name, placement, or entry format based on your preferences.

🤖 This PR was prepared by an agent operating in good faith on behalf of @DanCastHub. Per CONTRIBUTING.md, opting into the agent fast-track via the trailing emoji marker.