### PR TITLE
Add World Cup History MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🔒 - [Security](#security)
 * 🌐 - [Social Media](#social-media)
 * 🏃 - [Sports](#sports)
-- [zafronix/wc-mcp](https://github.com/zafronix/zafronix-wc-api/tree/main/mcp) 📇 🏠 ☁️ 🍎 🪟 🐧 - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
+- [zafronix/wc-mcp](https://github.com/zafronix/wc-mcp) [![World Cup History MCP server](https://glama.ai/mcp/servers/zafronix/wc-mcp/badges/score.svg)](https://glama.ai/mcp/servers/zafronix/wc-mcp) 📇 🏠 ☁️ 🍎 🪟 🐧 - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)
 * 🎧 - [Text-to-Speech](#text-to-speech)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🔒 - [Security](#security)
 * 🌐 - [Social Media](#social-media)
 * 🏃 - [Sports](#sports)
-- [zafronix/wc-mcp](https://github.com/zafronix/zafronix-wc-api/tree/main/mcp) 🌐 ☁️ - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
+- [zafronix/wc-mcp](https://github.com/zafronix/zafronix-wc-api/tree/main/mcp) 📇 🏠 ☁️ 🍎 🪟 🐧 - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)
 * 🎧 - [Text-to-Speech](#text-to-speech)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🔒 - [Security](#security)
 * 🌐 - [Social Media](#social-media)
 * 🏃 - [Sports](#sports)
+- [zafronix/wc-mcp](https://github.com/zafronix/zafronix-wc-api/tree/main/mcp) 🌐 ☁️ - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)
 * 🎧 - [Text-to-Speech](#text-to-speech)


### PR DESCRIPTION
World Cup data MCP wrapping a public REST API (api.zafronix.com). 23 tournaments, full historical coverage 1930-2026. MIT-licensed. Free tier with no card. npm: @zafronix/wc-mcp.