### PR TITLE
Add airtable/skills (official Airtable MCP server, plugins, and skills) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ Provides access to customer profiles inside of customer data platforms
 
 Secure database access with schema inspection capabilities. Enables querying and analyzing data with configurable security controls including read-only access.
 
+- [airtable/skills](https://github.com/airtable/skills) 🎖️ 📇 ☁️ - Official Airtable MCP server (`mcp.airtable.com/mcp`), plugins, and skills. The database and operations layer for your agents — whether running product, marketing, sales, ops, HR, or a custom business app.
 - [Aiven-Open/mcp-aiven](https://github.com/Aiven-Open/mcp-aiven) - 🐍 ☁️ 🎖️ -  Navigate your [Aiven projects](https://go.aiven.io/mcp-server) and interact with the PostgreSQL®, Apache Kafka®, ClickHouse® and OpenSearch® services
 - [alexanderzuev/supabase-mcp-server](https://github.com/alexander-zuev/supabase-mcp-server) - Supabase MCP Server with support for SQL query execution and database exploration tools
 - [aliyun/alibabacloud-tablestore-mcp-server](https://github.com/aliyun/alibabacloud-tablestore-mcp-server) ☕ 🐍 ☁️ - MCP service for Tablestore, features include adding documents, semantic search for documents based on vectors and scalars, RAG-friendly, and serverless.


### PR DESCRIPTION
Adds the official Airtable MCP server, plugins, and skills repo to the Databases section.

- Hosted at https://mcp.airtable.com/mcp (remote, OAuth-protected)
- Public repo (skills, plugin manifests, install instructions): https://github.com/airtable/skills
- Listed in the official MCP Registry as `com.airtable/mcp`

Placed alphabetically at the top of the Databases section per CONTRIBUTING.md. The two existing community Airtable entries (domdomegg, rashidazarang) are unchanged.

Format follows the convention used by other canonical company entries (cloudflare, redis, supabase-community, planetscale, github).