### PR TITLE
Add proompteng/bilig WorkPaper MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2626,3 +2626,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+- [io.github.proompteng/bilig-workpaper](https://github.com/proompteng/bilig) - WorkPaper MCP tools, resources, and prompts for readback, edits, and JSON persistence.

--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [BrainGrid MCP](https://docs.braingrid.ai/mcp-server/installation) 🎖️☁️ - [BrainGrid](https://braingrid.ai) MCP is the Product Management Agent that writes your specs, plans your features, and creates engineering-grade tasks your coding tools can build reliably.
 - [BrunoKrugel/echo-mcp](https://github.com/BrunoKrugel/echo-mcp) 🏎️ ☁️ 📟 🪟 🐧 🍎 - A zero-configuration Go library to automatically expose any existing Echo web framework APIs as MCP tools.
 - [buildkite/buildkite-mcp-server](https://github.com/buildkite/buildkite-mcp-server) 🎖️ 🏎️ 🏠 ☁️ 🍎 🪟 🐧 - Official MCP server for Buildkite. Create new pipelines, diagnose and fix failures, trigger builds, monitor job queues, and more.
+- [proompteng/bilig](https://github.com/proompteng/bilig) 📇 🏠 🍎 🪟 🐧 - Bilig WorkPaper MCP lets agents edit formula-backed workbook JSON, recalculate cells, read display values, and persist reviewable state for backend workflows.
 - [cerebrixos-org/tuning-engines-cli](https://github.com/cerebrixos-org/tuning-engines-cli) [![cerebrixos-org/tuning-engines-cli MCP server](https://glama.ai/mcp/servers/cerebrixos-org/tuning-engines-cli/badges/score.svg)](https://glama.ai/mcp/servers/cerebrixos-org/tuning-engines-cli) 📇 ☁️ 🍎 🪟 🐧 - Domain-specific fine-tuning of open-source LLMs and SLMs with zero infrastructure. Specialized tuning agents deliver sovereign models trained on your data. Supports Qwen, Llama, DeepSeek, Mistral, Gemma 1B-72B. LoRA, QLoRA, full fine-tuning. Cost estimation, model management, S3 export.
 - [Chunkydotdev/bldbl-mcp](https://github.com/chunkydotdev/bldbl-mcp) 📇 ☁️ 🍎 🪟 🐧 - Official MCP server for Buildable AI-powered development platform [bldbl.dev](https://bldbl.dev). Enables AI assistants to manage tasks, track progress, get project context, and collaborate with humans on software projects.
 - [CircleCI/mcp-server-circleci](https://github.com/CircleCI-Public/mcp-server-circleci) 📇 ☁️ Enable AI Agents to fix build failures from CircleCI.
@@ -2626,4 +2627,3 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
-- [io.github.proompteng/bilig-workpaper](https://github.com/proompteng/bilig) - WorkPaper MCP tools, resources, and prompts for readback, edits, and JSON persistence.


### PR DESCRIPTION
Adds Bilig WorkPaper MCP under Developer Tools.

Bilig lets agents edit formula-backed workbook JSON, recalculate cells, read display values, and persist reviewable state for backend workflows.

Repository: https://github.com/proompteng/bilig
Package: @bilig/headless
Docs: https://proompteng.github.io/bilig/mcp-client-setup.html

Submitted via mcp-submit, then manually corrected for category placement and description.