### PR TITLE
Add gohighlevel-mcp-pro to Customer Data Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ Provides access to customer profiles inside of customer data platforms
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
 - [lionkiii/google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) [![google-searchconsole-mcp MCP server](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp) 📇 🏠 - Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.
 - [saurabhsharma2u/search-console-mcp](https://github.com/saurabhsharma2u/search-console-mcp)  - An MCP server to interact with Google Search Console and Bing Webmasters.
+- [nafiurrahmanniloy/gohighlevel-mcp-pro](https://github.com/nafiurrahmanniloy/gohighlevel-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Hardened GoHighLevel/HighLevel MCP server with 566 tools, lean-mode tool filter (default 181 tools / ~90k tokens via `GHL_TOOLSETS` env), and 14 agency-grade composites — workflow auditing, contact deduplication, tag consolidation, deliverability health scoring, custom-field schema migration, Ed25519 webhook signature verification.
 
 ### 🗄️ <a name="databases"></a>Databases
 


### PR DESCRIPTION
Adds [gohighlevel-mcp-pro](https://github.com/nafiurrahmanniloy/gohighlevel-mcp-pro), a hardened GoHighLevel MCP server with lean-mode tool filtering, 14 agency-grade composite tools, and 15 documented bug fixes.

- Default loads ~181 tools (~90k tokens) instead of all 566 — solves the "context full" problem that makes large vertical MCPs unusable
- 14 composites mapped to top-voted GHL ideas-portal feature requests (workflow auditing, tag consolidation, contact dedup, deliverability health scoring, etc.)
- Future-proofed for the July 2026 GHL webhook auth migration (Ed25519 + RSA both supported via `verify_webhook_signature`)

No existing GoHighLevel or HighLevel entries in the list. Placed under Customer Data Platforms; happy to move to a different section if a maintainer prefers (Marketing or a new CRM subsection).

Repo is public, TypeScript, runs on stdio + Streamable HTTP.