### PR TITLE
Add Python MCP Masterclass to Tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [Python MCP Masterclass](https://github.com/ryanboscobanze/python-mcp-masterclass) - Official python-sdk examples restructured into paired server/client files, one runnable pattern per folder
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
-* [Python MCP Masterclass](https://github.com/ryanboscobanze/python-mcp-masterclass) - Official python-sdk examples restructured into paired server/client files, one runnable pattern per folder
+* [ryanboscobanze/python-mcp-masterclass](https://github.com/ryanboscobanze/python-mcp-masterclass) - Official python-sdk examples restructured into paired server/client teaching files, one runnable pattern per folder
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
-* [ryanboscobanze/python-mcp-masterclass](https://github.com/ryanboscobanze/python-mcp-masterclass) - Official python-sdk examples restructured into paired server/client teaching files, one runnable pattern per folder
+* [ryanboscobanze/python-mcp-masterclass](https://github.com/ryanboscobanze/python-mcp-masterclass) - 🐍 🏠 Official python-sdk examples restructured into paired server/client teaching files, one runnable pattern per folder
 
 ## Community
 


### PR DESCRIPTION
Adds a tutorial repo to the Tutorials section: the official MCP python-sdk examples restructured into paired server.py/client.py files, one runnable pattern per folder (tools, resources, sampling, elicitation, low-level API, tasks). MIT licensed. I am the author of the linked repo.