### PR TITLE
Add Airlock — local coordination daemon for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Yang1Bai/claw-tsaver](https://github.com/Yang1Bai/claw-tsaver)__ 🐍 🏠 🍎 🪟 🐧 - Token-saving MCP proxy that intercepts oversized tool returns and replaces them with a preview + on-demand handle. Real benchmark: 11,507 tokens → 104 tokens (99.1% saved) on a Wikipedia fetch. Works with OpenClaw + Claude.
 - [childrentime/reactuse](https://github.com/childrentime/reactuse) [![childrentime/reactuse MCP server](https://glama.ai/mcp/servers/childrentime/reactuse/badges/score.svg)](https://glama.ai/mcp/servers/childrentime/reactuse) 📇 🏠 🍎 🪟 🐧 - MCP server for the [ReactUse](https://reactuse.com) library — 110+ React Hooks (TypeScript-first, SSR-compatible, tree-shakable). Lets AI assistants discover hook signatures, demos, and usage patterns directly from the docs.
+- [adamorad/airlock](https://github.com/adamorad/airlock) 🏎️ 🏠 🍎 🐧 - Local always-on daemon that gives AI agents named locks (with blocking waits), atomic shared state, presence, events, and a task queue over MCP, so multiple agents working on one machine coordinate instead of stomping on each other.
   
 ### 🧮 <a name="data-science-tools"></a>Data Science Tools
 


### PR DESCRIPTION
Adds [Airlock](https://github.com/adamorad/airlock): an MIT-licensed local always-on daemon that gives AI agents named locks (with blocking waits), atomic shared state, presence, events, and a task queue over MCP — so multiple agents on one machine coordinate instead of stomping on each other.

- Single Go binary, zero runtime deps, pure-Go SQLite
- Cross-platform: macOS + Linux
- Speaks MCP over HTTP on 127.0.0.1:27183; works with any MCP client

Added under **Developer Tools** (appended to the end of the section), legend 🏎️ Go · 🏠 Local · 🍎 macOS · 🐧 Linux.