### PR TITLE
Add MonoSpay — non-custodial USDC settlement for paid MCP tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1231,6 +1231,8 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
+- [agash-sivathas/monospay](https://github.com/agash-sivathas/monospay) 🐍 📇 ☁️ - Pay per MCP tool call in USDC on Base. Non-custodial settlement, no admin keys, 30 bps fee.
+
 - [mrslbt/xendit-mcp](https://github.com/mrslbt/xendit-mcp) [![mrslbt/xendit-mcp MCP server](https://glama.ai/mcp/servers/mrslbt/xendit-mcp/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/xendit-mcp) 📇 ☁️ - Xendit payment gateway for Southeast Asia. Invoices, disbursements, balance checks, and bank transfers across Indonesia, Philippines, Thailand, Vietnam, and Malaysia. Install via `npx xendit-mcp`.
 - [@arbitova/mcp-server](https://github.com/jiayuanliang0716-max/Arbitova) [![jiayuanliang0716-max/Arbitova MCP server](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova/badges/score.svg)](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova) 📇 ☁️ - Non-custodial on-chain escrow + AI dispute arbitration for agent-to-agent USDC payments on Base. Seven tools covering the full `EscrowV1` contract surface: create escrow, mark delivered with on-chain content hash, confirm or dispute, arbiter resolves with signed verdict, cancel/escalate on timeout. `npx @arbitova/mcp-server`
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.

--- a/README.md
+++ b/README.md
@@ -1231,8 +1231,8 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
-- [agash-sivathas/monospay](https://github.com/agash-sivathas/monospay) 🐍 📇 ☁️ - Pay per MCP tool call in USDC on Base. Non-custodial settlement, no admin keys, 30 bps fee.
-
+- [monospay/monospay](https://github.com/monospay/monospay) 🐍 📇 ☁️ - Pay per MCP tool call in USDC on Base. Non-custodial settlement, no admin keys, 30 bps fee.
+  
 - [mrslbt/xendit-mcp](https://github.com/mrslbt/xendit-mcp) [![mrslbt/xendit-mcp MCP server](https://glama.ai/mcp/servers/mrslbt/xendit-mcp/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/xendit-mcp) 📇 ☁️ - Xendit payment gateway for Southeast Asia. Invoices, disbursements, balance checks, and bank transfers across Indonesia, Philippines, Thailand, Vietnam, and Malaysia. Install via `npx xendit-mcp`.
 - [@arbitova/mcp-server](https://github.com/jiayuanliang0716-max/Arbitova) [![jiayuanliang0716-max/Arbitova MCP server](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova/badges/score.svg)](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova) 📇 ☁️ - Non-custodial on-chain escrow + AI dispute arbitration for agent-to-agent USDC payments on Base. Seven tools covering the full `EscrowV1` contract surface: create escrow, mark delivered with on-chain content hash, confirm or dispute, arbiter resolves with signed verdict, cancel/escalate on timeout. `npx @arbitova/mcp-server`
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.

--- a/README.md
+++ b/README.md
@@ -1231,8 +1231,8 @@ Provides direct access to local file systems with configurable permissions. Enab
 
 ### 💰 <a name="finance--fintech"></a>Finance & Fintech
 
-- [monospay/monospay](https://github.com/monospay/monospay) 🐍 📇 ☁️ - Pay per MCP tool call in USDC on Base. Non-custodial settlement, no admin keys, 30 bps fee.
-  
+- [monospay/monospay](https://github.com/monospay/monospay) [![monospay/monospay MCP server](https://glama.ai/mcp/servers/monospay/monospay/badges/score.svg)](https://glama.ai/mcp/servers/monospay/monospay) 🐍 📇 ☁️ - Pay per MCP tool call in USDC on Base. Non-custodial settlement, no admin keys, 30 bps fee.
+    
 - [mrslbt/xendit-mcp](https://github.com/mrslbt/xendit-mcp) [![mrslbt/xendit-mcp MCP server](https://glama.ai/mcp/servers/mrslbt/xendit-mcp/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/xendit-mcp) 📇 ☁️ - Xendit payment gateway for Southeast Asia. Invoices, disbursements, balance checks, and bank transfers across Indonesia, Philippines, Thailand, Vietnam, and Malaysia. Install via `npx xendit-mcp`.
 - [@arbitova/mcp-server](https://github.com/jiayuanliang0716-max/Arbitova) [![jiayuanliang0716-max/Arbitova MCP server](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova/badges/score.svg)](https://glama.ai/mcp/servers/jiayuanliang0716-max/Arbitova) 📇 ☁️ - Non-custodial on-chain escrow + AI dispute arbitration for agent-to-agent USDC payments on Base. Seven tools covering the full `EscrowV1` contract surface: create escrow, mark delivered with on-chain content hash, confirm or dispute, arbiter resolves with signed verdict, cancel/escalate on timeout. `npx @arbitova/mcp-server`
 - [@asterpay/mcp-server](https://github.com/timolein74/asterpay-mcp-server) [![asterpay-mcp-server MCP server](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/timolein74/asterpay-mcp-server) 📇 ☁️ - EUR settlement for AI agents via x402 protocol. Market data, AI tools, crypto analytics — pay-per-call in USDC on Base. SEPA Instant EUR off-ramp.


### PR DESCRIPTION
**MonoSpay** 🐍 ☁️

Pay per MCP tool call in USDC on Base. Non-custodial — no admin keys, no custodian. 30 bps protocol fee on the optional 3-party escrow path; settlement-only path is fee-free except gas.

- npm: `npx monospay-mcp` — https://www.npmjs.com/package/monospay-mcp
- PyPI: `pip install monospay`
- Repo: https://github.com/monospay/monospay
- Settlement contract (Base mainnet): `0xA9DC3105ec1A84E4Bc3c9702dFC772a6efA2CDBA`
- Escrow contract (Base mainnet): `0x11deAF058eb447fF9F912806706890b7f13Be37B`
- Demo: https://monospay.com
- 79 tests passing, three real settled txs on Base mainnet.

x402-compatible at the request layer; differs from CDP's facilitator by being non-custodial and supporting 3-party escrow with `proveFraud()` for operator double-signs.

Added under Finance & Fintech, alphabetical position preserved.