### PR TITLE
Add CalcFleet (121 deterministic calculators as MCP tools) to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1839,6 +1839,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
 - [ENTIA-IA/entia-mcp-server](https://github.com/ENTIA-IA/entia-mcp-server) [![ENTIA-IA/entia-mcp-server MCP server](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server) 🎖️ 🐍 ☁️ - Verified business-identity intelligence for AI agents & MCP clients — company verification, VAT, BORME, GLEIF, ownership and risk signals across 34 countries. Remote MCP server, free tier. `npx mcp-remote https://mcp.entia.systems/mcp`
+- [egmuel/calcfleet-mcp](https://github.com/egmuel/calcfleet-mcp) 📇 ☁️ - 121 deterministic, source-cited calculators as MCP tools: finance, AI/LLM cost, health, home & construction, cooking and more. Reliable math agents can call instead of hallucinating numbers. Free, no API key. Remote MCP at https://calcfleet.com/api/mcp
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds [egmuel/calcfleet-mcp](https://github.com/egmuel/calcfleet-mcp) under **Finance & Fintech**.

CalcFleet is a hosted (Streamable HTTP) MCP server exposing 121 deterministic, source-cited calculators — finance, AI/LLM cost, health, home & construction, cooking and more — so agents can call tested math instead of hallucinating numbers. Free, no API key.

- Remote endpoint: https://calcfleet.com/api/mcp
- Site: https://calcfleet.com
- Official MCP Registry: `com.calcfleet/calculators`

Legend: 📇 (TypeScript) ☁️ (Cloud Service). Placed at the end of the Finance & Fintech section.