### PR TITLE
Add laszlopere/mcp-bytesmith 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ Tools for building and operating AI conversation agents that hold structured dia
 Tools for encrypting and decrypting data.
 
 - [denismaggior8/enigma-python-mcp](https://github.com/denismaggior8/enigma-python-mcp) [![denismaggior8/enigma-python-mcp MCP server](https://glama.ai/mcp/servers/denismaggior8/enigma-python-mcp/badges/score.svg)](https://glama.ai/mcp/servers/denismaggior8/enigma-python-mcp) 🐍 ☁️ 🏠 🍎 🪟 🐧 - A Model Context Protocol server that brings the capabilities of [enigmapython](https://github.com/denismaggior8/enigma-python) library to LLMs, allowing them to encrypt and decrypt messages using historically accurate Enigma machine emulators.
+- [laszlopere/mcp-bytesmith](https://github.com/laszlopere/mcp-bytesmith) [![laszlopere/mcp-bytesmith MCP server](https://glama.ai/mcp/servers/laszlopere/mcp-bytesmith/badges/score.svg)](https://glama.ai/mcp/servers/laszlopere/mcp-bytesmith) 🐍 🏠 - Local byte-wrangling toolbox: encoding (hex/Base64/Base32/Base58/Base45…), cryptographic + CRC hashing, base conversion, and CSPRNG tokens/passphrases, plus an opt-in Ethereum/EVM toolset (keccak, ABI/RLP codecs, EIP-191/712 hashing, function/event selectors, EIP-55). No network calls. `uvx mcp-bytesmith`.
 
 
 ### 👤 <a name="customer-data-platforms"></a>Customer Data Platforms


### PR DESCRIPTION
Adds a single server to the **🔑 Cryptography** section.

- Listed and graded **A** on Glama; score badge included in the entry.
- Local/offline MCP server, MIT/GPL licensed, with a clear one-line description and install command.

(Re-submitting one-server-per-PR after the bundled PRs #7921 / #8057 were closed by triage. This PR contains exactly one server.)