### PR TITLE
Add second-brain-cloudflare MCP server entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,6 +1769,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [trackmage/trackmage-mcp-server](https://github.com/trackmage/trackmage-mcp-server) 📇 - Shipment tracking api and logistics management capabilities through the [TrackMage API] (https://trackmage.com/)
 - [geolabel/geolabel-mcp](https://github.com/geolabel/geolabel-mcp) [![geolabel-mcp MCP server](https://glama.ai/mcp/servers/geolabel/geolabel-mcp/badges/score.svg)](https://glama.ai/mcp/servers/geolabel/geolabel-mcp) 🐍 ☁️ - GPS coordinates to AI-ready location context — returns place name, stable category (gym, supermarket, restaurant…), and live opening hours via OpenStreetMap. Works in Claude Desktop, Claude Code, Hermes Agent, OpenClaw, and any MCP client.
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
+- [rahilp/second-brain-cloudflare](https://github.com/rahilp/second-brain-cloudflare) [![second-brain-cloudflare MCP server](https://glama.ai/mcp/servers/rahilp/second-brain-cloudflare/badges/score.svg)](https://glama.ai/mcp/servers/rahilp/second-brain-cloudflare) 📇 ☁️ - Persistent memory for any MCP-compatible AI tool. Store notes, recall context semantically, and maintain continuity across sessions. Built on Cloudflare Workers + Vectorize.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
Adds second-brain-cloudflare to the Knowledge & Memory section.

- Persistent memory MCP server built on Cloudflare Workers + Vectorize
- Supports semantic recall, chunking, deduplication, and append
- Listed on glama.ai