### PR TITLE
Add llmtrim to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,6 +1269,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [laszlopere/mcp-abacus](https://github.com/laszlopere/mcp-abacus) [![laszlopere/mcp-abacus MCP server](https://glama.ai/mcp/servers/laszlopere/mcp-abacus/badges/score.svg)](https://glama.ai/mcp/servers/laszlopere/mcp-abacus) 🐍 🏠 🍎 🐧 - Type-faithful calculator: evaluate expressions under fixed-point, IEEE-754 double, or exact rational arithmetic, with every answer labelled exact vs inexact. Tools: calculate, analyze, solver, help, info. Offline, no network. `uvx mcp-abacus`.
 
 - [joaoh82/rustunnel](https://github.com/joaoh82/rustunnel) [![joaoh82/rustunnel MCP server](https://glama.ai/mcp/servers/joaoh82/rustunnel/badges/score.svg)](https://glama.ai/mcp/servers/joaoh82/rustunnel) 🦀 🏠 ☁️ - MCP server that lets AI agents create and manage public tunnels to local services (webhooks, dev servers, sharing) — six tools covering HTTP/TCP/UDP tunnels, custom subdomains, regions, and load-balanced pools. Pairs with the rustunnel CLI; managed cloud or self-hosted (AGPL).
+- [fkiene/llmtrim](https://github.com/fkiene/llmtrim) 🦀 🏠 🍎 🪟 🐧 - Compresses LLM prompts, tool outputs, and replies to cut token costs. Three tools: `llmtrim_compress` (shrink a full request body, honoring your config), `llmtrim_compress_text` (lossless text compression), and `llmtrim_stats` (savings ledger). Quality-gated so it never raises the bill; -31% input and -74% output tokens across 112 live A/B cases. Self-hosted, AGPL.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [llmtrim](https://github.com/fkiene/llmtrim) under **Developer Tools**.

llmtrim is a self-hosted MCP server (also a proxy, CLI, and library) that compresses LLM prompts, tool outputs, and replies to cut token costs. It exposes three tools:

- `llmtrim_compress` — compress a full request body, honoring your `~/.llmtrim` config
- `llmtrim_compress_text` — lossless compression of a single text blob
- `llmtrim_stats` — your savings ledger

Every compression step is re-measured with the provider's tokenizer and reverted if it does not save, and the cached prefix is never rewritten, so it cannot raise your bill. Measured -31% input and -74% output tokens across 112 live A/B cases.

- Rust, self-hosted/local (tagged 🦀 🏠 🍎 🪟 🐧).
- Open source (AGPL-3.0).