### PR TITLE
Add conorbronsdon/podcastindex-mcp to Podcasts 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2525,6 +2525,7 @@ Servers for controlling the desktop operating system: screenshots, window manage
 Servers for podcast analytics, search, hosting, and discovery.
 
 - [conorbronsdon/op3-mcp](https://github.com/conorbronsdon/op3-mcp) [![conorbronsdon/op3-mcp MCP server](https://glama.ai/mcp/servers/conorbronsdon/op3-mcp/badges/score.svg)](https://glama.ai/mcp/servers/conorbronsdon/op3-mcp) 📇 ☁️ - Podcast analytics from OP3, the Open Podcast Prefix Project: downloads over time, listener geography, app share, and per-episode breakdowns. Read-only by design.
+- [conorbronsdon/podcastindex-mcp](https://github.com/conorbronsdon/podcastindex-mcp) [![conorbronsdon/podcastindex-mcp MCP server](https://glama.ai/mcp/servers/conorbronsdon/podcastindex-mcp/badges/score.svg)](https://glama.ai/mcp/servers/conorbronsdon/podcastindex-mcp) 📇 ☁️ - Search the Podcast Index: podcasts, episodes, guest appearances by person, trending shows, and feed health.
 - [conorbronsdon/Transistor-MCP](https://github.com/conorbronsdon/Transistor-MCP) [![conorbronsdon/Transistor-MCP MCP server](https://glama.ai/mcp/servers/conorbronsdon/Transistor-MCP/badges/score.svg)](https://glama.ai/mcp/servers/conorbronsdon/Transistor-MCP) 📇 ☁️ - Manage Transistor.fm podcasts: episodes, analytics, download summaries, episode comparisons, transcripts, and webhooks.
 
 ### 📋 <a name="product-management"></a>Product Management


### PR DESCRIPTION
Adds one server to the Podcasts category:

- `conorbronsdon/podcastindex-mcp` — search the Podcast Index: podcasts, episodes, guest appearances by person, trending shows, and feed health. Glama score badge included.

Stacked on #8498, which creates the Podcasts category. Until #8498 merges, the diff here also shows the category scaffolding; once it lands, this collapses to the single line above. One of three one-server-per-PR submissions splitting #7900 (#8498 op3, #8499 podcastindex, #8500 Transistor).

**Disclosure:** I maintain this server.
