### PR TITLE
Add DealFlowPro MCP server to Real Estate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1924,6 +1924,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [jbechtel-97/dealflowpro-mcp-server](https://github.com/jbechtel-97/dealflowpro-mcp-server) 📇 ☁️ - Multifamily real estate deal analysis — cap rate, DSCR, cash-on-cash, IRR, DFP Score (0-100), max offer price, and market intelligence for 2-200 unit properties. 4 tools: analyze, score, reverse-calc, market data.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [DealFlowPro MCP Server](https://github.com/jbechtel-97/dealflowpro-mcp-server) to the Real Estate section.

**What it does:** Multifamily real estate deal analysis — 4 tools for analyzing 2-200 unit apartment properties:
- `analyze_deal` — full underwriting: cap rate, DSCR, cash-on-cash, IRR, DFP Score (0-100), max offer price
- `score_deal` — quick screening score + verdict
- `reverse_calc` — back-solve max offer price from target returns
- `market_data` — flood zone, neighborhood income, job growth

**Install:** `npx -y dealflowpro-mcp` ([npm](https://www.npmjs.com/package/dealflowpro-mcp))

**Why it belongs here:** First real estate underwriting tool in the MCP ecosystem. Fills a gap — no existing MCP server does financial analysis for multifamily investment properties.