### PR TITLE
Add imagedimensions-mcp (Developer Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
 
+- [Bishop81/imagedimensions-mcp](https://github.com/Bishop81/imagedimensions-mcp) [![Bishop81/imagedimensions-mcp MCP server](https://glama.ai/mcp/servers/Bishop81/imagedimensions-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Bishop81/imagedimensions-mcp) 📇 ☁️ - Audit the images on any web page: natural vs rendered dimensions, oversized-image detection, and format breakdown, so agents can check web-image performance. Calls the hosted imagedimensions.com API, so no local browser is required. `npx -y imagedimensions-mcp`
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)


### PR DESCRIPTION
Adds **imagedimensions-mcp** to Developer Tools.

Tool `scan_image_dimensions(url)` audits the images on any web page — natural vs rendered dimensions, oversized-image detection (a common LCP problem), and format breakdown — so AI agents can check web-image performance during development.

- npm: https://www.npmjs.com/package/imagedimensions-mcp
- Official MCP registry: `io.github.Bishop81/imagedimensions-mcp`
- Repo: https://github.com/Bishop81/imagedimensions-mcp

Calls the hosted imagedimensions.com API, so no local browser is required. Entry follows the existing format (📇 TypeScript/JS, ☁️ Cloud Service) with a Glama badge.