### PR TITLE
Add agent-gate to Developer Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [Jott2121/agent-gate](https://github.com/Jott2121/agent-gate) [![Jott2121/agent-gate MCP server](https://glama.ai/mcp/servers/Jott2121/agent-gate/badges/score.svg)](https://glama.ai/mcp/servers/Jott2121/agent-gate) 🐍 🏠 - Fail-closed quality gate for AI agents: an agent must pass a deterministic checklist before it can claim "done," and every decision is appended to a hash-chained receipt ledger that verifies tamper-free. Stops agents from grading their own homework. `pip install mcp-agent-gate`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds agent-gate, an MCP server that makes an AI agent pass a fail-closed quality gate before it can claim "done": a deterministic checklist plus an append-only, hash-chained receipt ledger that verifies tamper-free. Python, local (stdio), MIT licensed, on PyPI as `mcp-agent-gate` and in the official MCP registry. Added to Developer Tools in the existing format with a Glama score badge.