### PR TITLE
Add operator.fyi MCP under Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1815,6 +1815,8 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [ZLeventer/salesforce-marketing-mcp](https://github.com/ZLeventer/salesforce-marketing-mcp) [![salesforce-marketing-mcp MCP server](https://glama.ai/mcp/servers/ZLeventer/salesforce-marketing-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ZLeventer/salesforce-marketing-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Salesforce MCP server built for marketing and revenue ops teams. 47 tools for leads, contacts, accounts, campaigns, campaign members, tasks, and 17 reporting tools including campaign ROI, lead-source attribution, pipeline-by-campaign, multi-touch campaign influence, MQL trend, forecast summary, and the native SFDC Reports API.
 - [andrealufino/aapl-ads-mcp](https://github.com/andrealufino/aapl-ads-mcp) [![andrealufino/aapl-ads-mcp MCP server](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp/badges/score.svg)](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp) 📇 - 
 
+- [operator-fyi/operator](https://operator.fyi/mcp-endpoints/) 📇 ☁️ - Local-business intelligence MCP. Per-business endpoints at `/mcp/biz/<slug>/` expose a brain manifest (connected systems, brain score, missing-coverage gaps) + tools: `scan_business`, `search_businesses`, `get_business_valuation`, `find_similar_businesses`. Built on the operator.fyi substrate of ~29M local businesses across ~31K cities.
+
 ### 📊 <a name="monitoring"></a>Monitoring
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.


### PR DESCRIPTION
Adding operator.fyi to the **Marketing** section. Local-business intelligence MCP with per-business manifest endpoints + tools.

### Server details
- **URL pattern:** `https://operator.fyi/mcp/biz/<slug>/` returns a per-business JSON manifest (connected systems, brain score, missing-coverage gaps) and the tools list.
- **Tools:**
  - `scan_business` — fresh brain scan for any business URL; returns connected-systems map, brain score, and missing-coverage gaps
  - `search_businesses` — substrate search across ~29M local businesses / ~31K cities
  - `get_business_valuation` — vertical-aware ARR + multiples
  - `find_similar_businesses` — top-K neighbors by brain features

### Example
`curl https://operator.fyi/mcp/biz/operator-fyi/` returns the manifest.

### Why Marketing
Operator's primary use cases are local marketing intelligence — competitive analysis, GBP/review monitoring, market-rank tracking, niche substrate insights — for AI agents serving small/local-business operators.

Hosted service (no installable package); icons reflect that: 📇 ☁️.

Happy to revise the entry's wording or category placement if the maintainers prefer.