### PR TITLE
Add KyaniteLabs/DialectOS MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2594,6 +2594,7 @@ Tools for managing customer support, IT service management, and helpdesk operati
 
 Translation tools and services to enable AI assistants to translate content between different languages.
 
+- [KyaniteLabs/DialectOS](https://github.com/KyaniteLabs/DialectOS) [![KyaniteLabs/DialectOS MCP server](https://glama.ai/mcp/servers/KyaniteLabs/DialectOS/badges/score.svg)](https://glama.ai/mcp/servers/KyaniteLabs/DialectOS) 📇 🏠 - Spanish dialect localization server and CLI. Translates and QA-checks across 25 regional variants with register control, structure preservation, and adversarial quality gates.
 - [mmntm/weblate-mcp](https://github.com/mmntm/weblate-mcp) 📇 ☁️ - Comprehensive Model Context Protocol server for Weblate translation management, enabling AI assistants to perform translation tasks, project management, and content discovery with smart format transformations.
 - [shuji-bonji/xcomet-mcp-server](https://github.com/shuji-bonji/xcomet-mcp-server) 📇 🏠 - Translation quality evaluation using xCOMET models. Provides quality scoring (0-1), error detection with severity levels (minor/major/critical), and optimized batch processing with 25x speedup.
 - [translated/lara-mcp](https://github.com/translated/lara-mcp) 🎖️ 📇 ☁️ - MCP Server for Lara Translate API, enabling powerful translation capabilities with support for language detection and context-aware translations.


### PR DESCRIPTION
Adds KyaniteLabs/DialectOS as a single-server submission under Translation Services.

Validation:
- Added exactly one server entry in README.md
- Uses the full owner/repo link text and GitHub repository URL
- Includes the Glama score badge for KyaniteLabs/DialectOS
- Confirmed GitHub repo, Glama server page, badge SVG, and score page return HTTP 200
- Ran git diff --check and the repo pre-commit validation