### PR TITLE
Add aouellets/skillme to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [aouellets/skillme](https://github.com/aouellets/skillme) 📇 ☁️ - Open-source catalog of Claude Agent Skills and skill packs with semantic search and one-command install over MCP. Live at skillme.dev. Independent project, not affiliated with Anthropic.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds **SkillMe** under Developer Tools.

SkillMe (https://skillme.dev) is an open-source (MIT) catalog for Claude Agent Skills and skill packs, with semantic search and one-command install over MCP (`https://skillme.dev/api/mcp`, streamable-http). Source: https://github.com/aouellets/skillme.

📇 TypeScript codebase · ☁️ Cloud Service. This is an independent project and is **not affiliated with Anthropic**.