### PR TITLE
Add AudiopodAI/audiopod-mcp (Text-to-Speech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2856,6 +2856,7 @@ Translation tools and services to enable AI assistants to translate content betw
 
 Tools for converting text-to-speech and vice-versa
 
+- [AudiopodAI/audiopod-mcp](https://github.com/AudiopodAI/audiopod-mcp) 🎖️ 🐍 ☁️ - Hosted MCP server for [AudioPod](https://audiopod.ai)'s audio AI: text-to-speech, voice cloning, voice conversion, music generation, stem & speaker separation, transcription, and denoise. Streamable-HTTP at `https://mcp.audiopod.ai`, free tier.
 - [daisys-ai/daisys-mcp](https://github.com/daisys-ai/daisys-mcp) 🐍 🏠 🍎 🪟 🐧 - Generate high-quality text-to-speech and text-to-voice outputs using the [DAISYS](https://www.daisys.ai/) platform and make it able to play and store audio generated.
 - [fasuizu-br/brainiall-mcp-server](https://github.com/fasuizu-br/brainiall-mcp-server) [![brainiall-mcp-server MCP server](https://glama.ai/mcp/servers/fasuizu-br/brainiall-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/fasuizu-br/brainiall-mcp-server) 🐍 ☁️ - AI-powered speech tools: pronunciation assessment with phoneme-level feedback, speech-to-text with language detection, and text-to-speech with multiple voices.
 - [mbailey/voice-mcp](https://github.com/mbailey/voice-mcp) 🐍 🏠 - Complete voice interaction server supporting speech-to-text, text-to-speech, and real-time voice conversations through local microphone, OpenAI-compatible APIs, and LiveKit integration


### PR DESCRIPTION
Adds the official **AudioPod AI** hosted MCP server to the Text-to-Speech section.

\`\`\`
- [AudiopodAI/audiopod-mcp](https://github.com/AudiopodAI/audiopod-mcp) 🎖️ 🐍 ☁️ - Hosted MCP server for AudioPod's audio AI: text-to-speech, voice cloning, voice conversion, music generation, stem & speaker separation, transcription, and denoise. Streamable-HTTP at https://mcp.audiopod.ai, free tier.
\`\`\`

- Endpoint: `https://mcp.audiopod.ai` (Streamable-HTTP, MCP 2025-06-18), API-key/OAuth2 auth — 10 audio tools.
- Repo: https://github.com/AudiopodAI/audiopod-mcp · Docs: https://docs.audiopod.ai/sdks/mcp
- Official (vendor's own server), placed alphabetically by org/repo at the top of the section.