### PR TITLE
Add ares-mcp (Czech business registry / ARES) to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [milos106/ares-mcp](https://github.com/milos106/ares-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Czech business registry (ARES): company lookup, due diligence, statutory bodies, trade licenses, VAT, insolvency, and a cross-company person graph. Optional Ed25519-signed provenance — every fact carries its source and date, verifiable offline against a published JWKS. 14 tools, no API key (ARES is public).
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds [ares-mcp](https://github.com/milos106/ares-mcp) — an MCP server for **ARES, the Czech business registry**.

- Company lookup, due diligence, statutory bodies, trade licenses, VAT, insolvency, cross-company person graph (14 tools).
- TypeScript, stdio + Streamable HTTP. No API key (ARES is a public API).
- Optional **Ed25519-signed provenance**: every fact carries its registry source + date, verifiable offline against a published JWKS.

Placed in **Finance & Fintech** (appended). MIT licensed.