### PR TITLE
Add us-all/unifi-mcp-server (Other Tools and Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2778,6 +2778,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [yuna0x0/hackmd-mcp](https://github.com/yuna0x0/hackmd-mcp) 📇 ☁️ - Allows AI models to interact with [HackMD](https://hackmd.io)
 - [ZeparHyfar/mcp-datetime](https://github.com/ZeparHyfar/mcp-datetime) - MCP server providing date and time functions in various formats
 - [zueai/mcp-manager](https://github.com/zueai/mcp-manager) 📇 ☁️ - Simple Web UI to install and manage MCP servers for Claude Desktop App.
+- [us-all/unifi-mcp-server](https://github.com/us-all/unifi-mcp-server) 📇 🏠 🍎 🪟 🐧 [![us-all/unifi-mcp-server MCP server](https://glama.ai/mcp/servers/us-all/unifi-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/us-all/unifi-mcp-server) - UniFi semantic-analysis — 54 tools on Site Manager API + Cloud Connector. 8 workflow Prompts (4 fleet-ops + 4 MSP). Anomaly detection, fleet health, cross-site analytics. Read-only.
 - [SPL-BGU/PlanningCopilot](https://github.com/SPL-BGU/PlanningCopilot) [![planning-copilot MCP server](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot/badges/score.svg)](https://glama.ai/mcp/servers/SPL-BGU/planning-copilot) 🐍🏠 - A tool-augmented LLM system for the full PDDL planning pipeline, improving reliability without domain-specific training.
 - [yyyhy/nash-arena](https://github.com/yyyhy/nash-arena) [![yyyhy/nash-arena MCP server](https://glama.ai/mcp/servers/yyyhy/nash-arena/badges/score.svg)](https://glama.ai/mcp/servers/yyyhy/nash-arena) 🐍 ☁️ - A Chess and Card Game Arena For LLM, Agents can battle in game by mcp
 ## Frameworks


### PR DESCRIPTION
Adds [`us-all/unifi-mcp-server`](https://github.com/us-all/unifi-mcp-server) (`@us-all/unifi-mcp` on npm) to the **Other Tools and Integrations** section.

> UniFi semantic-analysis — 54 tools on Site Manager API + Cloud Connector. 8 workflow Prompts (4 fleet-ops + 4 MSP). Read-only.

**Listing requirements:**

- [x] **Glama** — listed and scored: https://glama.ai/mcp/servers/us-all/unifi-mcp-server
- [x] **MCP Registry** — `io.github.us-all/unifi` published via OIDC trusted publishing
- [x] **npm** — public, MIT, OIDC trusted publishing
- [x] **Single server in this PR** (per the [`triage-close-multiple`](https://github.com/punkpeye/awesome-mcp-servers/pull/5952) policy on #5952 / #5975)

**History:** Originally bundled in #5952 (7 servers) and #5975 (2 servers), both closed 2026-05-27 with the request to split into one-server-per-PR. Re-submitting individually — 9 sibling PRs covering the full @us-all MCP suite:

`datadog-mcp-server` · `android-mcp-server` · `google-drive-mcp-server` · `mcp-toolkit` · `mlflow-mcp-server` · `openmetadata-mcp-server` · `unifi-mcp-server` · `airflow-mcp-server` · `dbt-mcp-server`

Diff: **+1 line** in `README.md`, placed alphabetically in the Other Tools and Integrations section.

Happy to make any adjustments. Thanks for maintaining this list!
