### PR TITLE
Add quantum-vibecoding-mcp to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 - [thinkchainai/agentinterviews_mcp](https://github.com/thinkchainai/agentinterviews_mcp) - Conduct AI-powered qualitative research interviews and surveys at scale with [Agent Interviews](https://agentinterviews.com). Create interviewers, manage research projects, recruit participants, and analyze interview data through MCP.
 - [Pantheon-Security/notebooklm-mcp-secure](https://github.com/Pantheon-Security/notebooklm-mcp-secure) 📇 🏠 🍎 🪟 🐧 - Query Google NotebookLM from Claude/AI agents with 14 security hardening layers. Session-based conversations, notebook library management, and source-grounded research responses.
+- [JDerekLomas/quantuminspire](https://github.com/JDerekLomas/quantuminspire/tree/main/mcp-servers) 🐍 ☁️ 🍎 🪟 🐧 - Run real quantum experiments on real quantum hardware via natural language. Three MCP servers in one PyPI package ([`quantum-vibecoding-mcp`](https://pypi.org/project/quantum-vibecoding-mcp/)): Quantum Inspire Tuna-9 (9-qubit superconducting), IBM Quantum, and quantum RNG. Install: `claude mcp add qi-circuits -- uvx --from "quantum-vibecoding-mcp[qi]" qvc-qi`. From the [Quantum Vibecoding](https://quantumvibecoding.org) open-research initiative at TU Delft (6-paper hardware replication study).
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 


### PR DESCRIPTION
Adds **quantum-vibecoding-mcp** to the 🔬 Research section.

This is the first MCP server in the directory that lets Claude run circuits on **real quantum hardware** through natural language. The package bundles three servers in one PyPI install:

- `qvc-qi` — Quantum Inspire (Tuna-9, 9-qubit superconducting + cloud emulator)
- `qvc-ibm` — IBM Quantum (Heron, Eagle, etc.)
- `qvc-qrng` — Quantum random-number generator (QI hardware + ANU fallback)

One-line install for Claude Code:

```
claude mcp add qi-circuits -- uvx --from "quantum-vibecoding-mcp[qi]" qvc-qi
```

**Background:** the MCP came out of a 6-paper hardware replication study (VQE, QAOA, Quantum Volume, randomized benchmarking, utility-scale circuits) with a 93% claim pass rate across QI Tuna-9, IBM Torino, and IQM Garnet. Open research from TU Delft.

- Repo: https://github.com/JDerekLomas/quantuminspire/tree/main/mcp-servers
- PyPI: https://pypi.org/project/quantum-vibecoding-mcp/
- Site: https://quantumvibecoding.org

End-to-end verified: cold uvx install → MCP initialize → submit Bell state to QI cloud → poll → results returned correlated (100%).