### PR TITLE
Add FavCRM 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Provides access to customer profiles inside of customer data platforms
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
 - [lionkiii/google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) [![google-searchconsole-mcp MCP server](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp) 📇 🏠 - Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.
 - [saurabhsharma2u/search-console-mcp](https://github.com/saurabhsharma2u/search-console-mcp)  - An MCP server to interact with Google Search Console and Bing Webmasters.
+- [favcrm/mcp](https://github.com/favcrm/mcp) 🎖️ 📇 ☁️ - Agentic CRM for service businesses: bookings, customers, WhatsApp/SMS/email, loyalty and invoicing via 190+ typed, annotated MCP tools. Agentic registration (sign up from inside the agent), approval-gated sends, free tier.
 
 ### 🗄️ <a name="databases"></a>Databases
 


### PR DESCRIPTION
Adds **FavCRM** under **Customer Data Platforms**.

[favcrm/mcp](https://github.com/favcrm/mcp) — an agentic CRM for service businesses with a public, hosted MCP server (`https://api.favcrm.io/mcp`): bookings, customers, WhatsApp/SMS/email, loyalty and invoicing via 190+ typed, annotated MCP tools (read-only/destructive labelled, approval-gated sends). Official implementation, TypeScript, cloud-hosted → 🎖️ 📇 ☁️.

- One server per line, in the Customer Data Platforms section ✅
- Repo-linked, concise description, no fabricated metrics ✅

🤖🤖🤖