### PR TITLE
Add croc100/Litescope to Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [Zhwt/go-mcp-mysql](https://github.com/Zhwt/go-mcp-mysql) 🏎️ 🏠 – Easy to use, zero dependency MySQL MCP server built with Golang with configurable readonly mode and schema inspection.
 - [zilliztech/mcp-server-milvus](https://github.com/zilliztech/mcp-server-milvus) 🐍 🏠 ☁️ - MCP Server for Milvus / Zilliz, making it possible to interact with your database.
 - [wklee610/kafka-mcp](https://github.com/wklee610/kafka-mcp)[![kafka-mcp MCP server](https://glama.ai/mcp/servers/wklee610/kafka-mcp/badges/score.svg)](https://glama.ai/mcp/servers/wklee610/kafka-mcp) 🐍 🏠 ☁️ - MCP server for Apache Kafka that allows LLM agents to inspect topics, consumer groups, and safely manage offsets (reset, rewind).
+- [croc100/Litescope](https://github.com/croc100/Litescope) [![Litescope MCP server](https://glama.ai/mcp/servers/croc100/Litescope/badges/score.svg)](https://glama.ai/mcp/servers/croc100/Litescope) 🏎️ 🏠 ☁️ - MCP-first operations toolchain for SQLite, Cloudflare D1, and Turso. Inspect, diff, migrate, monitor, back up, and repair databases over stdio. Read-only by default; writes are opt-in, dry-run first, and auto-snapshot before applying. `npx -y litescope mcp`
 
 ### 📊 <a name="data-platforms"></a>Data Platforms
 


### PR DESCRIPTION
Hello, and thank you for maintaining this list.

This pull request adds Litescope to the Databases section.

[![Litescope MCP server](https://glama.ai/mcp/servers/croc100/Litescope/badges/score.svg)](https://glama.ai/mcp/servers/croc100/Litescope)

Litescope is an MCP-first operations toolchain for SQLite, Cloudflare D1, and Turso. Every command is available as both a CLI and an MCP tool, so an agent can inspect, diff, migrate, monitor, back up, and repair databases through the same interface a developer uses directly. The server exposes its tools over stdio and is read-only by default; write operations are opt-in, run as a dry run first, and take an automatic snapshot before any change is applied.

A few details that may help with review:

- Launch command: `npx -y litescope mcp` (also available via Homebrew and as a prebuilt binary).
- npm package: https://www.npmjs.com/package/litescope
- Published to the official MCP Registry as `io.github.croc100/litescope`.
- Listed on Glama with the score badge included inline in the entry: https://glama.ai/mcp/servers/croc100/Litescope

The entry is appended to the end of the Databases section, with legend markers for a Go codebase, local use, and optional cloud sources (Cloudflare D1 and Turso). Happy to adjust wording or placement to fit your conventions.
