### PR TITLE
Add VedaVisor Vedic Astrology MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3057,6 +3057,8 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
+- [dchhill/vedavisor-vedic-astrology-mcp](https://github.com/dchhill/vedavisor-vedic-astrology-mcp) 📇 ☁️ - Hosted Vedic astrology MCP server with 22 tools for birth charts, dashas, yogas, compatibility, panchanga, muhurta, prashna, and chart-aware Cosmic Advisor interpretation. Streamable HTTP endpoint: `https://mcp.vedavisor.com/mcp`.
+
 - [douglasgan/asktian](https://github.com/douglasgan/asktian-mcp) [![douglasgan/asktian-mcp MCP server](https://glama.ai/mcp/servers/douglasgan/asktian-mcp/badges/score.svg)](https://glama.ai/mcp/servers/douglasgan/asktian-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Chinese metaphysics (bazi 八字, qimen 奇門, 5-element, daily 干支) as decision-support tools. Ask "when should I do X" and get specific time windows instead of vague advice. 5 tools: daily reading, compat, best-time-for-action, today's energy, name analysis. `npm install -g @asktian/mcp-server`
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.


### PR DESCRIPTION
Adds VedaVisor Vedic Astrology MCP to the Other Tools and Integrations section.\n\nVedaVisor is a hosted Streamable HTTP MCP server for Vedic astrology with 22 tools for birth charts, dashas, yogas, compatibility, panchanga, muhurta, prashna, and chart-aware Cosmic Advisor interpretation.\n\nPublic listing repo: https://github.com/dchhill/vedavisor-vedic-astrology-mcp\nMCP endpoint: https://mcp.vedavisor.com/mcp