### PR TITLE
Add 3 MCP guides under Tutorials (curation, security audit, production stack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [MCP Servers 2026: Rankings & Selection Decision Tree](https://dibi8.com/resources/llm-frameworks/mcp-servers-2026-rankings-selection-guide/) - Curated top 30 servers across stdio / HTTP-SSE / OAuth-bridged transport modes with a decision tree to pick servers without drowning in registries.
+* [MCP Server Security Audit 2026](https://dibi8.com/resources/llm-frameworks/mcp-server-security-audit-2026-real-cases/) - 5 real community server audits (typosquats, telemetry exfiltration, over-scoped tokens) plus an 8-point pre-install checklist that takes 5 minutes per server.
+* [Claude Code MCP Advanced: 10-Server Production Stack](https://dibi8.com/resources/llm-frameworks/claude-code-mcp-advanced-10-server-stack-2026/) - Production-tested 10-server stack balancing power, security, and startup time; covers global vs per-project config patterns.
 
 ## Community
 


### PR DESCRIPTION
## What this adds

Three new entries under the **Tutorials** section, complementing the existing two:

1. **MCP Servers 2026: Rankings & Selection Decision Tree** — Curated top 30 servers across stdio / HTTP-SSE / OAuth-bridged transport modes. Includes a decision tree for choosing servers without drowning in registries.

2. **MCP Server Security Audit 2026** — Five real community server audits (one typosquat exfiltrating tokens, one with hidden telemetry post-maintainer-transfer, one over-scoped Slack server, two clean but architecturally risky) plus an 8-point pre-install checklist that takes ~5 minutes per server.

3. **Claude Code MCP Advanced: 10-Server Production Stack** — Production-tested stack balancing power, security, and startup latency. Covers global vs per-project mcp.json config patterns and per-server risk assessment.

## Why these fit Tutorials

The existing two entries cover quickstart + a specific Claude Desktop tutorial. These three add:
- **Curation** (which of 1000+ servers to actually install)
- **Security** (how to vet community servers before install)
- **Production** (real-world stack composition)

These are gaps the current Tutorials section doesn't cover.

## Source

All three articles are from dibi8.com, a multilingual open-source AI tools curation site (English / 中文 / 한국어 / Tiếng Việt). Editorial content, non-commercial, with FAQ schema and concrete data tables. The author publishes weekly comparisons and reviews of open-source AI tooling.

Happy to adjust phrasing, drop entries, or move sections per maintainer preference.