### PR TITLE
Add fdl-mcp-server (small business website audit + AI visibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,7 +1817,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [andrealufino/aapl-ads-mcp](https://github.com/andrealufino/aapl-ads-mcp) [![andrealufino/aapl-ads-mcp MCP server](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp/badges/score.svg)](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp) 📇 - 
 
 ### 📊 <a name="monitoring"></a>Monitoring
-- [Nareshdevelop/fdl-mcp-server](https://github.com/Nareshdevelop/fdl-mcp-server) 🌐 ☁️ - Free SMB website audit + AI-visibility check + redesign preview. 5 tools, no API key required, deterministic scoring.
+- [Nareshdevelop/fdl-mcp-server](https://github.com/Nareshdevelop/fdl-mcp-server) [![Nareshdevelop/fdl-mcp-server MCP server](https://glama.ai/mcp/servers/Nareshdevelop/fdl-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/Nareshdevelop/fdl-mcp-server) 📇 ☁️ - Free SMB website audit + AI-visibility check + redesign preview. 5 tools, no API key required, deterministic scoring.
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.
 

--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ Tools for creating and editing marketing content, working with web meta data, pr
 - [andrealufino/aapl-ads-mcp](https://github.com/andrealufino/aapl-ads-mcp) [![andrealufino/aapl-ads-mcp MCP server](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp/badges/score.svg)](https://glama.ai/mcp/servers/andrealufino/aapl-ads-mcp) 📇 - 
 
 ### 📊 <a name="monitoring"></a>Monitoring
+- [Nareshdevelop/fdl-mcp-server](https://github.com/Nareshdevelop/fdl-mcp-server) 🌐 ☁️ - Free SMB website audit + AI-visibility check + redesign preview. 5 tools, no API key required, deterministic scoring.
 
 Access and analyze application monitoring data. Enables AI models to review error reports and performance metrics.
 


### PR DESCRIPTION
Adds [fdl-mcp-server](https://github.com/Nareshdevelop/fdl-mcp-server) — a free MCP server that lets Claude audit, compare, and check the AI-visibility of any small business website.

Five tools:
- `audit_website` — 5-pillar deterministic site audit (Performance, SEO, Mobile, Security, AEO)
- `compare_websites` — side-by-side scorecard
- `ai_visibility_check` — how 5 major AI engines describe a business
- `get_city_dashboard` — local SMB web-quality dashboard
- `generate_redesign_preview` — free AI-generated site preview

No API key required. Public API. Open source (MIT). Built on top of the public registry at fivedaylaunch.com/sites.

Fits in the Marketing category. Thanks for maintaining the list! 🙏