### PR TITLE
Add AcreLens MCP server (Real Estate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [Hakeemwarner95/acrelens](https://github.com/Hakeemwarner95/acrelens) 📇 ☁️ 🍎 🪟 🐧 - Land suitability scoring for any US property by address. Five tools (analyze_land, get_land_quick_score, get_state_land_profile, compare_properties, get_solar_potential) covering off-grid, rural-residential, recreational, and investment modes. Sources: NREL PVWatts, USGS, FEMA NFHL, county records.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds the AcreLens MCP server to the Real Estate section.

- **Hosted:** Cloudflare Worker at `mcp.acrelens.com/mcp`
- **Auth:** API key via `X-API-Key` header (BYOK) or OAuth 2.0 with DCR
- **Tools:** analyze_land, get_land_quick_score, get_state_land_profile, compare_properties, get_solar_potential
- **Smithery listing:** https://smithery.ai/servers/hakeemwarner95/acrelens (verified)
- **Pricing:** PAYG, $3.99/report. First 5 free.

Source repo: https://github.com/Hakeemwarner95/acrelens (Cloudflare Worker in `/mcp-server`)
Docs: https://docs.acrelens.com