### PR TITLE
Add grounding-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1949,7 +1949,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 
-- [andyliszewski/grounding-ai](https://github.com/andyliszewski/grounding-ai) 🐍 🏠 - Build a searchable index from PDFs, EPUBs, and Word docs. Claude queries it via MCP and pulls grounded answers with exact page-and-section citations. Local-first, no cloud dependency.
+- [andyliszewski/grounding-ai](https://github.com/andyliszewski/grounding-ai) [![andyliszewski/grounding-ai MCP server](https://glama.ai/mcp/servers/andyliszewski/grounding-ai/badges/score.svg)](https://glama.ai/mcp/servers/andyliszewski/grounding-ai) 🐍 🏠 - Build a searchable index from PDFs, EPUBs, and Word docs. Claude queries it via MCP and pulls grounded answers with exact page-and-section citations. Local-first, no cloud dependency.
 - [gogabrielordonez/mcp-ragchat](https://github.com/gogabrielordonez/mcp-ragchat) 📇 🏠 - Add RAG-powered AI chat to any website with one command. Local vector store, multi-provider LLM (OpenAI/Anthropic/Gemini), self-contained chat server and embeddable widget.
 - [poll-the-people/customgpt-mcp](https://github.com/Poll-The-People/customgpt-mcp) 🐍 🏠 ☁️ - An MCP server for accessing all of CustomGPT.ai's anti-hallucination RAG-as-a-service API endpoints.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.

--- a/README.md
+++ b/README.md
@@ -1949,6 +1949,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 
+- [andyliszewski/grounding-ai](https://github.com/andyliszewski/grounding-ai) 🐍 🏠 - Build a searchable index from PDFs, EPUBs, and Word docs. Claude queries it via MCP and pulls grounded answers with exact page-and-section citations. Local-first, no cloud dependency.
 - [gogabrielordonez/mcp-ragchat](https://github.com/gogabrielordonez/mcp-ragchat) 📇 🏠 - Add RAG-powered AI chat to any website with one command. Local vector store, multi-provider LLM (OpenAI/Anthropic/Gemini), self-contained chat server and embeddable widget.
 - [poll-the-people/customgpt-mcp](https://github.com/Poll-The-People/customgpt-mcp) 🐍 🏠 ☁️ - An MCP server for accessing all of CustomGPT.ai's anti-hallucination RAG-as-a-service API endpoints.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.


### PR DESCRIPTION
Adds [grounding-ai](https://github.com/andyliszewski/grounding-ai) to the **end to end RAG platforms** section.

Local-first document corpus pipeline that ingests PDFs, EPUBs, and Word docs into a searchable index, exposed via an MCP server that returns chunks with page-and-section citations. Differentiates from the existing entries in the section (mcp-ragchat, customgpt-mcp, vectara-mcp), which are hosted RAG-as-a-service products — grounding-ai keeps both ingestion and retrieval local.

Format: alphabetical placement (a-n-d-y < g-o-g), legend emojis 🐍 (Python) and 🏠 (Local Service).

[![andyliszewski/grounding-ai MCP server](https://glama.ai/mcp/servers/andyliszewski/grounding-ai/badges/score.svg)](https://glama.ai/mcp/servers/andyliszewski/grounding-ai)