### PR TITLE
Add vyre-web-search-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2626,3 +2626,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+- [vyre-web-search-mcp](https://github.com/ishan-parihar/vyre-web-search-mcp) - Web Search MCP Server — search the web and fetch pages via Model Context Protocol. Built with FastMCP.


### PR DESCRIPTION
Adding vyre-web-search-mcp.

Web Search MCP Server — search the web and fetch pages via Model Context Protocol. Built with FastMCP.

**Repository**: https://github.com/ishan-parihar/vyre-web-search-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*