### PR TITLE
Add reanimatedead/edinet-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1839,6 +1839,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
 - [ENTIA-IA/entia-mcp-server](https://github.com/ENTIA-IA/entia-mcp-server) [![ENTIA-IA/entia-mcp-server MCP server](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server) 🎖️ 🐍 ☁️ - Verified business-identity intelligence for AI agents & MCP clients — company verification, VAT, BORME, GLEIF, ownership and risk signals across 34 countries. Remote MCP server, free tier. `npx mcp-remote https://mcp.entia.systems/mcp`
+- [reanimatedead/edinet-mcp](https://github.com/reanimatedead/edinet-mcp) [![reanimatedead/edinet-mcp MCP server](https://glama.ai/mcp/servers/reanimatedead/edinet-mcp/badges/score.svg)](https://glama.ai/mcp/servers/reanimatedead/edinet-mcp) 📇 🏠 🍎 🪟 🐧 - Normalized English income statement / balance sheet / cash-flow items for ~3,600 listed Japanese companies, from Japan’s FSA EDINET. Free, read-only, no API key.
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds **edinet-mcp** under Finance & Fintech.

An MCP server that gives LLM agents the normalized English income-statement / balance-sheet / cash-flow items (in JPY) for ~3,600 listed Japanese (non-financial) companies, sourced from Japan's FSA **EDINET**. Free, read-only (reads a public JSON API — no API key, no auth). Tools: `search_company`, `get_financials`, `compare_companies`, `list_companies`. Accounting standard auto-detected (IFRS / Japanese GAAP / US GAAP).

Repo: https://github.com/reanimatedead/edinet-mcp — MIT, TypeScript, stdio. One line added at the end of the Finance & Fintech section, following the existing format.