### PR TITLE
Add Construction & Civil Engineering section with BuildCalc API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🎥 - [Multimedia Process](#multimedia-process)
 * 🖥️ - [OS Automation](#os-automation)
 * 📋 - [Product Management](#product-management)
+* 🏗️ - [Construction & Civil Engineering](#construction)
 * 🏠 - [Real Estate](#real-estate)
 * 🔬 - [Research](#research)
 * 🔎 - [Search & Data Extraction](#search)
@@ -2073,6 +2074,12 @@ MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
 - [forgemeshlabs/disruption-intelligence-mcp](https://github.com/forgemeshlabs/disruption-intelligence-mcp) [![forgemeshlabs/disruption-intelligence-mcp MCP server](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp/badges/score.svg)](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp) 📇 ☁️ - AI-native commercial disruption intelligence for MCP clients and x402-powered agents. Supports WARN/layoff intelligence, company context, geospatial territory disruption, and x402 payment challenge inspection via the hosted Forgemesh API.
+
+### 🏗️ <a name="construction"></a>Construction & Civil Engineering
+
+MCP servers for construction data, building codes, and engineering calculations.
+
+- [BuildCalc API](https://buildcalcapi.dev) 🐍 ☁️ 🍎 🪟 🐧 - Vertical construction data API for AI agents. ~105 MCP tools across 5 verticals: 81 building-code-grounded calculators (concrete, framing, HVAC sizing, NEC electrical, IRC stairs); 937 IRC/IBC/NEC/IECC/IPC code sections with full-text search (dual-edition 2021/2024); federal cost data (BLS PPI materials + OEWS/QCEW labor wages by MSA/county/ZIP + Census BPS permits for 7,800+ jurisdictions); 43,400+ certified product SKUs (ENERGY STAR, ICC-ES ESR, NFRC CPD, EPA WaterSense, Simpson Strong-Tie); 15 standardized US residential project benchmarks. 96% certified-grade from federal/regulatory sources. Free tier 1,000 req/month.
 
 ### 🔬 <a name="research"></a>Research
 

--- a/README.md
+++ b/README.md
@@ -2079,7 +2079,7 @@ MCP servers for real estate CRM, property management, and agent workflows.
 
 MCP servers for construction data, building codes, and engineering calculations.
 
-- [BuildCalc API](https://buildcalcapi.dev) 🐍 ☁️ 🍎 🪟 🐧 - Vertical construction data API for AI agents. ~105 MCP tools across 5 verticals: 81 building-code-grounded calculators (concrete, framing, HVAC sizing, NEC electrical, IRC stairs); 937 IRC/IBC/NEC/IECC/IPC code sections with full-text search (dual-edition 2021/2024); federal cost data (BLS PPI materials + OEWS/QCEW labor wages by MSA/county/ZIP + Census BPS permits for 7,800+ jurisdictions); 43,400+ certified product SKUs (ENERGY STAR, ICC-ES ESR, NFRC CPD, EPA WaterSense, Simpson Strong-Tie); 15 standardized US residential project benchmarks. 96% certified-grade from federal/regulatory sources. Free tier 1,000 req/month.
+- [Nasty-Fury/buildcalcapi-mcp-server](https://github.com/Nasty-Fury/buildcalcapi-mcp-server) 🐍 ☁️ 🍎 🪟 🐧 - Vertical construction data API for AI agents. ~105 MCP tools across 5 verticals: 81 building-code-grounded calculators (concrete, framing, HVAC sizing, NEC electrical, IRC stairs); 937 IRC/IBC/NEC/IECC/IPC code sections with full-text search (dual-edition 2021/2024); federal cost data (BLS PPI materials + OEWS/QCEW labor wages by MSA/county/ZIP + Census BPS permits for 7,800+ jurisdictions); 43,400+ certified product SKUs (ENERGY STAR, ICC-ES ESR, NFRC CPD, EPA WaterSense, Simpson Strong-Tie); 15 standardized US residential project benchmarks. 96% certified-grade from federal/regulatory sources. Free tier 1,000 req/month.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## What this PR adds

A new **🏗️ Construction & Civil Engineering** category section for MCP servers that surface construction-industry data, building codes, and engineering calculations. The existing 🏠 Real Estate section is scoped to CRM/property/agent workflows — construction (building/permits/codes/engineering) is a distinct vertical that warrants its own home.

## Listing added

**[BuildCalc API](https://buildcalcapi.dev)** — vertical construction data API for AI agents. ~105 MCP tools across 5 federated verticals:

- **81 building-code-grounded calculators** (concrete, framing, drywall, roofing, HVAC sizing, NEC electrical, UPC/IPC plumbing, IECC envelope, IRC stairs, etc.)
- **937 IRC/IBC/NEC/IECC/IPC code sections** with full-text search (dual-edition 2021/2024)
- **Federal cost data** — BLS PPI materials, BLS OEWS/QCEW labor wages by MSA/county/ZIP, Census BPS permits for 7,800+ jurisdictions
- **43,400+ certified product SKUs** across 10 categories — ENERGY STAR, ICC-ES Evaluation Service Reports, NFRC CPD, EPA WaterSense, Simpson Strong-Tie (ESR-2552/3096/2236)
- **15 standardized US residential project benchmarks** × 5 geography tiers

96% of the catalog is `confidence='certified'` from federal/regulatory/third-party-independent sources. Free tier 1,000 req/month at https://buildcalcapi.dev/signup.

Also listed on the official Anthropic MCP Registry as `dev.buildcalcapi/server` and on Smithery as `buildcalcapi/server`.

## TOC update

Added `* 🏗️ - [Construction & Civil Engineering](#construction)` before the Real Estate entry to keep the vertical-categories grouped.

Happy to relocate to a different existing category (e.g. Data Platforms or Other Tools and Integrations) if you'd prefer not to add a new section — just let me know.