### PR TITLE
Add dfayd0/ship-kit-claude-code — PR review MCP server (Node.js, gh CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🚚 - [Delivery](#delivery)
 * 🛠️ - [Developer Tools](#developer-tools)
 * 🧮 - [Data Science Tools](#data-science-tools)
+- <img src="https://cdn.simpleicons.org/github/8A8A8A" height="14"/> [subsis-pr-mcp](https://github.com/dfayd0/ship-kit-claude-code) - PR review MCP server with pr_diff, pr_blame, pr_linked_issues, pr_files_changed via gh CLI and git
 * 📊 - [Data Visualization](#data-visualization)
 * 📟 - [Embedded system](#embedded-system)
 * 🎓 - [Education](#education)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🚚 - [Delivery](#delivery)
 * 🛠️ - [Developer Tools](#developer-tools)
 * 🧮 - [Data Science Tools](#data-science-tools)
-- <img src="https://cdn.simpleicons.org/github/8A8A8A" height="14"/> [subsis-pr-mcp](https://github.com/dfayd0/ship-kit-claude-code) - PR review MCP server with pr_diff, pr_blame, pr_linked_issues, pr_files_changed via gh CLI and git
+- [dfayd0/ship-kit-claude-code](https://github.com/dfayd0/ship-kit-claude-code) 📇 🏠 - MCP server for PR reviews: pr_diff, pr_blame, pr_linked_issues, pr_files_changed via gh CLI + git
 * 📊 - [Data Visualization](#data-visualization)
 * 📟 - [Embedded system](#embedded-system)
 * 🎓 - [Education](#education)


### PR DESCRIPTION
Adds [dfayd0/ship-kit-claude-code](https://github.com/dfayd0/ship-kit-claude-code) — a Node.js MCP server for PR-aware code review in Claude Code.

**Tools exposed:**
- `pr_diff` — full unified diff for a PR URL
- `pr_files_changed` — structured list of changed files
- `pr_linked_issues` — issues auto-closed by the PR
- `pr_blame` — per-line git blame on changed files

All backed by `gh` CLI + local git (no tokens beyond existing `gh` auth). Paid bundle (29 €) on Gumroad.

- [x] Entry uses `owner/repo` format
- [x] Entry alphabetically ordered  
- [x] No duplicate