### PR TITLE
🤖🤖🤖 Add Kronos Crypto Data MCP server (derivatives data + ML forecasts, x402 pay-per-call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [Kronos Crypto Data](https://github.com/hashchecked/kronos-mcp) - Real-time crypto derivatives data (funding rates, open interest, basis) + Kronos ML price forecasts for BTC/ETH/SOL. Pay-per-call via x402 on Base.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
## Summary

Adds [Kronos Crypto Data](https://github.com/hashchecked/kronos-mcp) to the Finance & Fintech section.

- Real-time crypto derivatives data: funding rates, open interest, basis, liquidation regimes across BTC/ETH/SOL
- Kronos ML price forecasts for BTC, ETH, and SOL
- Pay-per-call via x402 on Base at \$0.01–0.02/call — no signup, no API key
- Live API: https://kronossignals.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)