### PR TITLE
Add Shodai Agreements MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.
 
-- [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
+- [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) [![CNSLabs/agreements-api-sdk MCP server](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk/badges/score.svg)](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 > We now have a [web-based directory](https://glama.ai/mcp/servers) that is synced with the repository.
 
 * 🔗 - [Aggregators](#aggregators)
+* 🤝 - [Agreements & Coordination](#agreements--coordination)
 * 🎨 - [Art & Culture](#art-and-culture)
 * 📐 - [Architecture & Design](#architecture-and-design)
 * 📂 - [Browser Automation](#browser-automation)
@@ -221,6 +222,12 @@ Servers for accessing many apps and tools through a single MCP server.
 
 - [gregario/astronomy-oracle](https://github.com/gregario/astronomy-oracle) [![astronomy-oracle MCP server](https://glama.ai/mcp/servers/gregario/astronomy-oracle/badges/score.svg)](https://glama.ai/mcp/servers/gregario/astronomy-oracle) 📇 🏠 🍎 🪟 🐧 - Accurate astronomical catalog data and observing session planner. 13,000+ deep-sky objects from OpenNGC with deterministic visibility, rise/transit/set, and alt/az calculations. `npx astronomy-oracle`
 - [IO-Aerospace-software-community/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
+
+### 🤝 <a name="agreements--coordination"></a>Agreements & Coordination
+
+MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.
+
+- [Shodai Agreements](https://github.com/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.
 
-- [Shodai Agreements](https://github.com/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
+- [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 


### PR DESCRIPTION
## Summary
- Add a new Agreements & Coordination category for MCP servers whose primary surface is structured agreement lifecycle coordination.
- Add Shodai Agreements as a remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreement workflows.

## Category rationale
Shodai Agreements is not a legal document database, legal drafting tool, or generic integration. Its public README frames it as agreement lifecycle coordination for machine-readable workflows, signed participant inputs, state reads, and input history, so a focused Agreements & Coordination category fits better than Legal or Other Tools and Integrations.

## Checks
- Followed README entry format and one-server-per-line guidance.
- Linked the server name to the public repository.
- Kept claims aligned with the public README and hosted MCP docs.