### PR TITLE
Add e2e-runner (JSON-driven E2E testing MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [eat-pray-ai/yutu](https://github.com/eat-pray-ai/yutu) 🏎️ 🏠 🍎 🐧 🪟 - A fully functional MCP server and CLI for YouTube to automate YouTube operation
 - [executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright) 📇 - An MCP server using Playwright for browser automation and webscrapping
 - [eyalzh/browser-control-mcp](https://github.com/eyalzh/browser-control-mcp) 📇 🏠 - An MCP server paired with a browser extension that enables LLM clients to control the user's browser (Firefox).
+- [fastslack/e2e-runner](https://github.com/fastslack/mtw-e2e-runner) 📇 🏠 🍎 🪟 🐧 - JSON-driven E2E browser testing as an MCP server: your agent writes the test and runs it in parallel against a Chrome pool over CDP. 17 tools, click/type/assert/visual-diff/GraphQL actions.
 - [fradser/mcp-server-apple-reminders](https://github.com/FradSer/mcp-server-apple-reminders) 📇 🏠 🍎 - An MCP server for interacting with Apple Reminders on macOS
 - [freema/firefox-devtools-mcp](https://github.com/freema/firefox-devtools-mcp) 📇 🏠 - Firefox browser automation via WebDriver BiDi for testing, scraping, and browser control. Supports snapshot/UID-based interactions, network monitoring, console capture, and screenshots.
 - [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) 📇 🏠 - Extract structured data from any website. Just prompt and get JSON.


### PR DESCRIPTION
Adds one entry under **Browser Automation**, alphabetically between `eyalzh` and `fradser`.

[fastslack/e2e-runner](https://github.com/fastslack/mtw-e2e-runner) — JSON-driven E2E browser testing as an MCP server: you describe a test in plain English and your agent writes the JSON and runs it in parallel against a Chrome pool over CDP. 17 MCP tools (click/type/assert/visual-diff/GraphQL). Apache-2.0, npm `@matware/e2e-runner`.

- Flags: 📇 (TypeScript/JS) 🏠 (local) 🍎 🪟 🐧 (cross-platform Node)
- One entry, correct section, follows the list format.