### PR TITLE
Add Stash — token-light hosted record store for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -2820,6 +2820,8 @@ Now Claude can answer questions about writing MCP servers and how they work
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src=
+- [Stash](https://github.com/dancourse/stash) - Hosted MCP record store for Claude. Store contacts, tasks, notes and Notion exports; full-text search in milliseconds. `context()` loads standing context in one call. Google OAuth signup, no local install. Free tier available.
+"https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
## What is Stash?

Stash is a token-light hosted record store that Claude talks to over remote MCP.
It is to Notion what SQLite is to Postgres — fast, cheap, and enough for 90% of retrieval use cases.

- **Live endpoint**: https://stash-production-db08.up.railway.app/mcp
- **Homepage**: https://stash-claude.netlify.app
- **Auth**: Google OAuth (any Google account, free tier, no card)
- **Key tools**: `context()` (load standing context), `search()` (FTS5), `add()`, `upsert()`, `list()`, `usage()`

## Why it belongs here

- Remote/hosted HTTP connector (not local-only)
- Self-contained wedge use cases: Notion-offload, mini-CRM, Start-my-day
- token-light design (returns flat JSON, not Notion-style type envelopes)

## Category suggestion

Under "Productivity / Storage" or "Databases" — or wherever hosted record stores land.