### PR TITLE
Add rag-starter (end to end RAG platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2449,6 +2449,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 
+- [cstamigo-droid/rag-starter](https://github.com/cstamigo-droid/rag-starter) 🐍 🏠 - Keyless local RAG (ChromaDB, ONNX embeddings) that answers questions about your docs with traceable citations. Exposed over both MCP and a FastAPI HTTP API.
 - [gogabrielordonez/mcp-ragchat](https://github.com/gogabrielordonez/mcp-ragchat) 📇 🏠 - Add RAG-powered AI chat to any website with one command. Local vector store, multi-provider LLM (OpenAI/Anthropic/Gemini), self-contained chat server and embeddable widget.
 - [poll-the-people/customgpt-mcp](https://github.com/Poll-The-People/customgpt-mcp) 🐍 🏠 ☁️ - An MCP server for accessing all of CustomGPT.ai's anti-hallucination RAG-as-a-service API endpoints.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.

--- a/README.md
+++ b/README.md
@@ -2449,7 +2449,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 ### 🔎 <a name="RAG"></a>end to end RAG platforms
 
-- [cstamigo-droid/rag-starter](https://github.com/cstamigo-droid/rag-starter) 🐍 🏠 - Keyless local RAG (ChromaDB, ONNX embeddings) that answers questions about your docs with traceable citations. Exposed over both MCP and a FastAPI HTTP API.
+- [cstamigo-droid/rag-starter](https://github.com/cstamigo-droid/rag-starter) 🐍 🏠 - Keyless local RAG (ChromaDB, ONNX embeddings) that answers questions about your docs with traceable citations. Exposed over both MCP and a FastAPI HTTP API. [![rag-starter MCP server](https://glama.ai/mcp/servers/cstamigo-droid/rag-starter/badges/score.svg)](https://glama.ai/mcp/servers/cstamigo-droid/rag-starter)
 - [gogabrielordonez/mcp-ragchat](https://github.com/gogabrielordonez/mcp-ragchat) 📇 🏠 - Add RAG-powered AI chat to any website with one command. Local vector store, multi-provider LLM (OpenAI/Anthropic/Gemini), self-contained chat server and embeddable widget.
 - [poll-the-people/customgpt-mcp](https://github.com/Poll-The-People/customgpt-mcp) 🐍 🏠 ☁️ - An MCP server for accessing all of CustomGPT.ai's anti-hallucination RAG-as-a-service API endpoints.
 - [vectara/vectara-mcp](https://github.com/vectara/vectara-mcp) 🐍 🏠 ☁️ - An MCP server for accessing Vectara's trusted RAG-as-a-service platform.


### PR DESCRIPTION
Adds cstamigo-droid/rag-starter — keyless local RAG (ChromaDB, ONNX embeddings) answering questions about your docs with traceable citations, over both MCP and a FastAPI HTTP API. Python, stdio, local. Public repo.