### PR TITLE
Add dearlordylord/voila-sdk MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,10 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [stack-chan/stack-chan](https://github.com/stack-chan/stack-chan) 📇 📟 - A JavaScript-driven M5Stack-embedded super-kawaii robot with MCP server functionality for AI-controlled interactions and emotions.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 
+### 🛒 <a name="e-commerce"></a>E-Commerce
+
+- [dearlordylord/voila-sdk](https://github.com/dearlordylord/voila-sdk) [![dearlordylord/voila-sdk MCP server](https://glama.ai/mcp/servers/dearlordylord/voila-sdk/badges/score.svg)](https://glama.ai/mcp/servers/dearlordylord/voila-sdk) 📇 ☁️ 🏠 🍎 🪟 🐧 - Personal Voila grocery automation via MCP. Search products, inspect discounts, list delivery slots, read cart and order history, and update cart quantities.
+
 ### 🌳 <a name="environment-and-nature"></a>Environment & Nature
 
 Provides access to environmental data and nature-related tools, services and information.


### PR DESCRIPTION
## Summary

Adds `dearlordylord/voila-sdk` under E-Commerce as Voila Groceries MCP.

## Notes

- Glama listing: https://glama.ai/mcp/servers/dearlordylord/voila-sdk
- Glama score badge included in the README entry using the current bot-requested format.
- Description avoids checkout/order placement language and focuses on search, discounts, slots, cart/order history, and cart quantity updates.
- https://voila.ca/
