### PR TITLE
Add DC Hub — data-center intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ Tools for encrypting and decrypting data.
 
 Provides access to customer profiles inside of customer data platforms
 
+- [DC Hub](https://github.com/azmartone67/dchub-mcp-server) [![DC Hub MCP server](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server) 📇 ☁️ - Data-center, power & gas intelligence MCP server. 33 tools covering 21,000+ data-center facilities (170+ countries), 232 US power markets scored by the DC Hub Power Index (DCPI), 2,000+ tracked M&A deals, ISO grid telemetry (PJM, ERCOT, CAISO, MISO, SPP, NYISO), fiber routes, and energy pricing. Free to cite (CC-BY-4.0).
 - [antv/mcp-server-chart](https://github.com/antvis/mcp-server-chart) 🎖️ 📇 ☁️ - A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - [hustcc/mcp-echarts](https://github.com/hustcc/mcp-echarts) 📇 🏠 - Generate visual charts using [Apache ECharts](https://echarts.apache.org) with AI MCP dynamically.
 - [hustcc/mcp-mermaid](https://github.com/hustcc/mcp-mermaid) 📇 🏠 - Generate [mermaid](https://mermaid.js.org/) diagram and chart with AI MCP dynamically.

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ Tools for encrypting and decrypting data.
 
 Provides access to customer profiles inside of customer data platforms
 
-- [DC Hub](https://github.com/azmartone67/dchub-mcp-server) [![DC Hub MCP server](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server) 📇 ☁️ - Data-center, power & gas intelligence MCP server. 33 tools covering 21,000+ data-center facilities (170+ countries), 232 US power markets scored by the DC Hub Power Index (DCPI), 2,000+ tracked M&A deals, ISO grid telemetry (PJM, ERCOT, CAISO, MISO, SPP, NYISO), fiber routes, and energy pricing. Free to cite (CC-BY-4.0).
+- [azmartone67/dchub-mcp-server](https://github.com/azmartone67/dchub-mcp-server) [![DC Hub MCP server](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server) 📇 ☁️ - Data-center, power & gas intelligence MCP server. 33 tools covering 21,000+ data-center facilities (170+ countries), 232 US power markets scored by the DC Hub Power Index (DCPI), 2,000+ tracked M&A deals, ISO grid telemetry (PJM, ERCOT, CAISO, MISO, SPP, NYISO), fiber routes, and energy pricing. Free to cite (CC-BY-4.0).
 - [antv/mcp-server-chart](https://github.com/antvis/mcp-server-chart) 🎖️ 📇 ☁️ - A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - [hustcc/mcp-echarts](https://github.com/hustcc/mcp-echarts) 📇 🏠 - Generate visual charts using [Apache ECharts](https://echarts.apache.org) with AI MCP dynamically.
 - [hustcc/mcp-mermaid](https://github.com/hustcc/mcp-mermaid) 📇 🏠 - Generate [mermaid](https://mermaid.js.org/) diagram and chart with AI MCP dynamically.


### PR DESCRIPTION
## What
Adds DC Hub to the awesome-mcp-servers list.

## Server
- **Name:** DC Hub
- **URL:** https://dchub.cloud/mcp
- **Server card:** https://dchub.cloud/.well-known/mcp/server-card.json
- **Description:** Data-center, power & gas intelligence MCP server. 33 tools covering 21,000+ data-center facilities (170+ countries), 232 US power markets scored by the DC Hub Power Index (DCPI), 2,000+ tracked M&A deals, ISO grid telemetry (PJM, ERCOT, CAISO, MISO, SPP, NYISO), fiber routes, energy pricing.
- **License:** Free to cite (CC-BY-4.0).
- **Existing distribution:** In the official MCP registry; indexed by mcp.so, Glama, PulseMCP. Compatible with Claude, Cursor, Cline, and other MCP clients.

## Why this list
Closes a real gap — there is no other MCP server covering data-center / power-market intelligence at this scope. Existing entries cover finance, dev tools, search, and general data, but not infrastructure.

Generated by https://github.com/azmartone67/dchub-backend/.github/workflows/awesome-mcp-pr.yml