### PR TITLE
feat: add nozio-mcp (AI-native workspace server) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2863,6 +2863,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [nanana-app/mcp-server-nano-banana](https://github.com/nanana-app/mcp-server-nano-banana) 🐍 🏠 🍎 🪟 🐧 - AI image generation using Google Gemini's nano banana model.
 - [nguyenvanduocit/all-in-one-model-context-protocol](https://github.com/nguyenvanduocit/all-in-one-model-context-protocol) 🏎️ 🏠 - Some useful tools for developer, almost everything an engineer need: confluence, Jira, Youtube, run script, knowledge base RAG, fetch URL, Manage youtube channel, emails, calendar, gitlab
 - [NON906/omniparser-autogui-mcp](https://github.com/NON906/omniparser-autogui-mcp) - 🐍 Automatic operation of on-screen GUI.
+- [nozio-mcp](https://github.com/bedda-tech/nozio) 📇 ☁️ - AI-native workspace MCP server. Exposes Nozio documents, app pages, and REST API to AI agents.
 - [offorte/offorte-mcp-server](https://github.com/offorte/offorte-mcp-server) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - The Offorte Proposal Software MCP server enables creation and sending of business proposals.
 - [olalonde/mcp-human](https://github.com/olalonde/mcp-human) 📇 ☁️ - When your LLM needs human assistance (through AWS Mechanical Turk)
 - [olgasafonova/productplan-mcp-server](https://github.com/olgasafonova/productplan-mcp-server) 🏎️ ☁️ - Query ProductPlan roadmaps. Access OKRs, ideas, launches, and timeline data.


### PR DESCRIPTION
## Summary

Adds [nozio-mcp](https://github.com/bedda-tech/nozio) to the **Workplace & Productivity** section.

nozio-mcp is the MCP adapter for [Nozio](https://nozio.vercel.app) — an AI-native workspace where every page is a custom-generated app. The MCP server exposes Nozio documents, app pages, and REST API to AI agents, enabling agents to read, create, update, and query workspace content.

**Entry added:**
```
- [nozio-mcp](https://github.com/bedda-tech/nozio) 📇 ☁️ - AI-native workspace MCP server. Exposes Nozio documents, app pages, and REST API to AI agents.
```

Added in alphabetical order after `NON906/omniparser-autogui-mcp` (no < noz).