### PR TITLE
🤖🤖🤖 Add Cowboy MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [mshegolev/jaeger-mcp](https://github.com/mshegolev/jaeger-mcp) [![mshegolev/jaeger-mcp MCP server](https://glama.ai/mcp/servers/mshegolev/jaeger-mcp/badges/score.svg)](https://glama.ai/mcp/servers/mshegolev/jaeger-mcp) 🐍 ☁️ 🏠 – Jaeger distributed tracing MCP. 5 tools: list_services, list_operations, search_traces, get_trace, get_dependencies. Any Jaeger instance (HTTP API v3); PyPI + MCP Registry.
 
 - [parasxos/cpp26-adapter](https://github.com/parasxos/cpp26-adapter) [![parasxos/cpp26-adapter MCP server](https://glama.ai/mcp/servers/parasxos/cpp26-adapter/badges/score.svg)](https://glama.ai/mcp/servers/parasxos/cpp26-adapter) 🐍 🏠 🍎 🪟 🐧 - C++26 paper reference MCP (`cpp26-ref`) backing a Claude Code plugin: `lookup_paper`, fuzzy `search`, `compiler_status` over a 216-paper ISO/IEC 14882:2026 corpus. The plugin's skill + reviewer subagent use these tools to bias Claude toward reflection, contracts, `std::execution` senders, `#embed`, expansion statements — even when the local compiler lags. 95% on a held 39-task eval gate.
+- [februality/cowboy-mcp](https://github.com/februality/cowboy-mcp) ☁️ - Turn any WordPress site into a Streamable HTTP MCP server — 131 tools for posts, WooCommerce, plugins, themes, users & media, built for AI coding agents like Claude Code. Secure by default (bcrypt keys, safe mode, audit log), no Node.js proxy.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds **Cowboy MCP** under **Developer Tools**.

[februality/cowboy-mcp](https://github.com/februality/cowboy-mcp) is an open-source (GPL-2.0) WordPress plugin that turns any WordPress site into a **Streamable HTTP MCP server** (MCP 2025-06-18). It exposes **131 tools** — posts, pages, CPTs, taxonomies, comments, plugins, themes, users, media, options, DB query/write, WP-CLI, and diagnostics — plus conditional integrations for WooCommerce, ACF, Elementor, Wordfence, UpdraftPlus, SEO, forms, and cache plugins.

- Native PHP, **no Node.js proxy** required.
- Secure by default: bcrypt-hashed API keys, per-key rate limiting, safe mode, audit log, and SSRF/SQL/option guardrails.
- Complete README with install + connection instructions (Claude Code, Codex).
- Placed under **Developer Tools**, alongside the existing WordPress `wp-cli-mcp`.
- Scope ☁️ (remote HTTP service); no language emoji since PHP isn't in the legend.
