### PR TITLE
Add PalabreX/runpay-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,7 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
-- [PalabreX/runpay-mcp](https://github.com/PalabreX/runpay-mcp) 📇 ☁️ - Stripe-native marketplace where AI agents discover and pay per call for API services and agent infrastructure (memory, scheduling, locks, consensus).
+-  [PalabreX/runpay-mcp](https://github.com/PalabreX/runpay-mcp) 📇 ☁️ - Stripe-native marketplace where AI agents discover and pay per call for API services and agent infrastructure (memory, scheduling, locks, consensus). [![runpay-mcp MCP server](https://glama.ai/mcp/servers/PalabreX/runpay-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PalabreX/runpay-mcp)
 
 ### 🎮 <a name="gaming"></a>Gaming
 

--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [PalabreX/runpay-mcp](https://github.com/PalabreX/runpay-mcp) 📇 ☁️ - Stripe-native marketplace where AI agents discover and pay per call for API services and agent infrastructure (memory, scheduling, locks, consensus).
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds run.pay's MCP server to Finance & Fintech.

Stripe-native marketplace where AI agents discover and pay per call for API services and agent infrastructure (memory store, task scheduler, idempotency lock, cost calculator, consensus aggregator).

- Listed on the official MCP registry: io.github.PalabreX/runpay
- Live: https://getrunpay.com