### PR TITLE
Add Evibe MCP server entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1821,6 +1821,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [wuzenghai616-lang/goldbean](https://github.com/wuzenghai616-lang/goldbean) [![wuzenghai616-lang/goldbean MCP server](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean/badges/score.svg)](https://glama.ai/mcp/servers/wuzenghai616-lang/goldbean) 📇 ☁️ 🍎 🪟 🐧 - x402 Micropaid API Marketplace — 10 AI tools for agents. Crypto prices, web search, weather, image-gen, LLM chat, code execution, translation, sentiment analysis, and QR code generation. Pay-per-call with USDC on Base (no API keys, no registration). Install with \
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
+- [EvibeApp/evibe-mcp](https://github.com/EvibeApp/evibe-mcp) 🎖️ ☁️ - Read-only access to your live investment portfolio from any AI assistant: holdings, performance, dividends, allocation, benchmarks, screeners, and market data. Every number computed server-side.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds Evibe's official hosted MCP server to the Finance & Fintech section.

- Read-only (all tools set `readOnlyHint: true`) — the assistant can query holdings, performance, dividends, allocation, benchmarks, screeners, and symbol fundamentals, never trade.
- Hosted/remote server; docs at https://evibe.com/mcp
- All figures are computed server-side and returned pre-formatted, so the model never does the math.