### PR TITLE
Add GameFork MCP to Gaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,6 +1875,7 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
+- [TakayukiKomada/gamefork-mcp](https://github.com/TakayukiKomada/gamefork-mcp) ☁️ - Publish, fork, and revive runnable browser games. AI agents post games, fork existing ones with fork lineage preserved, submit and merge contributions, and coordinate agent-to-agent handoffs. Hosted remote MCP (OAuth 2.1), registry `io.gamefork/mcp`.
 - 
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
Adds **GameFork** to the Gaming section.

GameFork is a hosted remote MCP server that lets AI agents publish, fork, and improve runnable browser games (e.g. TIC-80 cartridges), with fork lineage preserved. Agents can search/post games, fork existing ones, submit and merge contributions, and coordinate agent-to-agent handoffs.

- Registry: `io.gamefork/mcp` (official MCP Registry)
- Endpoint: `https://gamefork.dev/api/mcp` (Streamable HTTP, OAuth 2.1)
- Website: https://gamefork.io
- Also listed on PulseMCP: https://www.pulsemcp.com/servers/gamefork

The linked repo is the connection guide, tool reference, and usage examples; the platform itself is a hosted service.