### PR TITLE
Add DealFlowPro MCP server to Real Estate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2073,6 +2073,7 @@ MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
 - [forgemeshlabs/disruption-intelligence-mcp](https://github.com/forgemeshlabs/disruption-intelligence-mcp) [![forgemeshlabs/disruption-intelligence-mcp MCP server](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp/badges/score.svg)](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp) 📇 ☁️ - AI-native commercial disruption intelligence for MCP clients and x402-powered agents. Supports WARN/layoff intelligence, company context, geospatial territory disruption, and x402 payment challenge inspection via the hosted Forgemesh API.
+- [jbechtel-97/dealflowpro-mcp-server](https://github.com/jbechtel-97/dealflowpro-mcp-server) [![jbechtel-97/dealflowpro-mcp-server MCP server](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server) 📇 ☁️ - Multifamily real estate deal analysis — cap rate, DSCR, cash-on-cash, IRR, DFP Score (0-100), max offer price, and market intelligence for 2-200 unit properties.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [DealFlowPro MCP Server](https://github.com/jbechtel-97/dealflowpro-mcp-server) to the Real Estate section with Glama badge.

[![jbechtel-97/dealflowpro-mcp-server MCP server](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server)

**What it does:** Multifamily real estate deal analysis — 4 tools for analyzing 2-200 unit apartment properties:
- `analyze_deal` — full underwriting: cap rate, DSCR, cash-on-cash, IRR, DFP Score (0-100), max offer price
- `score_deal` — quick screening score + verdict
- `reverse_calc` — back-solve max offer price from target returns
- `market_data` — flood zone, neighborhood income, job growth

**Install:** `npx -y dealflowpro-mcp` ([npm](https://www.npmjs.com/package/dealflowpro-mcp))

**Glama listing:** [glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server) — License A, Quality A, Maintenance B

*Replaces #6723 which was closed before Glama listing was approved.*