### PR TITLE
Add Norman Finance MCP server (Finance & Fintech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [norman-finance/norman-mcp-server](https://github.com/norman-finance/norman-mcp-server) [![norman-finance/norman-mcp-server MCP server](https://glama.ai/mcp/servers/@norman-finance/norman-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/@norman-finance/norman-mcp-server) 🐍 ☁️ 🏠 - German accounting, invoicing & VAT/UStVA filing inside Claude, Cursor & ChatGPT. Remote (OAuth) or local stdio.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds **Norman Finance** under **💰 Finance & Fintech**.

[norman-finance/norman-mcp-server](https://github.com/norman-finance/norman-mcp-server) — an official, MIT-licensed MCP server for German accounting & tax: create/track invoices (incl. ZUGFeRD), categorize transactions, and review/preview/file your VAT return (UStVA) with the Finanzamt — straight from Claude, Cursor, or ChatGPT. Works remotely over OAuth 2.1 (`https://mcp.norman.finance/mcp`) or locally via stdio (`pip install norman-mcp-server`).

- 🐍 Python · ☁️ remote/hosted · 🏠 local
- Description under 125 chars; appended to the end of the Finance & Fintech section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
