### PR TITLE
Add whamlink-mcp (Developer Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,8 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
 
+- [billkinddev/whamlink-mcp](https://github.com/billkinddev/whamlink-mcp) 📇 ☁️ - Publish HTML, Markdown, or text to a permanent, shareable link in one call. Built for agents to publish on a user’s behalf; links can be public, private, password-protected, or shared by email. `npx -y whamlink-mcp`
+
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)

--- a/README.md
+++ b/README.md
@@ -1306,7 +1306,7 @@ Tools and integrations that enhance the development workflow and environment man
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
 
-- [billkinddev/whamlink-mcp](https://github.com/billkinddev/whamlink-mcp) 📇 ☁️ - Publish HTML, Markdown, or text to a permanent, shareable link in one call. Built for agents to publish on a user’s behalf; links can be public, private, password-protected, or shared by email. `npx -y whamlink-mcp`
+- [billkinddev/whamlink-mcp](https://github.com/billkinddev/whamlink-mcp) [![MCP Score](https://glama.ai/api/git/billkinddev/whamlink-mcp/score.svg)](https://glama.ai/servers/billkinddev/whamlink-mcp) 📇 ☁️ - Publish HTML, Markdown, or text to a permanent, shareable link in one call. Built for agents to publish on a user’s behalf; links can be public, private, password-protected, or shared by email. `npx -y whamlink-mcp`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds **whamlink-mcp** to Developer Tools.

[whamlink](https://whamlink.com) publishes a file (HTML, Markdown, or text) to a permanent, shareable link in one call. Built for agents to publish on a user's behalf; links can be public, private, password-protected, or shared by email.

- npm: `npx -y whamlink-mcp`
- repo: https://github.com/billkinddev/whamlink-mcp

Entry added alphabetically/format per the list conventions (📇 TypeScript, ☁️ cloud service).