### PR TITLE
Add Air Jam MCP server to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1548,6 +1548,7 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
+- [vucinatim/air-jam](https://github.com/vucinatim/air-jam) 🎖️ 📇 🏠 - Official MCP server for [Air Jam](https://airjam.io), an open-source framework for QR-code phone-controller multiplayer party games. Tools for project inspection, dev/build logs, quality gates, screenshot capture, and publishing games to the arcade. Designed for AI-assisted game development (Claude Code, Cursor, etc.).
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
## What this adds

[Air Jam](https://airjam.io) is an open-source framework for building QR-code phone-controller multiplayer party games (think AirConsole, but open). The repo ships an official MCP server (`@air-jam/mcp-server`) that lets AI assistants like Claude Code and Cursor drive the whole game-development loop: project inspection, dev/build log reading, quality gates, screenshot capture, and publishing games to the live arcade.

## Entry

Added under **Gaming**:

\`\`\`
- [vucinatim/air-jam](https://github.com/vucinatim/air-jam) 🎖️ 📇 🏠 - Official MCP server for [Air Jam](https://airjam.io), an open-source framework for QR-code phone-controller multiplayer party games. Tools for project inspection, dev/build logs, quality gates, screenshot capture, and publishing games to the arcade. Designed for AI-assisted game development (Claude Code, Cursor, etc.).
\`\`\`

Flags:
- 🎖️ official implementation (maintained by the Air Jam project)
- 📇 TypeScript codebase
- 🏠 local service (runs alongside local game dev)

## Why this fits

The MCP server is purpose-built for AI-driven game development workflows — the same use case the list highlights with other game-engine integrations (Godot, Unity, Pyxel). It's published on npm as \`@air-jam/mcp-server\`, MIT-licensed, and actively maintained.

Happy to adjust the entry format / placement / flags if you'd like.