### PR TITLE
Add ai-divination-skills under Spirituality & Esoterica 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2566,6 +2566,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools — for AI agents that compute charts, draw cards, run dasha cycles, or generate horoscopes.
 
 - [astroway/astroway-mcp](https://github.com/astroway/astroway-mcp) [![astroway/astroway-mcp MCP server](https://glama.ai/mcp/servers/astroway/astroway-mcp/badges/score.svg)](https://glama.ai/mcp/servers/astroway/astroway-mcp) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive astrology MCP exposing every endpoint of the AstroWay Calculation API — natal charts, synastry, transits, Vedic dashas (Vimshottari, Yogini, Ashtottari, Kalachakra), 16 Vargas, Tarot (Rider-Waite-Smith / Marseille / Lenormand), Numerology (5 systems), Human Design, AI horoscopes. Sub-arcsecond Swiss Ephemeris precision, 10 000 free credits/month. Install: `npx @astroway/mcp`.
+- [sapuyou45-bit/ai-divination-skills](https://github.com/sapuyou45-bit/ai-divination-skills) 🐍 🏠 🍎 🪟 🐧 - Audited tarot, I Ching, and Xiao Liu Ren divination tools. The MCP server runs local seeded-or-system-entropy scripts that produce the draw or cast; the model never invents the result, it only interprets the JSON output. `pip install ai-divination-skills` then mount `ai-divination-mcp` in claude_desktop_config.json.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
Adds [sapuyou45-bit/ai-divination-skills](https://github.com/sapuyou45-bit/ai-divination-skills) — an MCP server (`ai-divination-mcp`) that exposes audited tarot, I Ching, and Xiao Liu Ren divination tools.

Key methodology: scripts (with system entropy by default) produce the draw / hexagram / position. The model never invents the result; it only interprets the JSON output.

- 🐍 Python codebase
- 🏠 Local service, 🍎 🪟 🐧 — pure stdlib MCP server, zero third-party deps
- On PyPI: `pip install ai-divination-skills` → exposes `ai-divination-mcp` console script
- 61 tests across Python 3.9–3.12, CodeQL, lychee link-check all green
- License: MIT
- Closes the gap for "Asian symbolic systems" (I Ching, Xiao Liu Ren) in the Spirituality & Esoterica section

Per CONTRIBUTING.md I've kept alphabetical order (astroway → sapuyou45-bit). Title tagged 🤖🤖🤖 to opt-in to the automated-agent fast-track.