### PR TITLE
Add yatabase — managed Graph DB BaaS with native MCP endpoint 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [XGenerationLab/xiyan_mcp_server](https://github.com/XGenerationLab/xiyan_mcp_server) 📇 ☁️ — An MCP server that supports fetching data from a database using natural language queries, powered by XiyanSQL as the text-to-SQL LLM.
 - [xing5/mcp-google-sheets](https://github.com/xing5/mcp-google-sheets) 🐍 ☁️ - A Model Context Protocol server for interacting with Google Sheets. This server provides tools to create, read, update, and manage spreadsheets through the Google Sheets API.
 - [yannbrrd/simple_snowflake_mcp](https://github.com/YannBrrd/simple_snowflake_mcp) 🐍 ☁️ - Simple Snowflake MCP server that works behind a corporate proxy. Read and write (optional) operations
+- [yatabase.gftd.ai](https://yatabase.gftd.ai) ☁️ 📇 - Managed Graph DB BaaS with a built-in `/mcp` endpoint. Query with Cypher, SPARQL, or SQL in one engine; AT Protocol DID-native auth, zero-knowledge E2E encryption (AES-256-GCM, client-side), and OWL EL/RL/QL reasoning. From ¥4,980/mo.
 - [ydb/ydb-mcp](https://github.com/ydb-platform/ydb-mcp) 🎖️ 🐍 ☁️ - MCP server for interacting with [YDB](https://ydb.tech) databases
 - [yincongcyincong/VictoriaMetrics-mcp-server](https://github.com/yincongcyincong/VictoriaMetrics-mcp-server) 🐍 🏠 - An MCP server for interacting with VictoriaMetrics database.
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.


### PR DESCRIPTION
## Summary

Adds **yatabase.gftd.ai** to the Databases section.

yatabase is a managed Graph DB BaaS with a built-in `/mcp` endpoint:
- **3 query languages in one engine**: Cypher (openCypher), SPARQL 1.1, PostgreSQL wire
- **MCP-native**: `/mcp` endpoint works out of the box with any MCP client
- **Zero-knowledge E2E encryption**: AES-256-GCM client-side (PBKDF2 + Web Crypto), server never sees plaintext
- **AT Protocol DID-based auth**: portable identity, no vendor lock-in
- **OWL EL/RL/QL reasoning** built-in
- **Backblaze B2 egress $0** (BWA partner)
- From ¥4,980/mo (~$33 USD)

Positioned alphabetically between `yannbrrd/simple_snowflake_mcp` and `ydb/ydb-mcp`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)