### PR TITLE
Add ProxyClaw MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+- [Iploop/proxyclaw-mcp](https://github.com/Iploop/proxyclaw-mcp) [![Iploop/proxyclaw-mcp MCP server](https://glama.ai/mcp/servers/Iploop/proxyclaw-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Iploop/proxyclaw-mcp) 📇 🐍 ☁️ - Residential proxy network MCP server. Route requests through real IPs with TLS JA3 spoofing, headless rendering, and structured data extraction from 60+ sites.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
Adds ProxyClaw MCP Server to the Browser Automation section.

Checklist addressed from the previous PR:
- Glama listing exists: https://glama.ai/mcp/servers/Iploop/proxyclaw-mcp
- Glama score badge added inline with the server entry
- Repo link verified: https://github.com/Iploop/proxyclaw-mcp

Previous inactive PR: #5314