### PR TITLE
Add Keryx — citation-toll research agent (x402/USDC on Arc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [tang-vu/keryx](https://github.com/tang-vu/keryx) 📇 ☁️ 🏠 - Autonomous research agent that buys paid sources under a budget and pays every creator it cites per-citation in USDC on Arc (x402 nanopayments). Free to try with no wallet at keryx.cc; add to any agent via `npx -y keryx-mcp@latest`.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds **Keryx** under **Finance & Fintech**.

Keryx is an autonomous research agent that buys paid sources under a budget, answers with inline citations, and pays every creator it cites a weighted nanopayment in USDC on Arc via x402. Each MCP call is a real on-chain payment from the caller's own funded Arc wallet.

- Live (free to try, no wallet): https://keryx.cc
- npm: `keryx-mcp` — `npx -y keryx-mcp@latest`
- Repo: https://github.com/tang-vu/keryx (MIT)

Single-line addition, format matches the list (📇 TypeScript, ☁️ cloud, 🏠 local).