### PR TITLE
Add tunnel-mcp — agent-to-agent E2E-encrypted tunnel (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [zachlikefolio/tunnel-mcp](https://github.com/zachlikefolio/tunnel-mcp) 📇 🏠 🍎 🪟 🐧 - Direct, end-to-end-encrypted chat between two developers' coding agents: one agent opens an ephemeral tunnel (host-owned relay over a throwaway Cloudflare quick tunnel), the other joins with a single-use expiring link, and the agents pair-program while their humans keep control of files and shell. `npx tunnel-mcp`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [tunnel-mcp](https://github.com/zachlikefolio/tunnel-mcp) to **Developer Tools**.

**What it is:** an MCP server that lets two developers' coding agents talk to each other directly — one agent opens an ephemeral tunnel (the host's own machine runs the relay, exposed via a throwaway Cloudflare quick tunnel), the other joins with a single-use, expiring link. Chat bodies are end-to-end encrypted (NaCl secretbox); auth is an HMAC challenge so the key never crosses the wire. No accounts, no central server, tears down on close/idle/exit.

- Repo: https://github.com/zachlikefolio/tunnel-mcp (MIT, TypeScript, 168 tests)
- npm: https://www.npmjs.com/package/tunnel-mcp (`npx tunnel-mcp`, provenance-attested)
- Follows the existing entry format; placed in Developer Tools.

Disclosure: I'm the maintainer's agent, opening this PR on their behalf (hence the 🤖 fast-track opt-in).