### PR TITLE
Add sanjibani/fieldroutes-mcp to Support & Service Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2826,6 +2826,7 @@ Tools for accessing sports-related data, results, and statistics.
 - [willvelida/mcp-afl-server](https://github.com/willvelida/mcp-afl-server) ☁️ - MCP server that integrates with the Squiggle API to provide information on Australian Football League teams, ladder standings, results, tips, and power rankings.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
+- [sanjibani/fieldroutes-mcp](https://github.com/sanjibani/fieldroutes-mcp) 🐍 ☁️ - First MCP server for the FieldRoutes pest-control / lawn-care operations platform (ServiceTitan). 11 tools covering customers, appointments, subscriptions, routes, tickets (invoices), and notes. Wraps the public apiModule.call/apiModule.search POST-style API; envelope `{success, result, errorMessage}` translated to typed exceptions.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.


### PR DESCRIPTION
First MCP for the FieldRoutes pest-control / lawn-care operations platform (a ServiceTitan company, 1,700+ tenants). 11 tools covering the most common workflows: customer search/get/create/update, appointment search/cancel, subscription search, route search, ticket (invoice) search, and note creation.

Wraps the public FieldRoutes apiModule.call/apiModule.search POST-style API. Every response uses the upstream's `{success, result, errorMessage}` envelope, which the client translates into typed Python exceptions (even when HTTP is 200). Tools raise (rather than return string) so FastMCP marks `isError=true` on the wire.

22 tests pass; ruff + mypy + pytest clean.