### PR TITLE
Add SignalBrain MCP server (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [whitestone1121-web/signalbrain](https://github.com/whitestone1121-web/signalbrain) 🐍 🏠 🍎 🪟 🐧 - Verifiable improvement receipts for coding agents: emit executable claims, objectively re-score them after merge, and gate auto-merge on per-class earned trust. `pip install "signalbrain[mcp]"`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds the SignalBrain MCP server to Developer Tools.

**What it is:** verifiable *improvement receipts* for coding agents — the agent emits an executable claim for each change (what changed, the command that proves it, stated confidence); claims are objectively re-scored after merge; auto-merge is gated on per-class earned trust (last 10 high-confidence claims ≥95% held).

- Server: `pip install "signalbrain[mcp]"` → `sb-mcp` (stdio); tools: `emit_receipt`, `validate_receipt`, `gate_status`
- Local-only (🏠): reads/writes files in the working repo, no external calls
- Apache-2.0; spec + incident forensics in the repo: https://github.com/whitestone1121-web/signalbrain
- Install line verified against live PyPI including the MCP initialize handshake

Per CONTRIBUTING.md: this PR was prepared by an agent (operator-reviewed), opting into the agent fast-track.