### PR TITLE
Add elster-mcp-server (German tax-portal ELSTER automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [lukasschwarz/elster-mcp-server](https://github.com/lukasschwarz/elster-mcp-server) 📇 🏠 🍎 🪟 🐧 - German tax-portal **ELSTER** automation via Puppeteer. Submit UStVA with human-in-the-loop confirmation, prepare EÜR / ESt drafts, sync inbox + history, generate UStVA XML snapshots. 13 tools, MIT licensed.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
## Summary

Adds a new MCP server entry to the Finance & Fintech section.

**Repo:** https://github.com/lukasschwarz/elster-mcp-server

**What it does:** Drives the German tax portal ELSTER via Puppeteer.
- Submit UStVA (Umsatzsteuer-Voranmeldung) with explicit human-in-the-loop confirmation
- Prepare EÜR (Anlage Einnahmen-Überschuss-Rechnung) and ESt (Einkommensteuer) drafts (never auto-submits)
- Sync inbox + transmission history with PDF export
- Generate UStVA XML snapshots for archival

13 MCP tools, fully configurable via env vars or `config.json`, MIT licensed, written in TypeScript on Node 18+.

Tested locally; conforms to the README format and legend (📇 = TypeScript codebase, 🏠 = service runs locally, 🍎🪟🐧 = cross-platform).