### PR TITLE
Add risal-dash-mcp - control ESP32/ESP8266 hardware from an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1390,6 +1390,8 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 - [catallo/misterclaw](https://github.com/catallo/misterclaw) [![catallo/misterclaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/score.svg)](https://glama.ai/mcp/servers/catallo/misterclaw) 🏎️ 📟 🏠 🐧 🍎 - MiSTerClaw — MCP remote control for MiSTer-FPGA. Launch games, search ROMs, take screenshots, manage systems, and set up Tailscale VPN. Auto-discovers 70+ systems with dynamic core/ROM scanning.
 - [zackpeters93/ugs-mcp](https://github.com/zackpeters93/ugs-mcp) [![zackpeters93/ugs-mcp MCP server](https://glama.ai/mcp/servers/zackpeters93/ugs-mcp/badges/score.svg)](https://glama.ai/mcp/servers/zackpeters93/ugs-mcp) 🐍 📟 🏠 🍎 - CNC machine control via Universal G-code Sender (GRBL). Jog axes, home, run G-code files, inspect toolpaths, estimate cycle times. Motion commands require two-step token confirmation — Claude cannot move hardware autonomously.
+- [ziyarago/risal-dash-mcp](https://github.com/ziyarago/risal-dash-mcp) 📇 📟 🏠 - Turn an ESP32/ESP8266 into agent tools: every RisalDash widget becomes a get_*/set_* tool (read sensors, flip relays) over the device's MCP manifest.
+
 
 ### 🎓 <a name="education"></a>Education
 


### PR DESCRIPTION
Adds risal-dash-mcp to Embedded Systems. It bridges a RisalDash device (ESP32/ESP8266) to an MCP client: reads /api/mcp/manifest and exposes every widget as a get_*/set_* tool, so an agent can read a sensor or toggle a relay. On npm (`npx risal-dash-mcp`), MIT.

Server: https://github.com/ziyarago/risal-dash-mcp
Device library: https://github.com/ziyarago/RisalDash