### PR TITLE
Add account-pool-mcp (Developer Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
 
+- [ankitsxchdeva/account-pool-mcp](https://github.com/ankitsxchdeva/account-pool-mcp) 📇 🏠 🍎 🪟 🐧 - Brokers exclusive, crash-safe leases on a pool of test accounts so parallel Claude/agent QA sessions never grab the same one. SQLite-backed `BEGIN IMMEDIATE` allocation, per-lease TTL auto-reclaim on crash, no shared parent process. `npx -y account-pool-mcp`
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)

--- a/README.md
+++ b/README.md
@@ -1306,7 +1306,7 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
 
-- [ankitsxchdeva/account-pool-mcp](https://github.com/ankitsxchdeva/account-pool-mcp) 📇 🏠 🍎 🪟 🐧 - Brokers exclusive, crash-safe leases on a pool of test accounts so parallel Claude/agent QA sessions never grab the same one. SQLite-backed `BEGIN IMMEDIATE` allocation, per-lease TTL auto-reclaim on crash, no shared parent process. `npx -y account-pool-mcp`
+- [ankitsxchdeva/account-pool-mcp](https://github.com/ankitsxchdeva/account-pool-mcp) [![ankitsxchdeva/account-pool-mcp MCP server](https://glama.ai/mcp/servers/ankitsxchdeva/account-pool-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ankitsxchdeva/account-pool-mcp) 📇 🏠 🍎 🪟 🐧 - Brokers exclusive, crash-safe leases on a pool of test accounts so parallel Claude/agent QA sessions never grab the same one. SQLite-backed `BEGIN IMMEDIATE` allocation, per-lease TTL auto-reclaim on crash, no shared parent process. `npx -y account-pool-mcp`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [account-pool-mcp](https://github.com/ankitsxchdeva/account-pool-mcp) under **Developer Tools**.

It brokers exclusive, crash-safe leases on a pool of test accounts so parallel agent/QA sessions (e.g. several Claude + Playwright runs) never grab the same account. SQLite-backed `BEGIN IMMEDIATE` allocation, per-lease TTL auto-reclaim on crash, no shared parent process. Published on npm as `account-pool-mcp`.

- TypeScript 📇, local stdio 🏠, cross-platform 🍎🪟🐧
- Entry follows the legend/format; placed at the end of the Developer Tools list.