### PR TITLE
Add magna-nz/backstory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [magna-nz/backstory](https://github.com/magna-nz/backstory) [![magna-nz/backstory MCP server](https://glama.ai/mcp/servers/magna-nz/backstory/badges/score.svg)](https://glama.ai/mcp/servers/magna-nz/backstory) #️⃣ 🏠 🍎 🪟 🐧 - Search your personal data exports (Google Takeout, Telegram, Spotify, Instagram) locally as one timeline. Hybrid semantic and keyword search, fully offline. 5 tools.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds Backstory, a local-first MCP server that imports your personal data exports (Google Takeout, Telegram, Spotify, Instagram) into one searchable timeline. Hybrid semantic and keyword search, runs fully offline with no API calls, MIT licensed, .NET 10.

Repo: https://github.com/magna-nz/backstory

Added under Knowledge & Memory. Tools: search_timeline, get_events, lookup_entity, summarize_period, list_sources.