### PR TITLE
Add World Cup 2026 Tour MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🌐 - [Social Media](#social-media)
 * 🔮 - [Spirituality & Esoterica](#spirituality-and-esoterica)
 * 🏃 - [Sports](#sports)
+- [abaiii168/world-cup-2026-mcp-server](https://github.com/abaiii168/world-cup-2026-mcp-server) 📇 ☁️ 🏠 🍎 🪟 🐧 - Free MCP server for the World Cup 2026 Tour public schedule API. Fetch all 104 fixtures, the next match, one match by id, and Dataset JSON-LD in local time zones. No API key required.
 - [zafronix/wc-mcp](https://github.com/zafronix/wc-mcp) [![World Cup History MCP server](https://glama.ai/mcp/servers/zafronix/wc-mcp/badges/score.svg)](https://glama.ai/mcp/servers/zafronix/wc-mcp) 📇 🏠 ☁️ 🍎 🪟 🐧 - Every FIFA World Cup since 1930. 23 tournaments, full squads, knockout brackets, stadium altitudes, hat-tricks. Free tier API.
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)


### PR DESCRIPTION
Adds a free Sports MCP server for the World Cup 2026 Tour public schedule API.\n\nRepository: https://github.com/abaiii168/world-cup-2026-mcp-server\n\nWhat it provides:\n- all 104 World Cup 2026 fixtures\n- next match\n- one match by id\n- Dataset JSON-LD\n- IANA local-time conversion through the public API\n- no API key required\n\nValidation run in the MCP server repo:\n- npm install\n- npm run check\n- smoke test starts the stdio server, initializes MCP, lists 5 tools, and calls get_world_cup_2026_matches against the production API.