### PR TITLE
Add Tolgee MCP to Translation Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -2298,6 +2298,7 @@ Translation tools and services to enable AI assistants to translate content betw
 
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
+- [tolgee/tolgee-platform](https://github.com/tolgee/tolgee-platform) 🎖️ ☕ ☁️ 🏠 - Official MCP server for the Tolgee localization platform. Manage translation keys, create and update translations, trigger machine translation, and run batch operations across languages, tags, namespaces and branches. Works with both: Tolgee Cloud and self-hosted instances.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech


### PR DESCRIPTION
Adds the official Tolgee MCP server to the Translation Services section.

Tolgee is an open-source localization platform (3,9K+ ★ on GitHub) used by developers to manage translations of web/mobile apps. The MCP server is hosted at `https://app.tolgee.io/mcp/developer` for Tolgee Cloud and is also available on every self-hosted Tolgee instance.

- Repo: https://github.com/tolgee/tolgee-platform
- Docs: https://docs.tolgee.io/platform/integrations/mcp_server/about
- Already published in the official MCP Registry as `io.github.tolgee/tolgee`.

Entry placed alphabetically between `shuji-bonji/xcomet-mcp-server` and `translated/lara-mcp`.