### PR TITLE
Add Long Horizon - agentic frontend testing via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+- [Long Horizon](https://longhorizon.dev) - Agentic frontend testing for the AI era. Plans, writes, and runs real browser tests via MCP for Claude Code and Cursor.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
## Description
Long Horizon is an agentic frontend testing tool that connects to 
Claude Code, Cursor, and other MCP-compatible coding agents. It 
automatically plans, writes, and runs real browser tests, then 
generates shareable execution reports with logs, screenshots, and 
network detail.

## Link
https://longhorizon.dev

## Category
Testing / Browser Automation

## Checklist
- [ ] I have read the contribution guidelines
- [ ] The entry follows the existing format
- [ ] The link is working and points to the correct page
- [ ] The description is factual and does not contain marketing language
- [ ] The entry is in alphabetical order within its section