### PR TITLE
Add hearsay to Speech-to-Text 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2682,6 +2682,7 @@ Translation tools and services to enable AI assistants to translate content betw
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 
 - [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) [![eviscerations/whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
+- [mudassar531/hearsay](https://github.com/mudassar531/hearsay) 🐍 🏠 - One command turns any YouTube video, podcast episode, or local recording into clean, timestamped, LLM-ready markdown — captions-first with local Whisper fallback. MCP tools: ingest_url, ingest_file.
 - [spokenmd/spoken](https://github.com/spokenmd/spoken) [![spokenmd/spoken MCP server](https://glama.ai/mcp/servers/spokenmd/spoken/badges/score.svg)](https://glama.ai/mcp/servers/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech


### PR DESCRIPTION
Adds **[hearsay](https://github.com/mudassar531/hearsay)** to the **Speech-to-Text** category.

hearsay is an open-source CLI + **local stdio MCP server** (Python, MIT) that turns any YouTube video, podcast episode, or local recording into clean, timestamped, LLM-ready markdown. It's captions-first (fast, no download) with an automatic local **faster-whisper** fallback. The MCP server exposes two tools — `ingest_url(url, transcribe?, lang?)` and `ingest_file(path)` — each returning markdown.

- Repo: https://github.com/mudassar531/hearsay
- PyPI: https://pypi.org/project/hearsay/

Checklist:
- [x] Placed under the relevant category (Speech-to-Text)
- [x] Alphabetical order within the category (between `eviscerations/...` and `spokenmd/...`)
- [x] Format matches existing entries (🐍 Python, 🏠 local), one server per line
- [x] Concise description

_PR prepared by an automated agent on the maintainer's behalf._