### PR TITLE
Add OTTASIA MCP server (streaming availability across 30 Asian/MENA markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1954,7 +1954,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.
 
 ### 🔎 <a name="search"></a>Search & Data Extraction
-
+- [AIweather-Anurag/ottasia](https://github.com/AIweather-Anurag/ottasia) 📇 ☁️ 🏠 - Where to watch any movie or TV show across 30 Asian and Middle Eastern streaming markets (Netflix, Disney+ Hotstar, Wavve, Shahid, Hoichoi, ZEE5, JioCinema, and 17 more). `npx -y @ottasia/mcp-server`
 - [mrslbt/rippr](https://github.com/mrslbt/rippr) [![mrslbt/rippr MCP server](https://glama.ai/mcp/servers/mrslbt/rippr/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/rippr) 📇 🏠 - YouTube transcript extraction for AI agents. Clean text, timestamps, or structured JSON from any video. No API keys required. Install via `npx rippr-mcp`.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.

--- a/README.md
+++ b/README.md
@@ -1954,7 +1954,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.
 
 ### 🔎 <a name="search"></a>Search & Data Extraction
-- [AIweather-Anurag/ottasia](https://github.com/AIweather-Anurag/ottasia) 📇 ☁️ 🏠 - Where to watch any movie or TV show across 30 Asian and Middle Eastern streaming markets (Netflix, Disney+ Hotstar, Wavve, Shahid, Hoichoi, ZEE5, JioCinema, and 17 more). `npx -y @ottasia/mcp-server`
+- [AIweather-Anurag/ottasia-mcp-server](https://github.com/AIweather-Anurag/ottasia-mcp-server) 📇 ☁️ 🏠 - Where to watch any movie or TV show across 30 Asian and Middle Eastern streaming markets (Netflix, Disney+ Hotstar, Wavve, Shahid, Hoichoi, ZEE5, JioCinema, and 17 more). `npx -y @ottasia/mcp-server`
 - [mrslbt/rippr](https://github.com/mrslbt/rippr) [![mrslbt/rippr MCP server](https://glama.ai/mcp/servers/mrslbt/rippr/badges/score.svg)](https://glama.ai/mcp/servers/mrslbt/rippr) 📇 🏠 - YouTube transcript extraction for AI agents. Clean text, timestamps, or structured JSON from any video. No API keys required. Install via `npx rippr-mcp`.
 - [0xdaef0f/job-searchoor](https://github.com/0xDAEF0F/job-searchoor) 📇 🏠 - An MCP server for searching job listings with filters for date, keywords, remote work options, and more.
 - [hanselhansel/aeo-cli](https://github.com/hanselhansel/aeo-cli) 🐍 🏠 - Audit URLs for AI crawler readiness — checks robots.txt, llms.txt, JSON-LD schema, and content density with 0-100 AEO scoring.


### PR DESCRIPTION
Adds OTTASIA MCP server under "Search & Data Extraction".

**What it does**: Answers "where can I watch X in Y" in Claude Desktop for 30 Asian and Middle Eastern streaming markets.

**Three tools**:
- `where_to_watch(title, country)` — specific title + country
- `whats_new_on(provider, country)` — latest arrivals on Netflix / Disney+ Hotstar / Wavve / Shahid / Hoichoi / 19 more
- `search_titles(q, country)` — multi-result lookup

**Install**: `npx -y @ottasia/mcp-server` (zero credentials needed for end users)

**Links**:
- npm: https://www.npmjs.com/package/@ottasia/mcp-server
- Source: https://github.com/AIweather-Anurag/ottasia (mcp/ subfolder)
- Official MCP Registry: io.github.AIweather-Anurag/ottasia
- Website: https://ottasia.com
- License: MIT