### PR TITLE
Add GoveBid MCP server (government tender intelligence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2097,6 +2097,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [zoharbabin/google-researcher-mcp](https://github.com/zoharbabin/google-researcher-mcp) [![google-researcher-mcp MCP server](https://glama.ai/mcp/servers/@zoharbabin/google-researcher-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@zoharbabin/google-researcher-mcp) 📇 ☁️ 🏠 - Comprehensive research tools including Google Search (web, news, images), web scraping with JavaScript rendering, academic paper search (arXiv, PubMed, IEEE), patent search, and YouTube transcript extraction.
 - [zlatkoc/youtube-summarize](https://github.com/zlatkoc/youtube-summarize) 🐍 ☁️ - MCP server that fetches YouTube video transcripts and optionally summarizes them. Supports multiple transcript formats (text, JSON, SRT, WebVTT), multi-language retrieval, and flexible YouTube URL parsing.
 - [zoomeye-ai/mcp_zoomeye](https://github.com/zoomeye-ai/mcp_zoomeye) 📇 ☁️ - Querying network asset information by ZoomEye MCP Server
+- [GoveBid/mcp](https://govebid.com/api/v1/mcp) 🐍 ☁️ - Government tender intelligence — search procurement opportunities from SAM.gov, TED Europa, UNGM, World Bank, AfDB, and USA Spending. Filter by source, country, category, keyword, value range, and deadline. Free tier 100 calls/month, no signup required for trial keys at [govebid.com](https://govebid.com).
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds **GoveBid** to the Search & Data Extraction section.

**What it does:** Aggregates live government procurement opportunities from 6 official sources: SAM.gov (US federal), TED Europa (EU), UNGM (UN), World Bank, AfDB, and USA Spending. Exposes a single MCP endpoint at `https://govebid.com/api/v1/mcp` for AI agents to search tenders by source, country, category, keyword, value range, and deadline.

**Why MCP:** Lets agents (Claude, Cursor, etc.) discover live RFPs and bidding opportunities without bespoke scrapers per portal.

**Tier:** Free (100 calls/month), no signup for trial keys.

**Docs:** https://govebid.com/api/v1/docs
**OpenAPI:** https://govebid.com/api/v1/openapi.json
**MCP endpoint:** https://govebid.com/api/v1/mcp