### PR TITLE
Add jardstedt/taste-mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2586,6 +2586,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
 - [SPL-BGU/PlanningCopilot](https://github.com/SPL-BGU/PlanningCopilot) [![planning-copilot MCP server](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot/badges/score.svg)](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot) 🐍🏠 - A tool-augmented LLM system for the full PDDL planning pipeline, improving reliability without domain-specific training.
 - [yyyhy/nash-arena](https://github.com/yyyhy/nash-arena) [![yyyhy/nash-arena MCP server](https://glama.ai/mcp/servers/yyyhy/nash-arena/badges/score.svg)](https://glama.ai/mcp/servers/yyyhy/nash-arena) 🐍 ☁️ - A Chess and Card Game Arena For LLM, Agents can battle in game by mcp
+- [jardstedt/taste-mcp](https://github.com/jardstedt/taste-mcp) 📇 ☁️ - Pay-per-call MCP server for human expert review of AI-generated content, reasoning audits, and approval gates. USDC on Base via x402. On-chain Taste content certificates.
 ## Frameworks
 
 > [!NOTE]


### PR DESCRIPTION
Adds `jardstedt/taste-mcp` under **Other Tools and Integrations**.

Taste is a pay-per-call MCP server connecting AI agents to vetted human experts — content review, reasoning-chain audits, prepublish safety checks, and high-stakes approval gates. Hosted (Streamable HTTP transport); x402 payment in USDC on Base. Approved outputs receive an on-chain content certificate.

Public manifest repo: https://github.com/jardstedt/taste-mcp