### PR TITLE
Add awesome-agentic-ai-zh to Tutorials — trilingual 7-stage learning roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 ## Tutorials
 
-* [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) — Trilingual (zh-TW · zh-CN · English) 7-stage learning roadmap for agentic AI. Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing your own server) with prerequisites and time estimates; the catalog includes 62 integrations grouped by use case.
+* [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) — Trilingual (zh-TW · zh-CN · English) 7-stage learning roadmap for agentic AI. Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing your own server) with prerequisites and time estimates; the catalog includes 62 integrations grouped by use case.
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 ## Tutorials
 
+* [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) — Trilingual (zh-TW · zh-CN · English) 7-stage learning roadmap for agentic AI. Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing your own server) with prerequisites and time estimates; the catalog includes 62 integrations grouped by use case.
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 ## Tutorials
 
-* [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) — Trilingual (zh-TW · zh-CN · English) 7-stage learning roadmap for agentic AI. Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing your own server) with prerequisites and time estimates; the catalog includes 62 integrations grouped by use case.
+* [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) 🐍 - Trilingual (zh-TW · zh-Hans · English) 8-stage learning roadmap for agentic AI. Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing your own server) with prerequisites and time estimates; rendered docs site: https://wenyuchiou.github.io/awesome-agentic-ai-zh/ — catalog of 62 integrations grouped by use case.
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
 


### PR DESCRIPTION
Hi @punkpeye,

awesome-mcp-servers is already cited in our README's `Related projects` section
([line 208](https://github.com/WenyuChiou/awesome-agentic-ai-zh/blob/main/README.md)).

Proposing [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)
for your `## Tutorials`:

- Trilingual (zh-TW · zh-CN · English) 7-stage learning roadmap for agentic AI
- Stage 5.2 is a dedicated MCP walkthrough (concept → first install → writing
  your own server)
- After Stage 5.2 readers are pointed to your catalog for picking specific servers

If a different section fits better, happy to update.

— Wenyu