### PR TITLE
🤖🤖🤖 feat: add rankparse-mcp to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 
+- [abhibavishi/rankparse-mcp](https://github.com/abhibavishi/rankparse-mcp) 📇 ☁️ - SEO data MCP server with 18+ tools — backlinks, domain authority, tech stack, referring domains, link intersect, and competitor overlap. Powered by Common Crawl data, no subscription required.
 - [AdsMCP/tiktok-ads-mcp-server](https://github.com/AdsMCP/tiktok-ads-mcp-server) 🐍 ☁️ - A Model Context Protocol server for TikTok Ads API integration, enabling AI assistants to manage campaigns, analyze performance metrics, handle audiences and creatives with OAuth authentication flow.
 - [BlockRunAI/x-grow](https://github.com/BlockRunAI/x-grow) 📇 ☁️ - X/Twitter algorithm optimizer with post drafting, review scoring, and AI image generation for maximum engagement.
 - [gomarble-ai/facebook-ads-mcp-server](https://github.com/gomarble-ai/facebook-ads-mcp-server) 🐍 ☁️ - MCP server acting as an interface to the Facebook Ads, enabling programmatic access to Facebook Ads data and management features.


### PR DESCRIPTION
Adds [RankParse MCP](https://github.com/abhibavishi/rankparse-mcp) to the Marketing section.

**What it is:** An MCP server exposing 18+ SEO tools — backlinks, domain authority, tech stack, referring domains, link intersect, and competitor overlap. Powered by pre-processed Common Crawl data.

**MCP server:** `https://mcp.rankparse.com/mcp`
**Docs:** https://rankparse.com/docs/mcp

- Language: TypeScript (Cloudflare Workers)
- Transport: Streamable HTTP + SSE
- Auth: API key (100 free credits on signup, no subscription)