### PR TITLE
Add Sariea (Saudi Arabia services marketplace) to E-Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -2604,6 +2604,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
 
 ## Tips and Tricks
+- [sovanza-inc/sariea](https://github.com/sovanza-inc/sariea-monorepo/tree/main/mcp_server) 📇 ☁️ 🍎 🪟 🐧 - Browse, register, and book home & professional services on **Sariea** — Saudi Arabia's on-demand services marketplace. Remote MCP at `https://mcp.sariea.com/mcp` (OAuth via phone OTP). 8 tools covering the catalog, bidding-request lifecycle (create, view bids, accept), and order history.
 
 ### Official prompt to inform LLMs how to use MCP
 

--- a/README.md
+++ b/README.md
@@ -2604,7 +2604,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
 
 ## Tips and Tricks
-- [sovanza-inc/sariea](https://github.com/sovanza-inc/sariea-monorepo/tree/main/mcp_server) 📇 ☁️ 🍎 🪟 🐧 - Browse, register, and book home & professional services on **Sariea** — Saudi Arabia's on-demand services marketplace. Remote MCP at `https://mcp.sariea.com/mcp` (OAuth via phone OTP). 8 tools covering the catalog, bidding-request lifecycle (create, view bids, accept), and order history.
+- [sovanza-inc/sariea](https://github.com/sovanza-inc/sariea-monorepo/tree/main/mcp_server) [![sovanza-inc/sariea-monorepo MCP server](https://glama.ai/mcp/servers/sovanza-inc/sariea-monorepo/badges/score.svg)](https://glama.ai/mcp/servers/sovanza-inc/sariea-monorepo) 📇 ☁️ 🍎 🪟 🐧 - Browse, register, and book home & professional services on **Sariea** — Saudi Arabia's on-demand services marketplace. Remote MCP at `https://mcp.sariea.com/mcp` (OAuth via phone OTP). 8 tools covering the catalog, bidding-request lifecycle (create, view bids, accept), and order history.
 
 ### Official prompt to inform LLMs how to use MCP
 

--- a/README.md
+++ b/README.md
@@ -2604,7 +2604,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
 
 ## Tips and Tricks
-- [sovanza-inc/sariea](https://github.com/sovanza-inc/sariea-monorepo/tree/main/mcp_server) [![sovanza-inc/sariea-monorepo MCP server](https://glama.ai/mcp/servers/sovanza-inc/sariea-monorepo/badges/score.svg)](https://glama.ai/mcp/servers/sovanza-inc/sariea-monorepo) 📇 ☁️ 🍎 🪟 🐧 - Browse, register, and book home & professional services on **Sariea** — Saudi Arabia's on-demand services marketplace. Remote MCP at `https://mcp.sariea.com/mcp` (OAuth via phone OTP). 8 tools covering the catalog, bidding-request lifecycle (create, view bids, accept), and order history.
+- [sovanza-inc/sariea-mcp](https://github.com/sovanza-inc/sariea-mcp) [![sovanza-inc/sariea-mcp MCP server](https://glama.ai/mcp/servers/sovanza-inc/sariea-mcp/badges/score.svg)](https://glama.ai/mcp/servers/sovanza-inc/sariea-mcp) 📇 ☁️ 🍎 🪟 🐧 - Browse, register, and book home & professional services on **Sariea** — Saudi Arabia's on-demand services marketplace. Remote MCP at `https://mcp.sariea.com/mcp` (OAuth via phone OTP). 8 tools covering the catalog, bidding-request lifecycle (create, view bids, accept), and order history.
 
 ### Official prompt to inform LLMs how to use MCP
 


### PR DESCRIPTION
Adds an E-Commerce entry for **Sariea**, the on-demand home & professional services marketplace in Saudi Arabia.

- **Public repo**: https://github.com/sovanza-inc/sariea-mcp
- **Remote MCP URL**: https://mcp.sariea.com/mcp
- **Transport**: Streamable HTTP (Web Standard)
- **Auth**: OAuth 2.0 + PKCE wrapping Sariea's existing phone-OTP login
- **Tools (8)**: `get_my_profile`, `list_categories`, `list_subcategories`, `create_booking_request`, `list_my_requests`, `view_bids`, `accept_bid`, `list_my_orders`
- **Discovery**: https://mcp.sariea.com/.well-known/oauth-authorization-server
- **Glama badge**: pre-wired at `glama.ai/mcp/servers/sovanza-inc/sariea-mcp` — registering on Glama next.