### PR TITLE
Add Agent Web Search MCP to Search & Data Extraction section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1955,6 +1955,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="search"></a>Search & Data Extraction
 
+- [tiagohanna123/agent-web-search-mcp](https://github.com/tiagohanna123/agent-web-search-mcp) [![agent-web-search-mcp MCP server](https://glama.ai/mcp/servers/tiagohanna123/agent-web-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/tiagohanna123/agent-web-search-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Web search MCP server for AI agents — DuckDuckGo search + URL content extraction + markdown conversion. No API key required. Free tier: 7 requests/IP/day. Pro: unlimited (R$50).
 - [mrslbt/rippr](https://github.com/mrslbt/rippr) [![mrslbt/rippr MCP server](https://glama.ai/mcp/servers/mrslbt/rippr/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/rippr) 📇 🏠 - YouTube transcript extraction for AI agents. Clean text, timestamps, or structured JSON from any video. No API keys required. Install via `npx rippr-mcp`.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.


### PR DESCRIPTION
Adds [Agent Web Search MCP](https://github.com/tiagohanna123/agent-web-search-mcp) to the Search & Data Extraction section.

- **What it does:** DuckDuckGo web search + URL content extraction + markdown conversion for AI agents
- **Free tier:** 7 requests/IP/day - no API key required
- **Pro tier:** unlimited use (R$50 via Pix or card)
- **Install:** `npx -y @tiagohanna123/agent-web-search-mcp` or remote server at https://hermes-api.tiagohanna.com/

Entry follows the same format as existing entries in this section.