### PR TITLE
Add polymatx/weave under Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2602,6 +2602,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [vinkius-labs/mcp-fusion](https://github.com/vinkius-labs/mcp-fusion) 📇 [![Glama](https://glama.ai/mcp/servers/badge/@vinkius-labs/mcp-fusion)](https://glama.ai/mcp/servers/@vinkius-labs/mcp-fusion) - A TypeScript framework for building production-ready MCP servers with automatic tool discovery, multi-transport support (stdio/SSE/HTTP), built-in validation, and zero-config setup.
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 - [rocketride-org/rocketride-server](https://github.com/rocketride-org/rocketride-server) [![rocketride-org/rocketride-server MCP server](https://glama.ai/mcp/servers/rocketride-org/rocketride-server/badges/score.svg)](https://glama.ai/mcp/servers/rocketride-org/rocketride-server) 📇 🏠 - MCP server that exposes RocketRide AI pipelines as tools for Claude, Cursor, and Windsurf. Self-hosted, open-source pipeline tool with multi-LLM support.
+- [polymatx/weave](https://github.com/polymatx/weave) 📇 🏠 - TypeScript-native multi-agent orchestrator that consumes MCP servers as first-class tools. Type-safe graph state, SQLite checkpoints, USD budget guardrails, streaming, and a local trace UI bundled in.
 
 ## Tips and Tricks
 


### PR DESCRIPTION
## What

Adds an entry for [polymatx/weave](https://github.com/polymatx/weave) under the **Frameworks** section.

> Note: this is a re-submission of [#6613](https://github.com/punkpeye/awesome-mcp-servers/pull/6613), which auto-closed when the source fork was deleted. Same entry, same context.

## Why this fits

`weave` is a TypeScript-native multi-agent orchestration framework that treats MCP servers as a first-class tool source. It uses `@modelcontextprotocol/sdk` to connect any MCP server (stdio or SSE) and exposes its tools directly to agents — there is no separate adapter layer. The Frameworks section already includes several agent frameworks of similar character (`FastMCP`, `TurboMCP`, `praisonai-mcp`, `gomcp`).

Highlights:

- `connectMcpServers({...})` returns a tools object that plugs directly into an agent definition
- Each MCP tool's input schema is auto-converted from JSON Schema to Zod for AI SDK strict typing
- Graph runtime with type-safe state, conditional edges, and SQLite checkpoints
- USD budget enforcement (kill-switch on overrun)
- Local trace UI bundled in the repo (no SaaS dependency)
- Published on npm: [\`@polymatx/weave\`](https://www.npmjs.com/package/@polymatx/weave), [\`@polymatx/weave-mcp\`](https://www.npmjs.com/package/@polymatx/weave-mcp), [\`@polymatx/weave-ui\`](https://www.npmjs.com/package/@polymatx/weave-ui)

## On the \`missing-glama\` label

Weave is a framework that *consumes* MCP servers — not an MCP server itself — so a Glama listing doesn't quite fit. Other Framework entries in this list (`FastMCP`, `TurboMCP`, `gomcp`, `praisonai-mcp`) similarly don't carry a Glama badge. Happy to add one if frameworks are also expected to be listed; let me know.

## Format check

- [x] Entry follows the established format: \` - [user/repo](url) <emoji> <emoji> - description.\`
- [x] Emoji legend: 📇 TypeScript, 🏠 Local Service
- [x] Description is one sentence
- [x] Placed at the end of the Frameworks list