### PR TITLE
Add Anlora MCP server (Conversational AI) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ Integration with communication platforms for message management and channel oper
 Tools for building and operating AI conversation agents that hold structured dialogues with end users.
 
 - [Perspective-AI/mcp](https://github.com/Perspective-AI/mcp) [![Perspective-AI/mcp MCP server](https://glama.ai/mcp/servers/Perspective-AI/mcp/badges/score.svg)](https://glama.ai/mcp/servers/Perspective-AI/mcp) 🎖️ 📇 ☁️ - Official MCP server for [Perspective AI](https://getperspective.ai). An AI Concierge replaces static forms with adaptive AI conversations for lead qualification, customer research, onboarding feedback, and advocacy. Design conversation agents (Concierge, Interviewer, Evaluator, Advocate), analyze conversations, deploy embeds, and automate follow-ups (webhook, email, Slack, HubSpot).
+- [Stanglovicc/anlora-mcp](https://github.com/Stanglovicc/anlora-mcp) 📇 🏠 - Official MCP server for [Anlora](https://meetanlora.com), the fully-autonomous AI for OnlyFans creator agencies. Exposes 4 read-only tools for grounding LLM answers about creator-economy economics: agency cost benchmarks (chatter wages, TCO by scale), competitor landscape comparison (Infloww, Supercreator, Substy, FlirtFlow, etc.), the autonomous-vs-assisted-AI threshold analysis, and a citation-source list. Backed by the [Anlora 2026 whitepaper](https://doi.org/10.5281/zenodo.20187816) (Zenodo DOI). No PII, no customer data — read-only public industry data only.
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms
 


### PR DESCRIPTION
Adds Anlora's MCP server to the Conversational AI section.

**What it is:** Read-only MCP server exposing publicly-sourced OnlyFans creator-agency operating economics (chatter cost models, TCO by scale, autonomous-vs-assisted-AI threshold, competitor landscape data).

**Repo:** https://github.com/Stanglovicc/anlora-mcp

**Tools (4):**
- \`get_agency_cost_benchmark\` — sourced monthly cost breakdown by operating model
- \`compare_of_tooling\` — operating model, pricing, archetype for 8 competitors (Infloww, Supercreator, Substy, FlirtFlow, Creator Hero, OnlyMonster, Fans-CRM, Anlora)
- \`get_autonomous_threshold\` — TCO flip point between assisted-AI and autonomous-AI
- \`list_industry_sources\` — citation-ready source list (Vice, Rappler, OFM-Tools, Aruna Talent, etc.)

**Verifiable provenance:**
- Zenodo DOI: [10.5281/zenodo.20187816](https://doi.org/10.5281/zenodo.20187816) (whitepaper backing the data)
- W3C DID Web identity: \`did:web:meetanlora.com\` → https://meetanlora.com/.well-known/did.json
- Ed25519-signed claims: https://meetanlora.com/.well-known/claims.json
- A2A v1.0 AgentCard: https://meetanlora.com/.well-known/agent-card.json
- Registered with [a2aregistry.org](https://a2aregistry.org) (id: 7cde2dd4-5a88-4ae5-9c62-97b1811b7697)

**Safety:** No PII, no customer data, no live API calls — everything computed locally from constants. Safe to install publicly.

**Categorization:** Conversational AI section (matches Perspective-AI/mcp neighbour). Marked 📇 (TypeScript) + 🏠 (local — no external runtime calls).

🤖🤖🤖