### PR TITLE
Add freebian/tideturtle to Environment & Nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,7 @@ Provides access to environmental data and nature-related tools, services and inf
 
 - [aliafsahnoudeh/wildfire-mcp-server](https://github.com/aliafsahnoudeh/wildfire-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - MCP server for detecting, monitoring, and analyzing potential wildfires globally using multiple data sources including NASA FIRMS, OpenWeatherMap, and Google Earth Engine.
 - [nalediym/touch-grass](https://github.com/nalediym/touch-grass) [![nalediym/touch-grass MCP server](https://glama.ai/mcp/servers/nalediym/touch-grass/badges/score.svg)](https://glama.ai/mcp/servers/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
+- [freebian/tideturtle](https://tideturtle.com/mcp) ☁️ 📇 - Free tide times + charts for 1,414 coastal places worldwide. Tools: `list_places`, `get_place`, `tides_nearby`. Predictions from NOAA, UK EA Flood, BSH, Open-Meteo Marine. No API key, CORS-open, MCP server hosted on Cloudflare Workers.
 
 ### 📂 <a name="file-systems"></a>File Systems
 


### PR DESCRIPTION
Adds **TideTurtle** to the Environment & Nature section.

- **Repo / URL:** https://github.com/freebian/tideturtle · https://tideturtle.com/mcp
- **What it does:** Free tide times + tide charts for 1,414 coastal places worldwide. MCP server with three tools: `list_places`, `get_place`, `tides_nearby`.
- **Hosted:** Cloudflare Workers (☁️ + 📇)
- **Auth:** none — no API key, no signup, CORS-open
- **Data sources:** NOAA CO-OPS, UK Environment Agency Flood, BSH (Germany), Open-Meteo Marine. Per-source accuracy at https://tideturtle.com/methodology
- **Docs / curl examples:** https://tideturtle.com/developers
- **OpenAPI 3 spec:** https://tideturtle.com/api/v1/openapi.json

Entry inserted alphabetically after `nalediym/touch-grass` in the existing Environment & Nature section.