### PR TITLE
Add Vitalini/ebb-ai to Environment & Nature 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,7 @@ Provides access to environmental data and nature-related tools, services and inf
 
 - [aliafsahnoudeh/wildfire-mcp-server](https://github.com/aliafsahnoudeh/wildfire-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server for detecting, monitoring, and analyzing potential wildfires globally using multiple data sources including NASA FIRMS, OpenWeatherMap, and Google Earth Engine.
 - [nalediym/touch-grass](https://github.com/nalediym/touch-grass) [![nalediym/touch-grass MCP server](https://glama.ai/mcp/servers/nalediym/touch-grass/badges/score.svg)](https://glama.ai/mcp/servers/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
+- [Vitalini/ebb-ai](https://github.com/Vitalini/ebb-ai) 📇 🐍 🏠 ☁️ 🍎 🪟 🐧 - Carbon-aware scheduling for agentic AI workflows. Defers non-urgent LLM tasks to the cleanest grid window inside a deadline. Per-task carbon receipts, Anthropic + OpenAI Batch APIs, durable SQLite queue. macOS launchd + Linux systemd cron + pmset/rtcwake so tasks survive laptop sleep.
 
 ### 📂 <a name="file-systems"></a>File Systems
 

--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,7 @@ Provides access to environmental data and nature-related tools, services and inf
 
 - [aliafsahnoudeh/wildfire-mcp-server](https://github.com/aliafsahnoudeh/wildfire-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server for detecting, monitoring, and analyzing potential wildfires globally using multiple data sources including NASA FIRMS, OpenWeatherMap, and Google Earth Engine.
 - [nalediym/touch-grass](https://github.com/nalediym/touch-grass) [![nalediym/touch-grass MCP server](https://glama.ai/mcp/servers/nalediym/touch-grass/badges/score.svg)](https://glama.ai/mcp/servers/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
-- [Vitalini/ebb-ai](https://github.com/Vitalini/ebb-ai) 📇 🐍 🏠 ☁️ 🍎 🪟 🐧 - Carbon-aware scheduling for agentic AI workflows. Defers non-urgent LLM tasks to the cleanest grid window inside a deadline. Per-task carbon receipts, Anthropic + OpenAI Batch APIs, durable SQLite queue. macOS launchd + Linux systemd cron + pmset/rtcwake so tasks survive laptop sleep.
+- [Vitalini/ebb-ai](https://github.com/Vitalini/ebb-ai) [![Vitalini/ebb-ai MCP server](https://glama.ai/mcp/servers/Vitalini/ebb-ai/badges/score.svg)](https://glama.ai/mcp/servers/Vitalini/ebb-ai) 📇 🐍 🏠 ☁️ 🍎 🪟 🐧 - Carbon-aware scheduling for agentic AI workflows. Defers non-urgent LLM tasks to the cleanest grid window inside a deadline. Per-task carbon receipts, Anthropic + OpenAI Batch APIs, durable SQLite queue. macOS launchd + Linux systemd cron + pmset/rtcwake so tasks survive laptop sleep.
 
 ### 📂 <a name="file-systems"></a>File Systems
 


### PR DESCRIPTION
## What

Adds [Vitalini/ebb-ai](https://github.com/Vitalini/ebb-ai) — an Apache-2.0 MCP server for carbon-aware scheduling of agentic AI workflows — to the **Environment & Nature** section.

## Why this section

ebb-ai is primarily an environmental tool: it exploits intra-day variation in electricity-grid carbon intensity (30–60% across US ISOs) to defer non-urgent LLM tasks to cleaner windows. Per-task carbon receipts are written to a SQLite ledger as an auditable climate-impact log. The carbon-awareness is the project's reason for existing.

Fits naturally alongside the wildfire-mcp-server and touch-grass entries already in this section.

## What it does

- Exposes 8 MCP tools: `get_grid_forecast`, `recommend_window`, `schedule_task`, `check_queue_status`, `cancel_task`, `expedite_task`, `update_deadline`, `retry_task`.
- 169 passing tests across TypeScript core (65), MCP server (8), CLI (21), Python port (75).
- Provider adapters: Anthropic + OpenAI, both sync and Batch API paths.
- Durable SQLite queue with row-level claim for concurrent tick safety.
- Cross-platform daemonization: macOS launchd + pmset wake, Linux systemd + rtcwake.
- 10 documented MCP-host integrations (Claude Desktop, Claude Code, Cursor, Cline, Continue, Zed, Windsurf, OpenClaw, OpenAI Codex CLI, Pi).

## Format

Followed the section's existing format. Alphabetical position: between `nalediym/touch-grass` and any future `V…` entry. Tags: 📇 TypeScript · 🐍 Python · 🏠 Local · ☁️ Cloud · 🍎 🪟 🐧 cross-OS.

## Notes

Live demo: https://ebb-ai.com
Repo: https://github.com/Vitalini/ebb-ai (Apache-2.0)
v0.5.0 tagged 2026-05-13.

🤖🤖🤖 (agent-assisted PR per CONTRIBUTING.md fast-track)