### PR TITLE
Add FoundryNet Forge (forge-mcp) — Embedded System

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 - [catallo/misterclaw](https://github.com/catallo/misterclaw) [![catallo/misterclaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/score.svg)](https://glama.ai/mcp/servers/catallo/misterclaw) 🏎️ 📟 🏠 🐧 🍎 - MiSTerClaw — MCP remote control for MiSTer-FPGA. Launch games, search ROMs, take screenshots, manage systems, and set up Tailscale VPN. Auto-discovers 70+ systems with dynamic core/ROM scanning.
+- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ 📟 🎖️ - Cross-OEM industrial machine intelligence — normalize and query machine telemetry across Fanuc, Siemens, Haas, DMG Mori, and Mazak through one schema. 14 tools for telemetry normalization, coverage lookup, and edge attestation.
 
 ### 🎓 <a name="education"></a>Education
 

--- a/README.md
+++ b/README.md
@@ -1316,7 +1316,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 - [catallo/misterclaw](https://github.com/catallo/misterclaw) [![catallo/misterclaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/score.svg)](https://glama.ai/mcp/servers/catallo/misterclaw) 🏎️ 📟 🏠 🐧 🍎 - MiSTerClaw — MCP remote control for MiSTer-FPGA. Launch games, search ROMs, take screenshots, manage systems, and set up Tailscale VPN. Auto-discovers 70+ systems with dynamic core/ROM scanning.
-- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ 📟 🎖️ - Cross-OEM industrial machine intelligence — normalize and query machine telemetry across Fanuc, Siemens, Haas, DMG Mori, and Mazak through one schema. 14 tools for telemetry normalization, coverage lookup, and edge attestation.
+- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp) 🐍 ☁️ 📟 🎖️ - Cross-OEM industrial machine intelligence — normalize and query machine telemetry across Fanuc, Siemens, Haas, DMG Mori, and Mazak through one schema. 14 tools for telemetry normalization, coverage lookup, and edge attestation.
 
 ### 🎓 <a name="education"></a>Education
 


### PR DESCRIPTION
Adds **FoundryNet/forge-mcp**, the official MCP server for FoundryNet Forge — cross-OEM industrial machine intelligence.

It normalizes and queries machine telemetry across different OEM controllers (Fanuc, Siemens, Haas, DMG Mori, Mazak) through one schema, with 14 tools for telemetry normalization, coverage lookup, and edge attestation. Placed in **📟 Embedded System**, alongside the existing industrial `modbus-mcp`/`opcua-mcp` servers.

- Python, hosted/remote (with an optional edge/Greengrass kernel)
- Public repo with README; link verified
- 🎖️ official: first-party implementation of the FoundryNet Forge service

One server per PR (companion PR adds MINT Protocol to 🔒 Security).