### PR TITLE
Add Bareun (Korean NLP / spell & grammar checker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🎯 - [Marketing](#marketing)
 * 📊 - [Monitoring](#monitoring)
 * 🎥 - [Multimedia Process](#multimedia-process)
+* ✍️ - [Natural Language Processing](#natural-language-processing)
 * 🖥️ - [OS Automation](#os-automation)
 * 📋 - [Product Management](#product-management)
 * 🏠 - [Real Estate](#real-estate)
@@ -2148,6 +2149,12 @@ Provides the ability to handle multimedia, such as audio and video editing, play
 - [video-edit-mcp](https://github.com/Aditya2755/video-edit-mcp) 🐍 🏠 🍎 🪟 - Comprehensive video and audio editing MCP server with advanced operations including trimming, merging, effects, overlays, format conversion, audio processing, YouTube downloads, and smart memory management for chaining operations without intermediate files
 - [TopazLabs/topaz-mcp](https://github.com/TopazLabs/topaz-mcp) 📇 ☁️ 🍎 🪟 🐧 - AI image enhancement (upscaling, denoising, sharpening) via Topaz Labs API. Supports 8 models including Standard V2, Wonder 2, Bloom, and Recover 3.
 - [verIdyia/autoeq-mcp](https://github.com/verIdyia/autoeq-mcp) [![autoeq-mcp MCP server](https://glama.ai/mcp/servers/verIdyia/autoeq-mcp/badges/score.svg)](https://glama.ai/mcp/servers/verIdyia/autoeq-mcp) 🐍 🏠 🍎 🪟 🐧 - Headphone/IEM equalization database with 8,800+ models from AutoEQ. Search by name or sound signature, get parametric EQ settings, compare headphones band-by-band, and browse Harman preference score rankings. Includes automatic sound signature classification (Neutral, Warm, Bright, Dark, V-shaped, etc.).
+
+### ✍️ <a name="natural-language-processing"></a>Natural Language Processing
+
+Morphological analysis, tokenization, part-of-speech tagging, and spell/grammar checking for natural-language text.
+
+- [gih2yun/bareun-mcp](https://github.com/gih2yun/bareun-mcp) 🎖️ 🏎️ ☁️ - Korean morphological analysis (POS tagging, tokenization) and spelling/spacing/grammar correction via the Bareun (바른) API. Hosted streamable-HTTP MCP server at https://api.bareun.ai/mcp (API-key auth).
 
 ### 🖥️ <a name="os-automation"></a>OS Automation
 


### PR DESCRIPTION
Adds **Bareun** — a Korean NLP / spell & grammar checking MCP server — under a new **Natural Language Processing** category.

- **Repo:** https://github.com/gih2yun/bareun-mcp
- **Type:** hosted, remote **Streamable HTTP** MCP server (`https://api.bareun.ai/mcp`), API-key auth. Official implementation by the Bareun (바른) team.
- **Tools:** `analyze_syntax` (POS tagging), `tokenize`, `correct_grammar` (spelling/spacing/grammar), `list_pos_tags`.

There was no existing Text/NLP/proofreading category (closest were Translation Services / Other), so I added a `Natural Language Processing` category in alphabetical position (between Multimedia Process and OS Automation), plus the matching Contents entry.

Notes:
- Glama score badge omitted for now — the server was just published to the official MCP registry and Glama hasn't indexed it yet; happy to add the badge once it's available.
- Entry uses the standard legend: 🎖️ official · 🏎️ Go · ☁️ cloud/remote.