### PR TITLE
Add mcp-servers-live to Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
+* [mcp-servers-live](https://github.com/linny006/mcp-servers-live) - Third-party live-updated index of newest MCP servers on GitHub. Auto-refreshes every 15 minutes via GitHub Actions cron.
+
+
 
 ## Legend
 


### PR DESCRIPTION
Adds [mcp-servers-live](https://github.com/linny006/mcp-servers-live) to the **Community** section as a third-party tracker.

It's a live-updated index of newest MCP servers across GitHub — auto-refreshed every 15 minutes by a GitHub Actions cron pulling from the GitHub Search API. Complements the canonical glama.ai/mcp/servers directory and this curated list by surfacing the long tail of in-development servers as they ship, with metadata (language, stars, last commit).

- Open source, MIT licensed
- Repo: https://github.com/linny006/mcp-servers-live
- Live data: https://linny006.github.io/mcp-servers-live/