### PR TITLE
Add quickhelp-mcp — 15 free dev tools with hosted HTTP MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [Jan-Stepien/quickhelp](https://github.com/Jan-Stepien/quickhelp) 📇 ☁️ - 15 free deterministic developer tools (JWT decoder, JSON formatter, Base64, image converter, background remover, hash generator, UUID, URL encoder, timestamp converter, and more). Each tool has a browser UI, REST API, and MCP entry. Hosted HTTP at `https://quickhelp.dev/mcp` or `npx quickhelp-mcp` for stdio.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
## Summary

Adds [quickhelp-mcp](https://github.com/Jan-Stepien/quickhelp) to the Developer Tools section.

**quickhelp.dev** is a hub of 15 free, deterministic developer tools — each exposed as a browser UI, REST API endpoint, and MCP tool from a single hosted server.

- **Hosted HTTP endpoint (no install):** `POST https://quickhelp.dev/mcp`
- **stdio:** `npx quickhelp-mcp`
- **Tools:** JWT decoder, JSON formatter, Base64, image converter, background remover (ONNX), hash generator, UUID v4/v7, URL encoder, timestamp converter, JSON→CSV, text case converter, colour converter, number base converter, LCOV viewer
- **Free, no auth, stateless, <5s per call**