### PR TITLE
feat: add Votura MCP — AI self-guided audio city tours 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2837,6 +2837,7 @@ Tools for converting text-to-speech and vice-versa
 
 ### 🚆 <a name="travel-and-transportation"></a>Travel & Transportation
 
+- [eugenelabonarsky/votura-mcp](https://github.com/eugenelabonarsky/votura-mcp) ☁️ - Search AI-generated self-guided audio city tours and points of interest by city. Returns tour names, durations, stop counts, and deep links across 500+ cities (walking, cycling, and driving tours). Hosted Streamable HTTP — no install required. Powered by [votura.app](https://votura.app).
 Access to travel and transportation information. Enables querying schedules, routes, and real-time travel data.
 
 - [alcylu/nightlife-mcp](https://github.com/alcylu/nightlife-mcp) [![nightlife](https://glama.ai/mcp/servers/alcylu/nightlife-mcp/badges/score.svg)](https://glama.ai/mcp/servers/alcylu/nightlife-mcp) 📇 ☁️ - MCP server for Tokyo nightlife event discovery, venue search, performer info, AI recommendations, and VIP table booking.


### PR DESCRIPTION
Adding Votura MCP server under **Travel & Transportation**.

**[eugenelabonarsky/votura-mcp](https://github.com/eugenelabonarsky/votura-mcp)** — Remote MCP server for searching AI-generated self-guided audio city tours and points of interest by city. 500+ cities, walking/cycling/driving tours, hosted Streamable HTTP transport. Powered by [votura.app](https://votura.app).