### PR TITLE
Add realm-mp-mcp to new Religion & Nonprofit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🎥 - [Multimedia Process](#multimedia-process)
 * 🖥️ - [OS Automation](#os-automation)
 * 📋 - [Product Management](#product-management)
+* ⛪ - [Religion & Nonprofit](#religion-and-nonprofit)
 * 🏠 - [Real Estate](#real-estate)
 * 🔬 - [Research](#research)
 * 🔎 - [Search & Data Extraction](#search)
@@ -2367,6 +2368,12 @@ MCP servers for real estate CRM, property management, and agent workflows.
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
 - [forgemeshlabs/disruption-intelligence-mcp](https://github.com/forgemeshlabs/disruption-intelligence-mcp) [![forgemeshlabs/disruption-intelligence-mcp MCP server](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp/badges/score.svg)](https://glama.ai/mcp/servers/forgemeshlabs/disruption-intelligence-mcp) 📇 ☁️ - AI-native commercial disruption intelligence for MCP clients and x402-powered agents. Supports WARN/layoff intelligence, company context, geospatial territory disruption, and x402 payment challenge inspection via the hosted Forgemesh API.
 - [jbechtel-97/dealflowpro-mcp-server](https://github.com/jbechtel-97/dealflowpro-mcp-server) [![jbechtel-97/dealflowpro-mcp-server MCP server](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/jbechtel-97/dealflowpro-mcp-server) 📇 ☁️ - Multifamily real estate deal analysis — cap rate, DSCR, cash-on-cash, IRR, DFP Score (0-100), max offer price, and market intelligence for 2-200 unit properties.
+
+### ⛪ <a name="religion-and-nonprofit"></a>Religion & Nonprofit
+
+MCP servers for church management, faith communities, synagogues, mosques, temples, and nonprofit operations.
+
+- [sanjibani/realm-mp-mcp](https://github.com/sanjibani/realm-mp-mcp) 🐍 ☁️ - The first MCP server for [Realm (MinistryPlatform)](https://help.acst.com/en/ministryplatform/developer-resources/), the church management system by ACS Technologies used by 10,000+ churches. 8 tools for contacts, events, small groups, donations, tasks, and communications via the public OAuth 2.0 REST API. `pip install realm-mp-mcp`. MIT-licensed.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
## Summary

Adds `sanjibani/realm-mp-mcp` — the first MCP server for **Realm (MinistryPlatform)**, the church management system from ACS Technologies used by 10,000+ churches worldwide. 8 tools for contacts, events, small groups, donations, tasks, and communications via the public OAuth 2.0 REST API.

## Why a new section

I checked the current categories and there's no `Religion` or `Nonprofit` section. Other adjacent sections (`Spirituality & Esoterica`, `Workplace & Productivity`) are the wrong fit — spirituality covers astrology/tarot, workplace covers generic productivity. Church / synagogue / mosque / temple / faith-community management is a distinct vertical that the list doesn't yet cover, and is the same scale of opportunity as the other "vertical SaaS" categories the list has (real estate, legal, dental, veterinary, etc.).

## Changes

- New section `⛪ Religion & Nonprofit` added between `Real Estate` and `Research` (alphabetical)
- ToC entry added in the correct alphabetical position
- One entry: `sanjibani/realm-mp-mcp` (8 tools, MIT, `pip install realm-mp-mcp`)

## Saturation check

Searched the MCP server landscape: no existing MCP for Realm, MinistryPlatform, ACS Technologies, Breeze, Planning Center, Pushpay, Tithe.ly, Realm ACS, or church management generally. Planning Center has a community MCP but is API-restricted; this fills the Realm gap.

Reference: https://help.acst.com/en/ministryplatform/developer-resources/developer-resources/rest-api