### PR TITLE
Add Unyly — MCP servers catalog (15k+ entries, 1-click install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
 * [Unyly](https://unyly.org) - 15,000+ MCP servers catalog with one-click install for Claude Desktop, Claude Code, Cursor, and VS Code. Semantic search, security audit, free.
+* [Unyly](https://unyly.org) - 15,000+ MCP servers catalog with one-click install for Claude Desktop, Claude Code, Cursor, and VS Code. Semantic search, security audit, free.
 
 ## Legend
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
+* [Unyly](https://unyly.org) - 15,000+ MCP servers catalog with one-click install for Claude Desktop, Claude Code, Cursor, and VS Code. Semantic search, security audit, free.
 
 ## Legend
 


### PR DESCRIPTION
Adding [Unyly](https://unyly.org) to the Community section.

## What it is

Unyly is a catalog of 15,000+ MCP servers indexed from multiple public sources (Smithery, PulseMCP, Glama, npm, the Official MCP Registry, community submissions). Key features:

- **One-click install**: detects your client (Claude Desktop, Claude Code, Cursor, VS Code Cline) and generates the right config block — solves the "MCP install is JSON-config hell" pain.
- **Semantic search**: "I need something to read my Notion pages" finds the right server without knowing the exact name.
- **Per-MCP security audit**: env vars from README, permission scope, dependency hygiene, repo health.
- **Real install counts**: actual button-click counts, not GitHub stars or npm downloads.
- **Free tier**: unlimited self-hosted installs, no registration required to browse the catalog.

## Why include in this list

This is the Community section — already lists r/mcp + Discord Server. Unyly is a similar resource: a public discovery + install tool for the MCP ecosystem, not a competitor to specific server implementations.

The catalog pulls from sources already linked in the repo (Smithery, Glama), aggregates them, and adds the install UX layer. We send users back to the original source on every listing.

Happy to update the description if anything needs adjusting!