### PR TITLE
🤖🤖🤖 Add SoapBox Faith MCP server (new Faith & Religion category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🎓 - [Education](#education)
 * 🛒 - [E-Commerce](#e-commerce)
 * 🌳 - [Environment & Nature](#environment-and-nature)
+* 🙏 - [Faith & Religion](#faith-and-religion)
 * 📂 - [File Systems](#file-systems)
 * 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
@@ -1435,6 +1436,12 @@ Provides access to environmental data and nature-related tools, services and inf
 - [atmospore/atmospore-mcp](https://github.com/atmospore/atmospore-mcp) [![atmospore/atmospore-mcp MCP server](https://glama.ai/mcp/servers/atmospore/atmospore-mcp/badges/score.svg)](https://glama.ai/mcp/servers/atmospore/atmospore-mcp) 🐍 ☁️ 🍎 🪟 🐧 - Per-species pollen forecasts at any point on Earth, seven days ahead, via the Atmospore API. Tools: `get_pollen`, `get_top_species`, `get_area_average`, `list_supported_species`. Free tier (100 calls/day, no credit card). Hosted variant at `mcp.atmospore.com`.
 - [nalediym/touch-grass](https://github.com/nalediym/touch-grass) [![nalediym/touch-grass MCP server](https://glama.ai/mcp/servers/nalediym/touch-grass/badges/score.svg)](https://glama.ai/mcp/servers/nalediym/touch-grass) 📇 🏠 🍎 🪟 🐧 - Claude Code plugin and MCP server that nudges you to take outdoor breaks based on local weather, sunset timing, and session streaks. Tools: `check_grass_conditions`, `suggest_activity`, `log_touch_grass`, `get_stats`. Fully local, no API keys, no cloud storage.
 - [Zhonghao1995/agentic-swmm-workflow](https://github.com/Zhonghao1995/agentic-swmm-workflow) [![Zhonghao1995/agentic-swmm-workflow MCP server](https://glama.ai/mcp/servers/Zhonghao1995/agentic-swmm-workflow/badges/score.svg)](https://glama.ai/mcp/servers/Zhonghao1995/agentic-swmm-workflow) 📇 🐍 🏠 🍎 🪟 🐧 - Eleven MCP servers exposing a reproducible EPA SWMM stormwater-modelling workflow: model building, simulation runs with manifests and continuity checks, calibration, GIS/QGIS integration, design storms and climate scenarios, uncertainty analysis, plotting, and modelling memory. Config generators included for Codex, Claude Code, OpenClaw, and Hermes.
+
+### 🙏 <a name="faith-and-religion"></a>Faith & Religion
+
+Tools for Christian and other faith content — Scripture lookup and citation, study aids, sermons, and church data — for AI agents that answer faith questions or surface religious content.
+
+- [alansafahi/soapbox-faith](https://github.com/alansafahi) 📇 ☁️ - Faith tools for AI agents from SoapBox: grounded, honestly-cited Christian content callable over Streamable HTTP. Ask ORA for Scripture-grounded answers citing KJV passages, verify Bible quotes, look up Strong's, browse pastor-consented sermons and reading plans, find churches, and (with user consent) post prayer or give. 18 tools; free read tools need no key. Remote server: `https://foyekanoxpnkydoibaas.supabase.co/functions/v1/faith-mcp`.
 
 ### 📂 <a name="file-systems"></a>File Systems
 

--- a/README.md
+++ b/README.md
@@ -1441,7 +1441,7 @@ Provides access to environmental data and nature-related tools, services and inf
 
 Tools for Christian and other faith content — Scripture lookup and citation, study aids, sermons, and church data — for AI agents that answer faith questions or surface religious content.
 
-- [alansafahi/soapbox-faith](https://github.com/alansafahi) 📇 ☁️ - Faith tools for AI agents from SoapBox: grounded, honestly-cited Christian content callable over Streamable HTTP. Ask ORA for Scripture-grounded answers citing KJV passages, verify Bible quotes, look up Strong's, browse pastor-consented sermons and reading plans, find churches, and (with user consent) post prayer or give. 18 tools; free read tools need no key. Remote server: `https://foyekanoxpnkydoibaas.supabase.co/functions/v1/faith-mcp`.
+- [alansafahi/soapbox-faith](https://github.com/alansafahi/soapbox-faith) 📇 ☁️ - Faith tools for AI agents from SoapBox: grounded, honestly-cited Christian content callable over Streamable HTTP. Ask ORA for Scripture-grounded answers citing KJV passages, verify Bible quotes, look up Strong's, browse pastor-consented sermons and reading plans, find churches, and (with user consent) post prayer or give. 18 tools; free read tools need no key. Remote server: `https://foyekanoxpnkydoibaas.supabase.co/functions/v1/faith-mcp`.
 
 ### 📂 <a name="file-systems"></a>File Systems
 


### PR DESCRIPTION
Adds **SoapBox Faith**, a public remote MCP server (Streamable HTTP) that makes grounded, honestly-cited Christian faith content callable by AI agents.

### What it does
Ask ORA for Scripture-grounded answers citing KJV passages, verify Bible quotes, look up Strong's, browse pastor-consented sermons and reading plans, find churches, and (with user consent) post a prayer request or give. 18 tools total; free read tools need no key — `Authorization: Bearer <key>` is only required for purchase/prayer/giving.

- Remote endpoint: `https://foyekanoxpnkydoibaas.supabase.co/functions/v1/faith-mcp`
- Published in the official MCP Registry as `io.github.alansafahi/soapbox-faith`
- Docs: https://soapboxsuperapp.com/developers

### Category
There was no existing home for faith/religion content. The closest existing section, **Spirituality & Esoterica**, is explicitly scoped to "astrology, tarot, numerology, Vedic systems, Human Design and other divinatory or esoteric tools," which doesn't fit a Scripture-citation tool. CONTRIBUTING.md permits new categories, so this adds a **🙏 Faith & Religion** section, placed alphabetically between *Environment & Nature* and *File Systems* in both the index and the body.

Badges: 📇 (TypeScript/Deno) ☁️ (cloud/hosted service). Entry follows the existing one-server-per-line format.