### PR TITLE
Add wehomemove/homedata-mcp under Real Estate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [wehomemove/homedata-mcp](https://github.com/wehomemove/loki/tree/main/homedata-mcp) 🎖️ 🐍 ☁️ 🍎 🪟 🐧 - UK property data MCP from [Homedata](https://homedata.co.uk): 29M UK addresses, EPC ratings, flood risk, planning applications, comparables, demographics, schools, broadband, and more. 16 tools, free tier with 100 calls/mo, no credit card. `pip install homedata-mcp`.
 
 ### 🔬 <a name="research"></a>Research
 

--- a/README.md
+++ b/README.md
@@ -1924,7 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
-- [wehomemove/homedata-mcp](https://github.com/wehomemove/loki/tree/main/homedata-mcp) 🎖️ 🐍 ☁️ 🍎 🪟 🐧 - UK property data MCP from [Homedata](https://homedata.co.uk): 29M UK addresses, EPC ratings, flood risk, planning applications, comparables, demographics, schools, broadband, and more. 16 tools, free tier with 100 calls/mo, no credit card. `pip install homedata-mcp`.
+- [wehomemove/homedata-mcp](https://github.com/wehomemove/homedata-mcp) 🎖️ 🐍 ☁️ 🍎 🪟 🐧 - UK property data MCP from [Homedata](https://homedata.co.uk): 29M UK addresses, EPC ratings, flood risk, planning applications, comparables, demographics, schools, broadband, and more. 14 working tools, free tier. `pip install homedata-mcp`.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds Homedata's official MCP server to the Real Estate section.

**Server:** https://github.com/wehomemove/loki/tree/main/homedata-mcp
**PyPI:** https://pypi.org/project/homedata-mcp/
**Install:** `pip install homedata-mcp`
**Author:** Homedata (https://homedata.co.uk) — UK B2B property data API
**Tools:** 16 (property lookup, EPC, flood risk, planning, comparables, demographics, schools, broadband, transport, council tax band, address search, batch lookup, etc.)
**Free tier:** 100 calls/mo, no credit card

Released to PyPI today via OIDC trusted publishing. Open-source, MIT-licensed.

The entry follows the standard format used elsewhere in the list and is placed alphabetically within the Real Estate section.