### PR TITLE
Add earningscalls-mcp (Finance & Fintech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [zolo-ryan/MarketAuxMcpServer](https://github.com/Zolo-Ryan/MarketAuxMcpServer) 📇 ☁️ - MCP server for comprehensive market and financial news search with advanced filtering by symbols, industries, countries, and date ranges.
 - [mnemox-ai/tradememory-protocol](https://github.com/mnemox-ai/tradememory-protocol) [Glama](https://glama.ai/mcp/servers/mnemox-ai/tradememory-protocol) 🐍 🏠 - Structured 3-layer memory system (trades → patterns → strategy) for AI trading agents. Supports MT5, Binance, and Alpaca.
 - [thoughtproof/thoughtproof-mcp](https://github.com/ThoughtProof/thoughtproof-mcp) [![thoughtproof-mcp MCP server](https://glama.ai/mcp/servers/ThoughtProof/thoughtproof-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ThoughtProof/thoughtproof-mcp) 📇 ☁️ - Adversarial multi-model reasoning verification for AI agents before trades execute. Claude, Grok, and DeepSeek challenge each decision — returns ALLOW or HOLD with JWKS-signed attestation. x402-gated on Base (USDC). Part of the 4-issuer Combined Attestation Standard with InsumerAPI, RNWY, and Maiat.
+- [stockmarketscan/earningscalls-mcp](https://github.com/stockmarketscan/earningscalls-mcp) 📇 ☁️ - Search and read 177,000+ earnings call transcripts (17,000+ companies, 70 countries, 2020-present) with role-tagged speaker segments and full-text search. Hosted MCP for Claude, Cursor, and Claude Code.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds **earningscalls-mcp** under Finance & Fintech.

Hosted MCP server for earnings call transcripts: 177,000+ transcripts from 17,000+ companies across 70 countries (2020–present), with role-tagged speaker segments and full-text search. Works with Claude Desktop, claude.ai, Claude Code, and Cursor.

- Repo: https://github.com/stockmarketscan/earningscalls-mcp
- Listed in the official MCP registry: `io.github.stockmarketscan/earningscalls-mcp`
- One server added, alphabetical/section placement per the list conventions.