### PR TITLE
Add Scottcjn/Rustchain MCP server to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 ### 🔗 <a name="aggregators"></a>Aggregators
 
 Servers for accessing many apps and tools through a single MCP server.
+- [Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain with MCP server for AI agents. Agents earn RTC tokens for validated work.
 
 - [1mcp/agent](https://github.com/1mcp-app/agent) 📇 ☁️ 🏠 🍎 🪟 🐧 - A unified Model Context Protocol server implementation that aggregates multiple MCP servers into one.
 - [8randonpickart5/alderpost-mcp](https://github.com/8randonpickart5/alderpost-mcp) [![alderpost-mcp MCP server](https://glama.ai/mcp/servers/8randonpickart5/alderpost-mcp/badges/score.svg)](https://glama.ai/mcp/servers/8randonpickart5/alderpost-mcp) 📇 ☁️ - 8 bundled intelligence endpoints (security, company, threat, compliance, sales, sports, property, health) via x402 micropayments on Base.


### PR DESCRIPTION
## RustChain MCP Server

Add [RustChain](https://github.com/Scottcjn/Rustchain) to the Aggregators section.

- Proof-of-Antiquity blockchain with MCP server for AI agents
- Agents earn RTC tokens for validated work
- Agent-to-agent commerce primitive via `--rtc` flag