### PR TITLE
Add gethumandesign (Human Design) server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2632,7 +2632,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools — for AI agents that compute charts, draw cards, run dasha cycles, or generate horoscopes.
 
 - [astroway/astroway-mcp](https://github.com/astroway/astroway-mcp) [![astroway/astroway-mcp MCP server](https://glama.ai/mcp/servers/astroway/astroway-mcp/badges/score.svg)](https://glama.ai/mcp/servers/astroway/astroway-mcp) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive astrology MCP exposing every endpoint of the AstroWay Calculation API — natal charts, synastry, transits, Vedic dashas (Vimshottari, Yogini, Ashtottari, Kalachakra), 16 Vargas, Tarot (Rider-Waite-Smith / Marseille / Lenormand), Numerology (5 systems), Human Design, AI horoscopes. Sub-arcsecond Swiss Ephemeris precision, 10 000 free credits/month. Install: `npx @astroway/mcp`.
-- [gethumandesign](https://www.gethumandesign.com/mcp-docs/) 🎖️ ☁️ - Calculate Human Design bodygraph charts from birth data, save people, compare charts, and analyse group dynamics. Hosted remote server (Streamable HTTP, OAuth 2.0) at `https://api.gethumandesign.com/mcp`, listed in the official MCP registry as `com.gethumandesign.www/mcp`.
+- [timvink/mcp-gethumandesign](https://github.com/timvink/mcp-gethumandesign) 🎖️ ☁️ - Calculate Human Design bodygraph charts from birth data, save people, compare charts, and analyse group dynamics. Hosted remote server (Streamable HTTP, OAuth 2.0) at `https://api.gethumandesign.com/mcp`, listed in the official MCP registry as `com.gethumandesign.www/mcp`.
 
 ### 🏃 <a name="sports"></a>Sports
 

--- a/README.md
+++ b/README.md
@@ -2632,6 +2632,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools — for AI agents that compute charts, draw cards, run dasha cycles, or generate horoscopes.
 
 - [astroway/astroway-mcp](https://github.com/astroway/astroway-mcp) [![astroway/astroway-mcp MCP server](https://glama.ai/mcp/servers/astroway/astroway-mcp/badges/score.svg)](https://glama.ai/mcp/servers/astroway/astroway-mcp) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive astrology MCP exposing every endpoint of the AstroWay Calculation API — natal charts, synastry, transits, Vedic dashas (Vimshottari, Yogini, Ashtottari, Kalachakra), 16 Vargas, Tarot (Rider-Waite-Smith / Marseille / Lenormand), Numerology (5 systems), Human Design, AI horoscopes. Sub-arcsecond Swiss Ephemeris precision, 10 000 free credits/month. Install: `npx @astroway/mcp`.
+- [gethumandesign](https://www.gethumandesign.com/mcp-docs/) 🎖️ ☁️ - Calculate Human Design bodygraph charts from birth data, save people, compare charts, and analyse group dynamics. Hosted remote server (Streamable HTTP, OAuth 2.0) at `https://api.gethumandesign.com/mcp`, listed in the official MCP registry as `com.gethumandesign.www/mcp`.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
Adds **gethumandesign** to the 🔮 Spirituality & Esoterica section (which already lists Human Design in its description), in alphabetical order.

- Hosted remote MCP server (Streamable HTTP, OAuth 2.0) at `https://api.gethumandesign.com/mcp`
- Listed in the official MCP registry as `com.gethumandesign.www/mcp`
- Entry links to the docs page: https://www.gethumandesign.com/mcp-docs/
- Markers: 🎖️ official implementation, ☁️ cloud service (talks to a remote API; no local install)
- Functionality: calculate Human Design bodygraph charts from birth data, save people, compare charts, and analyse group dynamics

🤖 Generated with [Claude Code](https://claude.com/claude-code)