### PR TITLE
Add live-translate-mcp — EN ↔ 中文 speech translation via Whisper + Claude + Piper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2678,6 +2678,7 @@ Translation tools and services to enable AI assistants to translate content betw
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
+- [waxberry-dev/live-translate-mcp](https://github.com/waxberry-dev/live-translate-mcp) 📇 🏠 🍎 🐧 - Real-time English ↔ Mandarin Chinese speech translation. Transcribes audio locally with Whisper, translates via Claude API, and synthesises speech locally with Piper TTS. Pass a WAV file path and Claude handles the rest.
 
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 

--- a/README.md
+++ b/README.md
@@ -2678,7 +2678,7 @@ Translation tools and services to enable AI assistants to translate content betw
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.
-- [waxberry-dev/live-translate-mcp](https://github.com/waxberry-dev/live-translate-mcp) 📇 🏠 🍎 🐧 - Real-time English ↔ Mandarin Chinese speech translation. Transcribes audio locally with Whisper, translates via Claude API, and synthesises speech locally with Piper TTS. Pass a WAV file path and Claude handles the rest.
+- [waxberry-dev/live-translate-mcp](https://github.com/waxberry-dev/live-translate-mcp) [![waxberry-dev/live-translate-mcp MCP server](https://glama.ai/mcp/servers/waxberry-dev/live-translate-mcp/badges/score.svg)](https://glama.ai/mcp/servers/waxberry-dev/live-translate-mcp) 📇 🏠 🍎 🐧 - Real-time English ↔ Mandarin Chinese speech translation. Transcribes audio locally with Whisper, translates via Claude API, and synthesises speech locally with Piper TTS. Pass a WAV file path and Claude handles the rest.
 
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 


### PR DESCRIPTION
## live-translate-mcp

**npm:** https://www.npmjs.com/package/live-translate-mcp
**GitHub:** https://github.com/waxberry-dev/live-translate-mcp

An MCP server that gives Claude the ability to translate speech audio between English and Mandarin Chinese. Pass a WAV file path and it handles the full pipeline:

- **ASR** — Whisper (runs locally via `@huggingface/transformers`)
- **Translation** — Claude API
- **TTS** — Piper ONNX (runs locally, no cloud)

The translated audio is saved to disk and played automatically.

**Install:**
\`\`\`json
{
  "mcpServers": {
    "live-translate": {
      "command": "npx",
      "args": ["-y", "live-translate-mcp"],
      "env": { "ANTHROPIC_API_KEY": "your-key-here" }
    }
  }
}
\`\`\`

Added to the Translation Services section.