### PR TITLE
Add freellmpool to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+- [0xzr/freellmpool](https://github.com/0xzr/freellmpool) 🐍 ☁️ 🏠 🍎 🪟 🐧 - MCP server that exposes pooled free LLM tiers from 16 providers (Groq, Cerebras, Gemini, OpenRouter, …) as ask/models/quota tools, with automatic failover; keyless to start (`pip install freellmpool`).
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
Adds [freellmpool](https://github.com/0xzr/freellmpool) to **Aggregators**.

`freellmpool mcp` is a zero-dependency (stdlib stdio JSON-RPC) MCP server that lets an MCP client reach pooled **free** LLM tiers from 16 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere, …) through one server — `free_llm_ask` / `free_llm_models` / `free_llm_quota` tools — with automatic failover and per-day quota tracking. Keyless to start (`pip install freellmpool`). It fits the "access many [providers] through a single MCP server" definition alongside entries like APIFold and agentforge.

Legend: 🐍 Python · ☁️ talks to remote provider APIs · 🏠 runs locally · 🍎🪟🐧.