### PR TITLE
Add mahiuddinalkamal/pdf-api — PDF generation & manipulation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1440,7 +1440,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [isaacphi/mcp-gdrive](https://github.com/isaacphi/mcp-gdrive) 📇 ☁️ - Model Context Protocol (MCP) Server for reading from Google Drive and editing Google Sheets.
 - [j0hanz/filesystem-context-mcp-server](https://github.com/j0hanz/filesystem-context-mcp-server) 📇 🏠 - Read-only MCP server for secure filesystem exploration, searching, and analysis with symlink protection.
 - [jeannier/homebrew-mcp](https://github.com/jeannier/homebrew-mcp) 🐍 🏠 🍎 - Control your macOS Homebrew setup using natural language via this MCP server. Simply manage your packages, or ask for suggestions, troubleshoot brew issues etc.
-- [mahiuddinalkamal/pdf-api](https://github.com/mahiuddinalkamal/pdf-api) 🐍 ☁️ 🍎 🪟 🐧 - HTML-to-PDF, merge, split, watermark, compress, protect, rotate, and extract text from PDFs. 8 tools via RapidAPI — free tier available.
+- [pdf-api-mcp](https://smithery.ai/servers/mahiuddinalkamal/pdf-api-mcp) 🐍 ☁️ 🍎 🪟 🐧 - HTML-to-PDF, URL-to-PDF, merge, split, watermark, compress, protect, rotate, and extract text from PDFs. 9 tools via RapidAPI — free tier available.
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [MarceauSolutions/md-to-pdf-mcp](https://github.com/MarceauSolutions/md-to-pdf-mcp) 🐍 🏠 🍎 🪟 🐧 - Convert Markdown files to professional PDFs with customizable themes, headers, footers, and styling
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.

--- a/README.md
+++ b/README.md
@@ -1440,6 +1440,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [isaacphi/mcp-gdrive](https://github.com/isaacphi/mcp-gdrive) 📇 ☁️ - Model Context Protocol (MCP) Server for reading from Google Drive and editing Google Sheets.
 - [j0hanz/filesystem-context-mcp-server](https://github.com/j0hanz/filesystem-context-mcp-server) 📇 🏠 - Read-only MCP server for secure filesystem exploration, searching, and analysis with symlink protection.
 - [jeannier/homebrew-mcp](https://github.com/jeannier/homebrew-mcp) 🐍 🏠 🍎 - Control your macOS Homebrew setup using natural language via this MCP server. Simply manage your packages, or ask for suggestions, troubleshoot brew issues etc.
+- [mahiuddinalkamal/pdf-api](https://github.com/mahiuddinalkamal/pdf-api) 🐍 ☁️ 🍎 🪟 🐧 - HTML-to-PDF, merge, split, watermark, compress, protect, rotate, and extract text from PDFs. 8 tools via RapidAPI — free tier available.
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [MarceauSolutions/md-to-pdf-mcp](https://github.com/MarceauSolutions/md-to-pdf-mcp) 🐍 🏠 🍎 🪟 🐧 - Convert Markdown files to professional PDFs with customizable themes, headers, footers, and styling
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.

--- a/README.md
+++ b/README.md
@@ -1440,7 +1440,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [isaacphi/mcp-gdrive](https://github.com/isaacphi/mcp-gdrive) 📇 ☁️ - Model Context Protocol (MCP) Server for reading from Google Drive and editing Google Sheets.
 - [j0hanz/filesystem-context-mcp-server](https://github.com/j0hanz/filesystem-context-mcp-server) 📇 🏠 - Read-only MCP server for secure filesystem exploration, searching, and analysis with symlink protection.
 - [jeannier/homebrew-mcp](https://github.com/jeannier/homebrew-mcp) 🐍 🏠 🍎 - Control your macOS Homebrew setup using natural language via this MCP server. Simply manage your packages, or ask for suggestions, troubleshoot brew issues etc.
-- [pdf-api-mcp](https://smithery.ai/servers/mahiuddinalkamal/pdf-api-mcp) 🐍 ☁️ 🍎 🪟 🐧 - HTML-to-PDF, URL-to-PDF, merge, split, watermark, compress, protect, rotate, and extract text from PDFs. 9 tools via RapidAPI — free tier available.
+- [mahiuddinalkamal/pdf-api](https://github.com/mahiuddinalkamal/pdf-api) 🐍 ☁️ 🍎 🪟 🐧 - HTML-to-PDF, URL-to-PDF, merge, split, watermark, compress, protect, rotate, and extract text from PDFs. 9 tools via RapidAPI — free tier available.
 - [mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search) 🐍 🏠 🪟 - Fast Windows file search using Everything SDK
 - [MarceauSolutions/md-to-pdf-mcp](https://github.com/MarceauSolutions/md-to-pdf-mcp) 🐍 🏠 🍎 🪟 🐧 - Convert Markdown files to professional PDFs with customizable themes, headers, footers, and styling
 - [mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server) 🏎️ 🏠 - Golang implementation for local file system access.


### PR DESCRIPTION
## New server: Simple PDF API

**Repository:** https://github.com/mahiuddinalkamal/pdf-api  
**Category:** 📂 File Systems  

### What it does

9 MCP tools for PDF generation and manipulation, backed by a live REST API:

- `html_to_pdf` — Convert HTML string → PDF
- `url_to_pdf` — Render any public URL → PDF  
- `merge_pdfs` — Merge multiple PDFs into one
- `split_pdf` — Extract page ranges
- `watermark_pdf` — Add CONFIDENTIAL / DRAFT overlays
- `compress_pdf` — Reduce file size
- `protect_pdf` — AES password-encrypt
- `rotate_pdf` — Rotate all or selected pages
- `extract_text` — Pull plain text

### Installation (Claude Desktop, Cursor, Windsurf)

```json
{
  "mcpServers": {
    "pdf-api": {
      "command": "uvx",
      "args": ["--from", "git+https://github.com/mahiuddinalkamal/pdf-api#subdirectory=mcp", "pdf-api-mcp"],
      "env": { "PDF_API_KEY": "your_rapidapi_key" }
    }
  }
}
```

Free tier available on RapidAPI. No local Chromium or Python setup needed.