### PR TITLE
Add Familiar Tarot to Spirituality & Esoterica 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2695,6 +2695,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools — for AI agents that compute charts, draw cards, run dasha cycles, or generate horoscopes.
 
 - [astroway/astroway-mcp](https://github.com/astroway/astroway-mcp) [![astroway/astroway-mcp MCP server](https://glama.ai/mcp/servers/astroway/astroway-mcp/badges/score.svg)](https://glama.ai/mcp/servers/astroway/astroway-mcp) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive astrology MCP exposing every endpoint of the AstroWay Calculation API — natal charts, synastry, transits, Vedic dashas (Vimshottari, Yogini, Ashtottari, Kalachakra), 16 Vargas, Tarot (Rider-Waite-Smith / Marseille / Lenormand), Numerology (5 systems), Human Design, AI horoscopes. Sub-arcsecond Swiss Ephemeris precision, 10 000 free credits/month. Install: `npx @astroway/mcp`.
+- [Familiar Tarot](https://familiartarot.com) 📇 ☁️ - Tarot across multiple decks (Rider–Waite–Smith, Marseille) with a real shuffle, cut, and draw — actual card art, upright or reversed, then a reading you talk through. Hosted remote server at mcp.familiartarot.com; works in Claude, ChatGPT (developer mode), and other MCP clients.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
Adds **Familiar Tarot** under 🔮 Spirituality & Esoterica (alphabetically, after `astroway`).

A hosted remote MCP server for tarot — a real shuffle, cut, and draw across multiple decks (Rider–Waite–Smith and a public-domain Tarot de Marseille), with actual card art and upright/reversed orientation, then a reading you talk through. Endpoint `mcp.familiartarot.com`; works in Claude, ChatGPT (developer mode), and other MCP clients.

It's a closed-source hosted service, so the entry links to the project site — consistent with the other hosted-service entries in the list.

- 📇 TypeScript · ☁️ Cloud Service
- One server, one line; category kept in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)