### PR TITLE
Add aitells-mcp to Marketing — AI text fingerprint detector + humanizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1774,6 +1774,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 
+- [Perufitlife/aitells-mcp](https://github.com/Perufitlife/aitells-mcp) 📇 ☁️ - Detect AI text fingerprints (em-dashes, "delve", parallel bullets, 9 more patterns) and humanize text in your voice. Free detector + $19 lifetime rewriter at [aitells.vercel.app](https://aitells.vercel.app).
 - [acamolese/google-search-console-mcp](https://github.com/acamolese/google-search-console-mcp) [![acamolese/google-search-console-mcp MCP server](https://glama.ai/mcp/servers/acamolese/google-search-console-mcp/badges/score.svg)](https://glama.ai/mcp/servers/acamolese/google-search-console-mcp) 🐍 ☁️ - Google Search Console MCP server: query performance data, inspect URLs, check indexing, and generate brandable HTML SEO audit reports with a 30/60/90-day roadmap. Read-only OAuth scope, installable via `uvx mcp-google-search-console`.
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
 - [alexey-pelykh/lhremote](https://github.com/alexey-pelykh/lhremote) 📇 🏠 - Open-source CLI and MCP server for LinkedHelper automation — 32 tools for campaign management, messaging, and profile queries via Chrome DevTools Protocol.


### PR DESCRIPTION
Adds [aitells-mcp](https://github.com/Perufitlife/aitells-mcp) to the Marketing section.

[![Perufitlife/aitells-mcp MCP server](https://glama.ai/mcp/servers/Perufitlife/aitells-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Perufitlife/aitells-mcp)

**What it does:** detects AI text fingerprints (em-dashes, "delve", parallel bullets, "navigate the X", 8 more patterns) and rewrites text matching user-provided writing samples. Two MCP tools: `detect_ai_tells` and `humanize_text`.

**Why Marketing:** target audience is content marketers, ghostwriters, and anyone shipping LinkedIn posts / cold emails / Reddit comments drafted with AI who get flagged.

- npm: [`@perufitlife/aitells-mcp`](https://www.npmjs.com/package/@perufitlife/aitells-mcp)
- Repo: [github.com/Perufitlife/aitells-mcp](https://github.com/Perufitlife/aitells-mcp)
- Web app: [aitells.vercel.app](https://aitells.vercel.app)

Detector is free forever, humanizer is $19 lifetime (first 100 buyers).

Built after my own Reddit account got 2 public "all comments AI generated" callouts in 24 hours. Story: [dev.to/perufitlife](https://dev.to/perufitlife/i-built-a-free-ai-tell-detector-after-my-own-reddit-account-got-2-all-comments-are-ai-generated-57ei).

---

Submitting to Glama now. Badge will resolve once their checks pass — repo is published on npm and has working `detect_ai_tells` + `humanize_text` tool surface tested with Claude Code, Cursor, and Cline.