### PR TITLE
Add sanjibani/cleancloud-mcp to new Laundry & Dry Cleaning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 📟 - [Embedded system](#embedded-system)
 * 🎓 - [Education](#education)
 * 🛒 - [E-Commerce](#e-commerce)
+* 🧺 - [Laundry & Dry Cleaning](#laundry-and-dry-cleaning)
 * 🌳 - [Environment & Nature](#environment-and-nature)
 * 📂 - [File Systems](#file-systems)
 * 💰 - [Finance & Fintech](#finance--fintech)
@@ -1416,6 +1417,12 @@ MCP servers for e-commerce platforms and online store management.
 - [nicktcode/swissgroceries-mcp](https://github.com/nicktcode/swissgroceries-mcp) [![nicktcode/swissgroceries-mcp MCP server](https://glama.ai/mcp/servers/nicktcode/swissgroceries-mcp/badges/score.svg)](https://glama.ai/mcp/servers/nicktcode/swissgroceries-mcp) 📇 ☁️ 🍎 🪟 🐧 - Swiss grocery search, weekly promotions, and multi-store shopping plans across Migros, Coop, Aldi, Denner, Lidl, Farmy, Volg, and Otto's. Cross-chain unit-price comparison and three planning strategies (single_store / split_cart / absolute_cheapest). Install via `npx -y @nicktcode/swissgroceries-mcp`.
 - [slookisen/lokal](https://github.com/slookisen/lokal) [![slookisen/lokal MCP server](https://glama.ai/mcp/servers/slookisen/lokal/badges/score.svg)](https://glama.ai/mcp/servers/slookisen/lokal) 📇 ☁️ 🍎 🪟 🐧 - Search and discover 1,400+ verified local food producers in Norway — farms, REKO rings, farmers' markets, and farm shops. Natural-language search (NO/EN), geo-filtered discovery, and A2A protocol support, backed by [rettfrabonden.com](https://rettfrabonden.com). Install via `npx lokal-mcp`.
 - [tokenofesteem/mcp](https://github.com/tokenofesteem/mcp) [![tokenofesteem/mcp MCP server](https://glama.ai/mcp/servers/tokenofesteem/mcp/badges/score.svg)](https://glama.ai/mcp/servers/tokenofesteem/mcp) 🎖️ 📇 ☁️ - An agent can commission a funny, personalized printed booklet and have it printed and mailed as a gift, including a surprise for its own user. Pay with an account token, or tokenless with a single-use Stripe payment over HTTP 402. Remote MCP, US shipping, $19.99.
+
+### 🧺 <a name="laundry-and-dry-cleaning"></a>Laundry & Dry Cleaning
+
+MCP servers for laundromat, dry cleaning, and alterations POS platforms.
+
+- [sanjibani/cleancloud-mcp](https://github.com/sanjibani/cleancloud-mcp) 🐍 ☁️ - First MCP server for the CleanCloud POS API. 9 tools covering orders, order summary, invoices, payments, customers, business accounts, repeat pickups, and pickup availability. CleanCloud serves 2,500+ shops in 90+ countries. 31 tests, ruff + mypy --strict clean. MIT.
 
 ### 🌳 <a name="environment-and-nature"></a>Environment & Nature
 


### PR DESCRIPTION
Add sanjibani/cleancloud-mcp to a new Laundry & Dry Cleaning section in E-Commerce — first MCP for the laundry / dry-cleaning / alterations POS space. CleanCloud serves 2,500+ shops in 90+ countries. 9 tools covering orders, invoices, customers, payments, and pickup availability. 31 tests, ruff + mypy --strict clean. MIT.