### PR TITLE
Add NYC Property Intel to Real Estate category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [ccedacero/nyc-property-intel](https://github.com/ccedacero/nyc-property-intel) 🐍 ☁️ 🏠 🍎 🪟 🐧 - MCP server for NYC real estate due diligence — query 22+ NYC public databases (DOB violations, HPD complaints, ECB, ACRIS deeds, DOF sales, 311, FDNY, NYPD, marshal evictions, PLUTO, rent stabilization) in plain English. Live demo (no install): https://nycpropertyintel.com/chat
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds **NYC Property Intel** to the 🏠 Real Estate category as the second entry alongside propstack-mcp.

## What it is

Open-source MCP server (MIT) giving Claude AI access to 22+ NYC public-record databases (DOB violations, HPD complaints, ECB violations, ACRIS deeds, DOF sales, 311 complaints, FDNY incidents, NYPD complaints, marshal evictions, PLUTO, rent stabilization registry) for real estate due diligence in plain English.

## Highlights

- **Live demo (no install required):** https://nycpropertyintel.com/chat
- **Repo:** https://github.com/ccedacero/nyc-property-intel
- **Hosted endpoint:** `https://nyc-property-intel-production.up.railway.app/mcp` (HTTP transport, Bearer-token auth)
- ~19M rows of NYC public records loaded into Postgres via the open-source [nycdb](https://github.com/nycdb/nycdb) project
- Tier-1 datasets refresh daily; tier-2 weekly; tier-3 monthly
- Free trial: 10 queries/day for 30 days
- Self-host fully supported

## Differentiator

Replaces the manual workflow of clicking through 8–10 NYC city websites for due diligence on a single property. Works with Claude Code (`claude mcp add --transport http ...`) and Claude Desktop.

## Checklist

- [x] Alphabetical ordering — inserted after `ashev87/propstack-mcp` since `ccedacero` > `ashev87`
- [x] Includes legend emojis: 🐍 (Python) ☁️ (cloud-hosted) 🏠 (self-hostable) 🍎 🪟 🐧 (cross-platform)
- [x] One line, concise description
- [x] Working repo + live demo links