### PR TITLE
Add FoundryNet Forge (forge-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [0x1abin/matter-controller-mcp](https://github.com/0x1abin/matter-controller-mcp) 📇 📟 - An MCP server for Matter Controller, enabling AI agents to control and interact with Matter devices.
 - [adancurusul/embedded-debugger-mcp](https://github.com/adancurusul/embedded-debugger-mcp) 🦀 📟 - A Model Context Protocol server for embedded debugging with probe-rs - supports ARM Cortex-M, RISC-V debugging via J-Link, ST-Link, and more
 - [adancurusul/serial-mcp-server](https://github.com/adancurusul/serial-mcp-server) 🦀 📟 - A comprehensive MCP server for serial port communication
+- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp) 🐍 ☁️ 📟 🎖️ - Cross-OEM industrial telemetry normalization, runtime kernel, and machine identity for industrial equipment. 18 OEM families, 189 canonical fields. 5 tools.
 - [horw/esp-mcp](https://github.com/horw/esp-mcp) 📟 - Workflow for fixing build issues in ESP32 series chips using ESP-IDF.
 - [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp) 🐍 📟 - An MCP server that standardizes and contextualizes industrial Modbus data.
 - [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp) 🐍 📟 - An MCP server that connects to OPC UA-enabled industrial systems.


### PR DESCRIPTION
Adds **FoundryNet Forge** (`FoundryNet/forge-mcp`) to the Embedded System section.

Cross-OEM industrial telemetry normalization, a runtime kernel, and machine identity for industrial equipment — 18 OEM families, 189 canonical fields, 5 tools. Live, MIT-licensed, and published to the official MCP registry as `io.github.FoundryNet/forge-mcp`.

Note: this restores an entry from PR #7868 (merged 2026-06-15) that was later dropped from main during a subsequent merge. One server per PR per contributing guidelines.