### PR TITLE
Add brewpage-mcp — publish HTML/JSON/KV/files to brewpage.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2506,6 +2506,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [kiwamizamurai/mcp-kibela-server](https://github.com/kiwamizamurai/mcp-kibela-server) - 📇 ☁️ Powerfully interact with Kibela API.
 - [kj455/mcp-kibela](https://github.com/kj455/mcp-kibela) - 📇 ☁️ Allows AI models to interact with [Kibela](https://kibe.la/)
 - [Klavis-AI/YouTube](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/youtube) 🐍 📇 - Extract and convert YouTube video information.
+- [kochetkov-ma/brewpage-mcp](https://github.com/kochetkov-ma/brewpage-openapi) 📇 ☁️ - Publish HTML, Markdown, JSON, key-value pairs, files, and multi-file sites to [brewpage.app](https://brewpage.app) — a free hosting service with short URLs, TTL-based retention (15–30 days), and owner tokens for later updates. No account required. `npx -y brewpage-mcp`.
 - [KS-GEN-AI/confluence-mcp-server](https://github.com/KS-GEN-AI/confluence-mcp-server) 📇 ☁️ 🍎 🪟 - Get Confluence data via CQL and read pages.
 - [KS-GEN-AI/jira-mcp-server](https://github.com/KS-GEN-AI/jira-mcp-server) 📇 ☁️ 🍎 🪟 - Read jira data via JQL and api and execute requests to create and edit tickets.
 - [kw510/strava-mcp](https://github.com/kw510/strava-mcp) 📇 ☁️ - An MCP server for Strava, an app for tracking physical exercise


### PR DESCRIPTION
### Server

[`kochetkov-ma/brewpage-mcp`](https://github.com/kochetkov-ma/brewpage-openapi) — npm: [`brewpage-mcp`](https://www.npmjs.com/package/brewpage-mcp), stdio transport.

Publishes HTML pages, Markdown documents, JSON, key-value pairs, files, and multi-file sites to [brewpage.app](https://brewpage.app) — a free hosting service. Returns a short URL (`https://brewpage.app/{ns}/{id10}`) and an owner token for later updates. TTL-based retention (15–30 days). No account required.

### Placement

Inserted in `Other Tools and Integrations`, alphabetically between `Klavis-AI/YouTube` and `KS-GEN-AI/confluence-mcp-server`.

### Public OpenAPI / docs

- Spec: https://github.com/kochetkov-ma/brewpage-openapi/blob/main/openapi/openapi.yaml
- Rendered docs: https://kochetkov-ma.github.io/brewpage-openapi/
- llms.txt: https://brewpage.app/llms.txt

### Install

```
npx -y brewpage-mcp
```

```json
{
  "mcpServers": {
    "brewpage": { "command": "npx", "args": ["-y", "brewpage-mcp"] }
  }
}
```

### Checklist

- [x] Existing format & style respected (single line, codebase emoji + scope emoji + dash + description).
- [x] Alphabetical placement within section.
- [x] Repository link verified.
- [x] npm package published.