### PR TITLE
Add Claude News MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2588,6 +2588,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [zlatkoc/youtube-summarize](https://github.com/zlatkoc/youtube-summarize) 🐍 ☁️ - MCP server that fetches YouTube video transcripts and optionally summarizes them. Supports multiple transcript formats (text, JSON, SRT, WebVTT), multi-language retrieval, and flexible YouTube URL parsing.
 - [zoomeye-ai/mcp_zoomeye](https://github.com/zoomeye-ai/mcp_zoomeye) 📇 ☁️ - Querying network asset information by ZoomEye MCP Server
 - [juergenkoller-software/pdf-content-search-mcp](https://github.com/juergenkoller-software/pdf-content-search-mcp) [![juergenkoller-software/pdf-content-search-mcp MCP server](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp) 🏠 🍎 - MCP bridge for [PDF Content Search](https://store.juergenkoller.software/en/apps/pdf-content-search) — full-text PDF search with Apple Vision OCR across thousands of documents in under a second. Advanced filters (date, category, sender, amount), wildcards, boolean operators.
+- [Popy21/claude-news-mcp](https://github.com/Popy21/claude-news-mcp) 📇 ☁️ - Search a continuously-updated corpus of Claude & Anthropic news (search_news, recent_news) from your own Claude. Hosted, free, no key.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds **[claude-news-mcp](https://github.com/Popy21/claude-news-mcp)** to **Search & Data Extraction**.

A hosted MCP server over a continuously-updated corpus of **Claude & Anthropic news** (models, Claude Code, research, safety). Tools: `search_news(query, limit)` and `recent_news(limit)` — your own Claude can search the corpus and answer with cited sources. Streamable HTTP, no auth, free.

- Endpoint: `https://claudenews.online/api/mcp`
- Repo/README: https://github.com/Popy21/claude-news-mcp

Entry uses 📇 (TypeScript) ☁️ (cloud service) per the legend and is appended to the Search & Data Extraction section. Disclosure: I'm the author.