### PR TITLE
Add DocJacket to Real Estate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [DocJacket-LLC/claude-plugin](https://github.com/DocJacket-LLC/claude-plugin) #️⃣ ☁️ - Real-estate transaction coordination MCP. Read transactions, key dates, contingencies, missing documents, and contacts from any MCP client. Hosted at `https://mcp.docjacket.com/mcp` with OAuth 2.1 + DCR — paste-URL-and-go from Claude, ChatGPT, Codex, or Gemini.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds DocJacket to the Real Estate section.

**What it is:** Real-estate transaction coordination MCP server. Read transactions, key dates, contingencies, missing documents, and contacts from any MCP client (Claude, ChatGPT, Codex, Gemini).

**Legends used:** `#️⃣` (C# / .NET 9 codebase) · `☁️` (Cloud Service — hosted SaaS, no local install)

- Endpoint: https://mcp.docjacket.com/mcp
- Auth: OAuth 2.1 + PKCE + DCR
- Homepage: https://docjacket.com/ai-access
- Repo: https://github.com/DocJacket-LLC/claude-plugin

Slotted after the existing `ashev87/propstack-mcp` entry. 10 read tools shipped in v0.9.