### PR TITLE
Add MetaEngine MCP server (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [meta-engine/mcp-server](https://github.com/meta-engine/mcp-server) [![meta-engine/mcp-server MCP server](https://glama.ai/mcp/servers/meta-engine/mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/meta-engine/mcp-server) 🎖️ 📇 🏠 ☁️ 🍎 🪟 🐧 - Spec-first code generation: converts OpenAPI, GraphQL, Protobuf, and SQL specs into typed clients and models across 10 frameworks / 11 languages, plus batch generation of arbitrary type graphs with resolved imports. Deterministic output, free, no API key. `npx -y @metaengine/mcp-server`.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds [meta-engine/mcp-server](https://github.com/meta-engine/mcp-server) to **Developer Tools**.

MetaEngine's official MCP server (TypeScript, stdio, MIT): spec-first code generation — converts OpenAPI 3.x, GraphQL SDL, Protocol Buffers, and SQL DDL into typed clients and models across 10 frameworks / 11 languages, plus batch generation of arbitrary type graphs with resolved imports. Free, no API key: `npx -y @metaengine/mcp-server`.

Also listed on the official MCP Registry as `eu.metaengine/mcp-server` and on npm as [@metaengine/mcp-server](https://www.npmjs.com/package/@metaengine/mcp-server).