### PR TITLE
Add Spoken (podcast transcripts) to Speech-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2481,6 +2481,7 @@ Translation tools and services to enable AI assistants to translate content betw
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 
 - [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) [![eviscerations/whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
+- [spokenmd/spoken](https://github.com/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech
 

--- a/README.md
+++ b/README.md
@@ -2481,7 +2481,7 @@ Translation tools and services to enable AI assistants to translate content betw
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 
 - [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) [![eviscerations/whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
-- [spokenmd/spoken](https://github.com/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
+- [spokenmd/spoken](https://github.com/spokenmd/spoken) [![spokenmd/spoken MCP server](https://glama.ai/mcp/servers/spokenmd/spoken/badges/score.svg)](https://glama.ai/mcp/servers/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech
 


### PR DESCRIPTION
Adds [Spoken](https://spoken.md), an MCP server that fetches **published podcast transcripts** as clean Markdown with real speaker names (not "Speaker 1").

- **npm:** `spoken-mcp` · **Registry:** `io.github.spokenmd/spoken` (official MCP registry) · **Repo:** https://github.com/spokenmd/spoken
- **Tools:** `search_podcasts`, `get_transcript`, `get_balance`
- TypeScript (📇), cloud-backed (☁️). Added alphabetically under 🎙️ Speech-to-Text.

Single-line entry, follows the existing format and legend.