### PR TITLE
Add audit-ledger-mcp to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2401,6 +2401,12 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [shyshlakov/pci-dss-mcp](https://github.com/shyshlakov/pci-dss-mcp) [![shyshlakov/pci-dss-mcp MCP server](https://glama.ai/mcp/servers/shyshlakov/pci-dss-mcp/badges/score.svg)](https://glama.ai/mcp/servers/shyshlakov/pci-dss-mcp) 🏎️ 🏠 🍎 🪟 🐧 - PCI DSS v4.0.1 static-analysis MCP server for Go payment codebases. 12 scanners detect PAN/CVV exposure, weak crypto, missing audit logs, vulnerable deps, TLS misconfig, auth weaknesses, plus CycloneDX 1.6 SBOM generation - each finding mapped to the exact PCI requirement. AI-assisted triage via triage_findings. Keyless-signed multi-arch Docker image on ghcr.io.
 - [layervai/qurl-mcp](https://github.com/layervai/qurl-mcp) [![layervai/qurl-mcp MCP server](https://glama.ai/mcp/servers/layervai/qurl-mcp/badges/score.svg)](https://glama.ai/mcp/servers/layervai/qurl-mcp) 📇 ☁️ 🍎 🪟 🐧 - Mint, resolve, audit, and rotate expiring scope-limited access links (qURLs) for AI agents — secure URL gateway for the qURL API. 9 tools (create / resolve / list / get / delete / extend / update / mint-link / batch-create), 3 resources, 3 guided prompts. stdio transport, OIDC-attested npm provenance.
 - [WRG-11/wrg-sigma-rules](https://github.com/WRG-11/wrg-sigma-rules) [![WRG-11/wrg-sigma-rules MCP server](https://glama.ai/mcp/servers/WRG-11/wrg-sigma-rules/badges/score.svg)](https://glama.ai/mcp/servers/WRG-11/wrg-sigma-rules) 🐍 🏠 ☁️ 🍎 🪟 🐧 - Sigma detection rule writing, validation, and conversion (Splunk/Elastic/Kibana/Wazuh) via 3 MCP tools (`draft_rule`, `validate_rule`, `convert_rule`) backed by a 61-rule production corpus across 11 MITRE ATT&CK tactic categories. Standalone server + Claude Code plugin distribution.
+- [shahidh68/audit-ledger-mcp](https://github.com/shahidh68/audit-ledger-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Tamper-evident audit logging for AI decisions in regulated fintech. Three tools (`record_decision`, `verify_decision`, `list_decisions`) write to a regulator-grade ledger built on AWS S3 Object Lock COMPLIANCE mode with 7-year retention. PII hashed locally before transit. Built for EU AI Act Article 12 and FCA SS1/23 evidence requirements. Also on [Smithery](https://smithery.ai/server/s-hamid/audit-ledger-mcp) and [npm](https://www.npmjs.com/package/audit-ledger-mcp).
+
+
+
+
+
 ### 🌐 <a name="social-media"></a>Social Media
 
 Integration with social media platforms to allow posting, analytics, and interaction management. Enables AI-driven automation for social presence.


### PR DESCRIPTION
Adds [audit-ledger-mcp](https://www.npmjs.com/package/audit-ledger-mcp) to the Security section.

**What it does:**
- Tamper-evident audit logging for AI decisions
- Three tools: `record_decision`, `verify_decision`, `list_decisions`
- Writes to a regulator-grade ledger (AWS S3 Object Lock COMPLIANCE mode, 7-year retention)
- PII hashed locally before transit — only fingerprints leave the MCP server
- Built specifically for EU AI Act Article 12 and FCA SS1/23 evidence requirements

**Links:**
- GitHub repo: https://github.com/shahidh68/audit-ledger-mcp
- npm package: https://www.npmjs.com/package/audit-ledger-mcp
- Smithery: https://smithery.ai/server/s-hamid/audit-ledger-mcp
- Live demo: https://d2pfirb2397ixy.cloudfront.net/?demo=1

License: Apache-2.0