### PR TITLE
Add rustunnel-mcp to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [OsamaHassouna/docs-hub](https://github.com/OsamaHassouna/docs-hub) [![OsamaHassouna/docs-hub MCP server](https://glama.ai/mcp/servers/OsamaHassouna/docs-hub/badges/score.svg)](https://glama.ai/mcp/servers/OsamaHassouna/docs-hub) 📇 ☁️ 🏠 🍎 🪟 🐧 - HTML Email Playbook — MCP server + CLI that teaches AI clients (Claude, Cursor, Cline, Codex) to write HTML email that renders in Outlook, Gmail, and Apple Mail. 4 tools, 19 rules, 6 components. Install: `npx -y email-playbook-mcp@latest`. Hosted: `https://docs.osamahassouna.com/api/mcp`.
 
+- [joaoh82/rustunnel](https://github.com/joaoh82/rustunnel) [![joaoh82/rustunnel MCP server](https://glama.ai/mcp/servers/joaoh82/rustunnel/badges/score.svg)](https://glama.ai/mcp/servers/joaoh82/rustunnel) 🦀 ☁️ - MCP server that lets AI agents create and manage public tunnels to local services (webhooks, dev servers, sharing). Pairs with the rustunnel CLI + managed tunnel service.
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)


### PR DESCRIPTION
Hi! I'm Joao (@joaoh82), author of rustunnel and rustunnel-mcp.

`rustunnel-mcp` is an MCP server that lets AI agents (Claude Code, Cursor, Windsurf) spawn public tunnels to local services from inside an agent session — useful for testing webhooks (Stripe, GitHub, Twilio), exposing a dev server, or letting the agent share a result externally.

It's a production-grade server (not a toy/demo): pairs with the rustunnel CLI and managed tunnel service. Written in Rust.

- Source: https://github.com/joaoh82/rustunnel (MCP server crate in `crates/rustunnel-mcp/`)
- crates.io: https://crates.io/crates/rustunnel-mcp
- Website: https://rustunnel.com
- License: AGPL-3.0

Inserted under **Developer Tools** in the format I see for surrounding entries. Happy to adjust emoji set, category, or wording if anything's off.