### PR TITLE
Add OpenFate Bazi MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2745,6 +2745,7 @@ Integration with social media platforms to allow posting, analytics, and interac
 Astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools — for AI agents that compute charts, draw cards, run dasha cycles, or generate horoscopes.
 
 - [astroway/astroway-mcp](https://github.com/astroway/astroway-mcp) [![astroway/astroway-mcp MCP server](https://glama.ai/mcp/servers/astroway/astroway-mcp/badges/score.svg)](https://glama.ai/mcp/servers/astroway/astroway-mcp) 📇 ☁️ 🍎 🪟 🐧 - Comprehensive astrology MCP exposing every endpoint of the AstroWay Calculation API — natal charts, synastry, transits, Vedic dashas (Vimshottari, Yogini, Ashtottari, Kalachakra), 16 Vargas, Tarot (Rider-Waite-Smith / Marseille / Lenormand), Numerology (5 systems), Human Design, AI horoscopes. Sub-arcsecond Swiss Ephemeris precision, 10 000 free credits/month. Install: `npx @astroway/mcp`.
+- [openfate-ai/bazi-mcp](https://github.com/openfate-ai/bazi-mcp) [![openfate-ai/bazi-mcp MCP server](https://glama.ai/mcp/servers/openfate-ai/bazi-mcp/badges/score.svg)](https://glama.ai/mcp/servers/openfate-ai/bazi-mcp) 📇 🏠 🍎 🪟 🐧 - Deterministic Bazi / Four Pillars MCP server with True Solar Time, lunar/solar conversion, Da Yun luck cycles, branch interactions, reverse Bazi lookup, and OpenFate calculation metadata. Install: `npx -y @openfate/bazi-mcp`.
 
 ### 🏃 <a name="sports"></a>Sports
 


### PR DESCRIPTION
Adds OpenFate Bazi MCP to the Spirituality & Esoterica section.

Repository:
https://github.com/openfate-ai/bazi-mcp

Package:
https://www.npmjs.com/package/@openfate/bazi-mcp

Install:
npx -y @openfate/bazi-mcp

The server provides deterministic Bazi / Four Pillars calculations with True Solar Time, lunar/solar conversion, Da Yun luck cycles, branch interactions, reverse Bazi lookup, and OpenFate calculation metadata.