### PR TITLE
Add compass — next-best-prompts MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ Data Platforms for data integration, transformation and pipeline orchestration.
 
 
 ### 💻 <a name="developer-tools"></a>Developer Tools
+- [danzimon-rgb/compass-mcp-server](https://github.com/danzimon-rgb/compass-mcp-server) 📇 🏠 ☁️ 🍎 🪟 🐧 - Ends each turn with 2-4 ranked, copy-paste-ready next-best-prompts, and skips when there's none. A portable end-of-turn suggestion rule (stdio + hosted HTTP) for Claude Code, Desktop, and web/mobile.
 - [adrianczuczka/mason](https://github.com/adrianczuczka/mason) [![adrianczuczka/mason MCP server](https://glama.ai/mcp/servers/adrianczuczka/mason/badges/score.svg)](https://glama.ai/mcp/servers/adrianczuczka/mason) 📇 🏠 🍎 🪟 🐧 - Context engineering MCP server. Generates CLAUDE.md from git history and architectural file sampling, and maintains a concept-map snapshot of features/flows → files so agents can skip grep/glob on repeat queries.
    The fast, idiomatic Go framework for building MCP servers. Struct-tag auto schema, middleware chain, and adapters to import existing Gin/OpenAPI/gRPC services as MCP tools.
 - [masondelan/selvedge](https://github.com/masondelan/selvedge) [![masondelan/selvedge MCP server](https://glama.ai/mcp/servers/masondelan/selvedge/badges/score.svg)](https://glama.ai/mcp/servers/masondelan/selvedge) 🐍 🏠 - Change tracking for AI-era codebases. AI agents call it to log structured change events (entity + diff + reasoning) before the session ends, then query history with diff, blame, history, changeset, and search. Captures the intent that would otherwise evaporate.


### PR DESCRIPTION
Adds **compass**, a small MCP server that carries one rule: end a substantive turn with 2–4 ranked, copy-paste-ready *next-best-prompts* (the user replies with a single digit to pick one) — and skip entirely when there's no high-value next move.

- Repo: https://github.com/danzimon-rgb/compass-mcp-server
- npm: https://www.npmjs.com/package/@danzimon/compass-mcp (`npx @danzimon/compass-mcp`)
- MIT · TypeScript · pure guidance — no secrets, no network, no side-effecting tools.
- Two transports from one source of truth: stdio (Claude Code / Claude Desktop) and hosted Streamable HTTP (Claude.ai web/mobile connectors). Exposes the rule via the `instructions` field, a `compass` prompt, and a `get_next_best_prompts_rule` tool.

Placed in **Developer Tools** alongside the other agent-utility servers, at the top with the section's recent additions. One server, one line, per the contributing guide.
