### PR TITLE
Add MCPSense: MCP server security scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Run commands, capture output and otherwise interact with shells and command line
 - [ferodrigop/forge](https://github.com/ferodrigop/forge) [![forge MCP server](https://glama.ai/mcp/servers/ferodrigop/forge/badges/score.svg)](https://glama.ai/mcp/servers/ferodrigop/forge) 📇 🏠 - Terminal MCP server for AI coding agents with persistent PTY sessions, ring-buffer incremental reads, headless xterm screen capture, multi-agent orchestration, and a real-time web dashboard.
 - [WhenLabs-org/when](https://github.com/WhenLabs-org/when) [![WhenLabs-org/when MCP server](https://glama.ai/mcp/servers/WhenLabs-org/when/badges/score.svg)](https://glama.ai/mcp/servers/WhenLabs-org/when) 📇 🏠 🍎 🪟 🐧 - Developer toolkit: auto-detect stack for AI context files, catch port conflicts, validate .env schemas, spot docs drift, audit dependency licenses, and time coding tasks — 7 MCP tools, one install.
 - [LukeLamb/claude-terminal-mcp](https://github.com/LukeLamb/claude-terminal-mcp) [![LukeLamb/claude-terminal-mcp MCP server](https://glama.ai/mcp/servers/LukeLamb/claude-terminal-mcp/badges/score.svg)](https://glama.ai/mcp/servers/LukeLamb/claude-terminal-mcp) 📇 🏠 🐧 🍎 - Terminal, filesystem, and background-job tools for Claude Desktop on Linux/macOS. Zero npm deps, pure Node.
+- [fayzkk889/MCPSense](https://github.com/fayzkk889/MCPSense) 🏎️ 🏠 🍎 🪟 🐧 - MCP server security scanner. 27 checks for tool poisoning, config injection, prompt injection, annotation integrity, and spec compliance. SARIF output and GitHub Action for CI/CD.
 
 ### 💬 <a name="communication"></a>Communication
 


### PR DESCRIPTION
MCPSense is an open-source CLI security scanner for MCP servers.

- 27 checks: tool poisoning, config command injection, prompt injection, SSRF, path traversal, credential leakage
- 4 scan modes: static, manifest, config, live
- SARIF 2.1.0 output, GitHub Action
- Go binary, cross-platform

GitHub: https://github.com/fayzkk889/MCPSense

Note: MCPSense is a CLI security scanner for MCP servers, not an MCP server itself. The Glama badge doesn't apply here as Glama registers MCP server implementations, not ecosystem tooling. Happy to add any other metadata needed.