### PR TITLE
Add childrentime/reactuse MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [catrinmdonnelly/royalmail-mcp](https://github.com/catrinmdonnelly/royalmail-mcp) [![catrinmdonnelly/royalmail-mcp MCP server](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp/badges/score.svg)](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp) 📇 ☁️ - Book, label, track and cancel Royal Mail and Parcelforce shipments. 33 UK and international services via friendly keys or raw Service Register codes. `npx royalmail-mcp`.
 
 - [Yang1Bai/claw-tsaver](https://github.com/Yang1Bai/claw-tsaver)__ 🐍 🏠 🍎 🪟 🐧 - Token-saving MCP proxy that intercepts oversized tool returns and replaces them with a preview + on-demand handle. Real benchmark: 11,507 tokens → 104 tokens (99.1% saved) on a Wikipedia fetch. Works with OpenClaw + Claude.
-- [childrentime/reactuse](https://github.com/childrentime/reactuse) 📇 🏠 🍎 🪟 🐧 - MCP server for the [ReactUse](https://reactuse.com) library — 110+ React Hooks (TypeScript-first, SSR-compatible, tree-shakable). Lets AI assistants discover hook signatures, demos, and usage patterns directly from the docs.
+- [childrentime/reactuse](https://github.com/childrentime/reactuse) [![childrentime/reactuse MCP server](https://glama.ai/mcp/servers/childrentime/reactuse/badges/score.svg)](https://glama.ai/mcp/servers/childrentime/reactuse) 📇 🏠 🍎 🪟 🐧 - MCP server for the [ReactUse](https://reactuse.com) library — 110+ React Hooks (TypeScript-first, SSR-compatible, tree-shakable). Lets AI assistants discover hook signatures, demos, and usage patterns directly from the docs.
   
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [catrinmdonnelly/royalmail-mcp](https://github.com/catrinmdonnelly/royalmail-mcp) [![catrinmdonnelly/royalmail-mcp MCP server](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp/badges/score.svg)](https://glama.ai/mcp/servers/catrinmdonnelly/royalmail-mcp) 📇 ☁️ - Book, label, track and cancel Royal Mail and Parcelforce shipments. 33 UK and international services via friendly keys or raw Service Register codes. `npx royalmail-mcp`.
 
 - [Yang1Bai/claw-tsaver](https://github.com/Yang1Bai/claw-tsaver)__ 🐍 🏠 🍎 🪟 🐧 - Token-saving MCP proxy that intercepts oversized tool returns and replaces them with a preview + on-demand handle. Real benchmark: 11,507 tokens → 104 tokens (99.1% saved) on a Wikipedia fetch. Works with OpenClaw + Claude.
+- [childrentime/reactuse](https://github.com/childrentime/reactuse) 📇 🏠 🍎 🪟 🐧 - MCP server for the [ReactUse](https://reactuse.com) library — 110+ React Hooks (TypeScript-first, SSR-compatible, tree-shakable). Lets AI assistants discover hook signatures, demos, and usage patterns directly from the docs.
   
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 


### PR DESCRIPTION
Adds [childrentime/reactuse](https://github.com/childrentime/reactuse) MCP server under Developer Tools.

ReactUse is a library of 110+ React Hooks (TypeScript-first, SSR-compatible, tree-shakable, with interactive demos for every hook). The MCP server exposes hook signatures, demos, and usage patterns so AI coding assistants can discover and use any hook directly from their context.

- Repo: https://github.com/childrentime/reactuse
- npm (lib): https://www.npmjs.com/package/@reactuses/core
- npm (mcp): https://www.npmjs.com/package/@reactuses/mcp
- Docs: https://reactuse.com

Format matches existing entries in Developer Tools — `[owner/repo](url) 📇 🏠 🍎 🪟 🐧 - description`.