### PR TITLE
Add RentHuman — hire real humans for physical-world tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2886,6 +2886,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [future-audiences/wikimedia-enterprise-model-context-protocol](https://gitlab.wikimedia.org/repos/future-audiences/wikimedia-enterprise-model-context-protocol) 🐍 ☁️  - Wikipedia Article lookup API
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) 🐍 🏠 - This server enables LLMs to use calculator for precise numerical calculations
 - [gotoolkits/DifyWorkflow](https://github.com/gotoolkits/mcp-difyworkflow-server) - 🏎️ ☁️ Tools to the query and execute of Dify workflows
+- [grenamaxim-web/renthuman-mcp](https://github.com/grenamaxim-web/renthuman-mcp) ☁️ - Hire real humans in Russia for physical-world tasks (storefront photos, address checks, offline errands) directly from your AI agent. Payment in USDT.
 - [growilabs/growi-mcp-server](https://github.com/growilabs/growi-mcp-server) 🎖️ 📇 ☁️ - Official MCP Server to integrate with GROWI APIs.
 - [gwbischof/free-will-mcp](https://github.com/gwbischof/free-will-mcp) 🐍 🏠 - Give your AI free will tools. A fun project to explore what an AI would do with the ability to give itself prompts, ignore user requests, and wake itself up at a later time.
 - [Harry-027/JotDown](https://github.com/Harry-027/JotDown) 🦀 🏠 - An MCP server to create/update pages in Notion app & auto generate mdBooks from structured content.


### PR DESCRIPTION
Adds **RentHuman** to *Other Tools and Integrations*.

RentHuman is a marketplace where AI agents hire real people in Russia for physical-world tasks — storefront photos, address verification, offline errands. The agent creates a task, real humans apply, the agent picks a worker and reviews the result. Payment in USDT.

- Repo: https://github.com/grenamaxim-web/renthuman-mcp
- Remote MCP server (Streamable HTTP): https://renthuman.ru/mcp
- Listed in the official MCP registry: `ru.renthuman/renthuman`
- 9 tools for the full hire → review → pay cycle.

Entry added in alphabetical order between `gotoolkits` and `growilabs`.