### PR TITLE
Add KatokMCP — KakaoTalk MCP Server

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -195,6 +195,8 @@
 - [elie222/inbox-zero](https://github.com/elie222/inbox-zero/tree/main/apps/mcp-server) - 🐍 ☁️ - Inbox Zero를 위한 MCP 서버. 답장해야 할 이메일이나 후속 조치가 필요한 이메일을 찾는 등 Gmail 위에 기능을 추가합니다.
 - [carterlasalle/mac_messages_mcp](https://github.com/carterlasalle/mac_messages_mcp) 🏠 🍎 🚀 - 모델 컨텍스트 프로토콜(MCP)을 통해 iMessage 데이터베이스와 안전하게 인터페이스하는 MCP 서버로, LLM이 iMessage 대화를 쿼리하고 분석할 수 있게 합니다. 강력한 전화번호 유효성 검사, 첨부 파일 처리, 연락처 관리, 그룹 채팅 처리 및 메시지 송수신 전체 지원을 포함합니다.
 - [line/line-bot-mcp-server](https://github.com/line/line-bot-mcp-server) 🎖 📇 ☁️ - LINE 공식 계정을 통합하는 MCP 서버
+- [mwl313/KatokMCP](https://github.com/mwl313/KatokMCP) 📇 🏠 🍎 🪟 🐧 - 카카오톡 MCP 서버. AI 비서(Claude/OpenClaw)가 채팅방 목록 확인, 메시지 읽기/전송, 멤버 조회 가능. 1회 폰 인증, Token Caching 지원. 설치: `npm install -g @katok-mcp/mcp-server && katok-mcp setup` [![mwl313/KatokMCP MCP server](https://glama.ai/mcp/servers/mwl313/KatokMCP/badges/score.svg)](https://glama.ai/mcp/servers/mwl313/KatokMCP)
+
 - [ztxtxwd/open-feishu-mcp-server](https://github.com/ztxtxwd/open-feishu-mcp-server) 📇 ☁️ 🏠 - 내장된 Feishu OAuth 인증을 갖춘 Model Context Protocol(MCP) 서버로, 원격 연결을 지원하고 블록 생성, 콘텐츠 업데이트 및 고급 기능을 포함한 포괄적인 Feishu 문서 관리 도구를 제공합니다.
 - [sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp) - 📇 🏠 VRChat API와 상호 작용하기 위한 MCP 서버입니다. VRChat에서 친구, 월드, 아바타 등에 대한 정보를 검색할 수 있습니다.
 - [arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks) - 📇 ☁️ - Google Tasks API와 인터페이스하기 위한 MCP 서버

--- a/README.md
+++ b/README.md
@@ -599,6 +599,8 @@ Run commands, capture output and otherwise interact with shells and command line
 - [laszlopere/mcp-tmux](https://github.com/laszlopere/mcp-tmux) [![laszlopere/mcp-tmux MCP server](https://glama.ai/mcp/servers/laszlopere/mcp-tmux/badges/score.svg)](https://glama.ai/mcp/servers/laszlopere/mcp-tmux) 🐍 🏠 🐧 🍎 - Universal tmux driver: sessions, windows, panes, keystrokes, and pane capture — local or remote over SSH. Curated tools plus a raw `tmux_command` passthrough; works against tmux 1.8+. Shared, visible sessions for pair-programming with the agent. `uvx mcp-tmux`.
 - [zb-ss/servonaut](https://github.com/zb-ss/servonaut) [![zb-ss/servonaut MCP server](https://glama.ai/mcp/servers/@zb-ss/servonaut/badges/score.svg)](https://glama.ai/mcp/servers/@zb-ss/servonaut) 🐍 🏠 🍎 🐧 - Manage AWS EC2, Hetzner, OVH and custom SSH servers: run commands, fetch logs, CloudWatch/CloudTrail queries, fleet health snapshots, IP banning, S3 — with readonly/standard/dangerous guard tiers and a JSONL audit trail.
 
+- [mwl313/KatokMCP](https://github.com/mwl313/KatokMCP) 📇 🏠 🍎 🪟 🐧 - KakaoTalk (Korea #1 messenger) MCP Server. AI assistant (Claude/OpenClaw) can read chats, list rooms, send messages, and manage members. One-time phone auth, token caching. Install: `npm install -g @katok-mcp/mcp-server && katok-mcp setup` [![mwl313/KatokMCP MCP server](https://glama.ai/mcp/servers/mwl313/KatokMCP/badges/score.svg)](https://glama.ai/mcp/servers/mwl313/KatokMCP)
+
 ### 💬 <a name="communication"></a>Communication
 
 Integration with communication platforms for message management and channel operations. Enables AI models to interact with team communication tools.


### PR DESCRIPTION
## Add KatokMCP to Communication section

**Description:** KatokMCP lets AI assistants (Claude, OpenClaw, etc.) control KakaoTalk — Korea\'s #1 messaging app with 50M+ users. Read chats, send messages, list rooms, and manage members through the MCP protocol.

Install: `npm install -g @katok-mcp/mcp-server && katok-mcp setup`

Language: TypeScript | Platform: All (macOS/Windows/Linux) | Scope: Local