### PR TITLE
Add OsamaHassouna/docs-hub (HTML Email Playbook MCP) to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [parasxos/cpp26-adapter](https://github.com/parasxos/cpp26-adapter) [![parasxos/cpp26-adapter MCP server](https://glama.ai/mcp/servers/parasxos/cpp26-adapter/badges/score.svg)](https://glama.ai/mcp/servers/parasxos/cpp26-adapter) 🐍 🏠 🍎 🪟 🐧 - C++26 paper reference MCP (`cpp26-ref`) backing a Claude Code plugin: `lookup_paper`, fuzzy `search`, `compiler_status` over a 216-paper ISO/IEC 14882:2026 corpus. The plugin's skill + reviewer subagent use these tools to bias Claude toward reflection, contracts, `std::execution` senders, `#embed`, expansion statements — even when the local compiler lags. 95% on a held 39-task eval gate.
 
-- [OsamaHassouna/docs-hub](https://github.com/OsamaHassouna/docs-hub) 📇 ☁️ 🏠 🍎 🪟 🐧 - HTML Email Playbook — MCP server + CLI that teaches AI clients (Claude, Cursor, Cline, Codex) to write HTML email that renders in Outlook, Gmail, and Apple Mail. 4 tools, 19 rules, 6 components. Install: `npx -y email-playbook-mcp@latest`. Hosted: `https://docs.osamahassouna.com/api/mcp`.
+- [OsamaHassouna/docs-hub](https://github.com/OsamaHassouna/docs-hub) [![OsamaHassouna/docs-hub MCP server](https://glama.ai/mcp/servers/OsamaHassouna/docs-hub/badges/score.svg)](https://glama.ai/mcp/servers/OsamaHassouna/docs-hub) 📇 ☁️ 🏠 🍎 🪟 🐧 - HTML Email Playbook — MCP server + CLI that teaches AI clients (Claude, Cursor, Cline, Codex) to write HTML email that renders in Outlook, Gmail, and Apple Mail. 4 tools, 19 rules, 6 components. Install: `npx -y email-playbook-mcp@latest`. Hosted: `https://docs.osamahassouna.com/api/mcp`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 

--- a/README.md
+++ b/README.md
@@ -1172,6 +1172,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [parasxos/cpp26-adapter](https://github.com/parasxos/cpp26-adapter) [![parasxos/cpp26-adapter MCP server](https://glama.ai/mcp/servers/parasxos/cpp26-adapter/badges/score.svg)](https://glama.ai/mcp/servers/parasxos/cpp26-adapter) 🐍 🏠 🍎 🪟 🐧 - C++26 paper reference MCP (`cpp26-ref`) backing a Claude Code plugin: `lookup_paper`, fuzzy `search`, `compiler_status` over a 216-paper ISO/IEC 14882:2026 corpus. The plugin's skill + reviewer subagent use these tools to bias Claude toward reflection, contracts, `std::execution` senders, `#embed`, expansion statements — even when the local compiler lags. 95% on a held 39-task eval gate.
 
+- [OsamaHassouna/docs-hub](https://github.com/OsamaHassouna/docs-hub) 📇 ☁️ 🏠 🍎 🪟 🐧 - HTML Email Playbook — MCP server + CLI that teaches AI clients (Claude, Cursor, Cline, Codex) to write HTML email that renders in Outlook, Gmail, and Apple Mail. 4 tools, 19 rules, 6 components. Install: `npx -y email-playbook-mcp@latest`. Hosted: `https://docs.osamahassouna.com/api/mcp`.
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)


### PR DESCRIPTION
Adds the **HTML Email Playbook** MCP server to the Developer Tools section.

## What it does
MCP server + CLI that teaches AI clients (Claude Desktop, Cursor, Cline, Codex) how to write HTML email that actually renders in Outlook, Gmail, and Apple Mail. The four tools (`list_categories`, `get_playbook_rules`, `list_components`, `get_component`) expose 19 rules across structure, compatibility, production, and AI generation, plus 6 reusable components (buttons, spacing, images, inline-icon, background-images, text).

## Why it's useful
Frontend devs hit Outlook-rendering bugs constantly when AI assistants generate HTML email. This server lets the model fetch the actual playbook patterns (with VML, MSO conditionals, table layout) instead of hallucinating its own.

## Install paths
- **npm**: `npx -y email-playbook-mcp@latest`
- **Hosted**: `https://docs.osamahassouna.com/api/mcp` (no install)
- **Docs**: https://docs.osamahassouna.com/email-playbook/cli/
- **Repo**: https://github.com/OsamaHassouna/docs-hub
- **MIT licensed**

Entry placed at the end of the Developer Tools section in the same style as recent additions.