### PR TITLE
Add Ambix to Product Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2297,6 +2297,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 - [spranab/saga-mcp](https://github.com/spranab/saga-mcp) [![saga-mcp MCP server](https://glama.ai/mcp/servers/@spranab/saga-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@spranab/saga-mcp) 📇 🏠 🍎 🪟 🐧 - A Jira-like project tracker for AI agents with full hierarchy (Projects > Epics > Tasks > Subtasks), task dependencies with auto-block/unblock, threaded comments, reusable templates, activity logging, and a natural language dashboard. SQLite-backed, 31 tools.
 - [agrath/Trello-Desktop-MCP](https://github.com/agrath/Trello-Desktop-MCP) [![agrath/Trello-Desktop-MCP MCP server](https://glama.ai/mcp/servers/agrath/Trello-Desktop-MCP/badges/score.svg)](https://glama.ai/mcp/servers/agrath/Trello-Desktop-MCP) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive Trello integration: 46 tools covering boards, cards, lists, labels, checklists, attachments, members, custom fields, and search. Read-only mode, image attachment
 auto-download. Install via `npx atlassian-trello-mcp`.
+- [Ambix](https://ambix.ai) 🎖️ 🏎️ ☁️ - Shared strategic product memory for product teams, served as a remote MCP server. Connects Claude to your Ambix workspace — strategy, initiatives, objectives, opportunities, journey stages and decisions — so the team reasons over its full product context in conversation. Hosted at `https://mcp.ambix.ai`.
 
 ### 🏠 <a name="real-estate"></a>Real Estate
 


### PR DESCRIPTION
Adds **Ambix** under **Product Management**.

Ambix is a shared strategic product-memory layer for product teams, served as a remote MCP server (`https://mcp.ambix.ai`, Streamable HTTP). It connects Claude to a team's Ambix workspace — strategy, initiatives, objectives, opportunities, journey stages and decisions — so the team can reason over its full product context in conversation.

- Listed on the official MCP Registry as `ai.ambix/ambix`.
- Also on [Glama](https://glama.ai/mcp/connectors/ai.ambix.mcp/ambix-ai-product-management) (ownership-verified) and [Smithery](https://smithery.ai/servers/ambix/ambix).

Legend: 🎖️ official · 🏎️ Go · ☁️ cloud service.