### PR TITLE
Add accessibility-scanner-mcp and imagedimensions-mcp to Developer Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,8 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [Bishop81/accessibility-scanner-mcp](https://github.com/Bishop81/accessibility-scanner-mcp) 📇 ☁️ - MCP server to scan any URL for WCAG accessibility issues with axe-core and return per-element fixes for an AI agent. Powered by accessibilityscanner.app.
+- [Bishop81/imagedimensions-mcp](https://github.com/Bishop81/imagedimensions-mcp) 📇 ☁️ - MCP server to audit a web page’s images: natural vs rendered size, oversized-image detection, and format checks. Powered by imagedimensions.com.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds two MCP servers to the Developer Tools category. Both are published to npm and listed in the official MCP registry.

- **accessibility-scanner-mcp** — https://github.com/Bishop81/accessibility-scanner-mcp · `npx accessibility-scanner-mcp` · registry: `io.github.Bishop81/accessibility-scanner-mcp`. Scans any URL for WCAG issues (axe-core) and returns per-element fixes.
- **imagedimensions-mcp** — https://github.com/Bishop81/imagedimensions-mcp · `npx imagedimensions-mcp` · registry: `io.github.Bishop81/imagedimensions-mcp`. Audits a web page's images (natural vs rendered size, oversized detection, formats).

Two entries, existing format, appended to Developer Tools.