### PR TITLE
Add Royalti-io/ikenga-pkg-mcp-iyke to OS Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1908,6 +1908,7 @@ Servers for controlling the desktop operating system: screenshots, window manage
 
 - [sbuysse/gnome-desktop-mcp](https://github.com/sbuysse/gnome-desktop-mcp) [![gnome-desktop-mcp MCP server](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sbuysse/gnome-desktop-mcp) 🐍 🏠 🐧 - GNOME desktop automation for AI agents. 30 tools via D-Bus: screenshots, window management, mouse/keyboard injection, clipboard, workspaces, and system notifications. Works on any GNOME 45–49 Linux desktop.
 - [dimpagk92/cellar](https://github.com/dimpagk92/cellar) [![dimpagk92/cellar MCP server](https://glama.ai/mcp/servers/dimpagk92/cellar/badges/score.svg)](https://glama.ai/mcp/servers/dimpagk92/cellar) 🦀 📇 🏠 🍎 🐧 - Hybrid computer-use runtime. Fuses accessibility tree + Chrome DevTools Protocol + vision into structured context with per-element confidence. 4 MCP tools (see/act/think/perceive). Continuous awareness engine (Cortex) with freshness + side-effect detection. Works offline with Ollama + local models.
+- [Royalti-io/ikenga-pkg-mcp-iyke](https://github.com/Royalti-io/ikenga-pkg-mcp-iyke) 📇 🏠 🍎 🪟 🐧 - Drive a running Ikenga desktop app (Tauri 2) from MCP clients — read DOM, click, type, navigate, screenshot. Listed at `io.github.Royalti-io/ikenga-pkg-mcp-iyke` on the official MCP registry.
 
 ### 📋 <a name="product-management"></a>Product Management
 


### PR DESCRIPTION
Adds [Royalti-io/ikenga-pkg-mcp-iyke](https://github.com/Royalti-io/ikenga-pkg-mcp-iyke) under \`### 🖥️ OS Automation\`.

**What it does:** Drives a running Ikenga desktop app (Tauri 2) from any MCP client — read DOM, click, type, navigate, capture screenshots. Cross-platform (macOS / Windows / Linux), local service (no cloud).

**Tags:** 📇 (TypeScript) 🏠 (Local Service) 🍎 🪟 🐧

**Distribution:** npm \`@ikenga/mcp-iyke\` (Apache 2.0), also published to the official MCP registry as \`io.github.Royalti-io/ikenga-pkg-mcp-iyke\`.