### PR TITLE
Add b2b-enrichment-mcp to Customer Data Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,8 @@ Tools for encrypting and decrypting data.
 
 Provides access to customer profiles inside of customer data platforms
 
+- [Aleksey-Panf/b2b-enrichment-mcp](https://github.com/Aleksey-Panf/b2b-enrichment-mcp) 🐍 ☁️ - B2B lead enrichment server integrating Hunter.io and Apollo APIs. 9 tools for email discovery, domain search, company data, and contact verification.
+- 
 - [azmartone67/dchub-mcp-server](https://github.com/azmartone67/dchub-mcp-server) [![azmartone67/dchub-mcp-server MCP server](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/azmartone67/dchub-mcp-server) 📇 ☁️ - Data-center, power & gas intelligence MCP server. 33 tools covering 21,000+ data-center facilities (170+ countries), 232 US power markets scored by the DC Hub Power Index (DCPI), 2,000+ tracked M&A deals, ISO grid telemetry (PJM, ERCOT, CAISO, MISO, SPP, NYISO), fiber routes, and energy pricing. Free to cite (CC-BY-4.0).
 - [antv/mcp-server-chart](https://github.com/antvis/mcp-server-chart) 🎖️ 📇 ☁️ - A Model Context Protocol server for generating visual charts using [AntV](https://github.com/antvis).
 - [ckalima/pipedrive-mcp-server](https://github.com/ckalima/pipedrive-mcp-server) [![ckalima/pipedrive-mcp-server MCP server](https://glama.ai/mcp/servers/ckalima/pipedrive-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ckalima/pipedrive-mcp-server) 📇 ☁️ - MCP server for [Pipedrive CRM](https://www.pipedrive.com). 155 tools covering deals, persons, organizations, activities, products, projects, tasks, leads, notes, mail, and fields. stdio transport, API-key auth, delete tools gated behind an env flag. Published on npm as `@ckalima/pipedrive-mcp-server`. MIT.


### PR DESCRIPTION
Adding b2b-enrichment-mcp to the Customer Data Platforms section.

What it does:
- B2B lead enrichment server combining Hunter.io and Apollo APIs
- 9 tools covering email discovery, domain search, company data, and contact verification
- Built with FastMCP (Python)

Repo: https://github.com/Aleksey-Panf/b2b-enrichment-mcp

[![b2b-enrichment-mcp MCP server](https://glama.ai/mcp/servers/Aleksey-Panf/b2b-enrichment-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Aleksey-Panf/b2b-enrichment-mcp)