### PR TITLE
Add YallaCalculators MCP under Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,6 +1505,8 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [toolstem/toolstem-sec-mcp-server](https://github.com/toolstem/toolstem-sec-mcp-server) 📇 ☁️ – SEC EDGAR signal intelligence for AI agents — insider trading (Form 4), 13F institutional holdings, 10-K/8-K filing velocity, activist risk flags, and multi-company disclosure comparisons. Three pricing tiers. Available on the Apify Store.
 - [pickelfintech/the13f-mcp](https://github.com/pickelfintech/the13f-mcp) [![pickelfintech/the13f-mcp MCP server](https://glama.ai/mcp/servers/pickelfintech/the13f-mcp/badges/score.svg)](https://glama.ai/mcp/servers/pickelfintech/the13f-mcp) 🐍 ☁️ - Institutional 13F intelligence for Claude Desktop, Cursor, and VS Code. Nine Read tools: manager search, holdings lookup, portfolio similarity, consensus portfolio, market regime, sector flows. SEC EDGAR-sourced. Install `uvx the13f-mcp`.
 
+- [varunp316/yalla-calculators](https://github.com/varunp316/yalla-calculators) 📇 ☁️ - UAE financial calculators for AI agents — 5 tools (rent vs buy, mortgage affordability under UAE Central Bank Circular 31/2013, end-of-service gratuity per Federal Decree-Law 33/2021, property closing fees per emirate, credit card stack optimizer across 280+ UAE cards). Streamable HTTP at https://www.yallacalculators.online/api/mcp. Math verified against UAE Central Bank, MOHRE, RERA, DLD primary sources; re-audited monthly. Read-only, stateless, no auth.
+
 ### 🎮 <a name="gaming"></a>Gaming
 
 Integration with gaming related data, game engines, and services


### PR DESCRIPTION
## What this adds

A new entry under `### 💰 Finance & Fintech` for [YallaCalculators MCP](https://github.com/varunp316/yalla-calculators) — a remote MCP server exposing 5 UAE-specific financial calculators as callable tools for any MCP-compatible AI client.

## Why it's worth listing

- **Genuinely new niche** — every other Finance & Fintech entry is US/EU equities (Yahoo Finance, SEC EDGAR, 13F, Plaid), DeFi (Uniswap, Aerodrome), or crypto pricing. None cover UAE-specific personal-finance math (mortgage affordability under UAE Central Bank Circular 31/2013, end-of-service gratuity per Federal Decree-Law 33/2021, property closing fees per emirate, RERA rent-tier rules). YC fills a real gap for the 200M+ UAE residents + expat audience.
- **Streamable HTTP, no install friction** — single URL paste into any MCP client config. No npm install, no auth, no API key.
- **Read-only and stateless** — zero PII risk; inputs are numeric (salary, prices, years). Function logs aggregate-only with 30-day Vercel retention.
- **Math verified against primary UAE government sources** (UAE Central Bank, MOHRE, RERA, DLD) and re-audited monthly via a documented automation cycle. Not a thin LLM wrapper.

## The 5 tools

| Tool | What it does |
|---|---|
| `rent_vs_buy` | Wealth-gap projection over user's horizon — DLD fees + mortgage amortization + RERA rent inflation + S&P 500 alternate-investment return |
| `mortgage_affordability` | Max property under UAE CB Circular 31/2013 — DBR ≤50% + LTV bands (80% expat / 85% national first home; 50% off-plan) |
| `gratuity_calculator` | UAE end-of-service per Federal Decree-Law 33/2021 (21 days/yr first 5, 30 days/yr after) |
| `property_fees_calculator` | Itemized closing costs per emirate (DLD 4% Dubai / 2% other + agency + bank fees) |
| `card_stack_optimizer` | Optimal 1-5 card stack across 280+ UAE cards given spend profile + salary |

## Install

```json
{
  "mcpServers": {
    "yallacalculators": {
      "type": "http",
      "url": "https://www.yallacalculators.online/api/mcp"
    }
  }
}
```

Documentation: <https://www.yallacalculators.online/mcp>

## Strategic context

This is Wave 35-mcp-foundation of YallaCalculators' AEO/SEO/GEO program. The thesis: rather than play the AI-citation game (volatile, retuned monthly by engine vendors), be invoked **directly** as a tool inside the AI session. Citation rate fluctuates; install count compounds.

Happy to address feedback on the listing format. Thanks for maintaining this list!