### PR TITLE
Add Boardstate — agent-composable dashboards (Data Visualization) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,6 +1375,8 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 
 Interactive charts, dashboards, and visual data tools rendered inside AI conversations.
 
+- [100yenadmin/boardstate](https://github.com/100yenadmin/boardstate) 📇 🏠 🍎 🪟 🐧 - Agent-composable dashboards where the whole dashboard is one validated JSON document: any MCP client builds and edits it through `boardstate_*` tools (tabs, widgets, layout, live stream bindings, a design-review lint), humans edit the same board with drag & drop, and agent-authored custom widgets run sandboxed behind an approval gate.
+
 - [KyuRish/mcp-dashboards](https://github.com/KyuRish/mcp-dashboards) [![mcp-dashboards MCP server](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards/badges/score.svg)](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards) 📇 🏠 🍎 🪟 🐧 - 45+ interactive chart types (bar, line, pie, candlestick, sankey, geo, radar, funnel, treemap, and more), dashboards with KPI cards, drill-down navigation, live API polling, 20 themes, and export to PNG/PPT/A4. Built on MCP Apps.
 
 - [marzukia/charted](https://github.com/marzukia/charted) [![marzukia/charted MCP server](https://glama.ai/mcp/servers/marzukia/charted/badges/score.svg)](https://glama.ai/mcp/servers/marzukia/charted) 🐍 🏠 🍎 🪟 🐧 - Zero-dependency chart server that renders bar, line, pie, scatter, and more from JSON or CSV to SVG, HTML, PNG, or data URL. Built-in themes; PNG output renders inline in chat. Install via `uvx --from charted[mcp] charted-mcp`.

--- a/README.md
+++ b/README.md
@@ -1375,7 +1375,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 
 Interactive charts, dashboards, and visual data tools rendered inside AI conversations.
 
-- [100yenadmin/boardstate](https://github.com/100yenadmin/boardstate) 📇 🏠 🍎 🪟 🐧 - Agent-composable dashboards where the whole dashboard is one validated JSON document: any MCP client builds and edits it through `boardstate_*` tools (tabs, widgets, layout, live stream bindings, a design-review lint), humans edit the same board with drag & drop, and agent-authored custom widgets run sandboxed behind an approval gate.
+- [100yenadmin/boardstate](https://github.com/100yenadmin/boardstate) [![100yenadmin/boardstate MCP server](https://glama.ai/mcp/servers/100yenadmin/boardstate/badges/score.svg)](https://glama.ai/mcp/servers/100yenadmin/boardstate) 📇 🏠 🍎 🪟 🐧 - Agent-composable dashboards where the whole dashboard is one validated JSON document: any MCP client builds and edits it through `boardstate_*` tools (tabs, widgets, layout, live stream bindings, a design-review lint), humans edit the same board with drag & drop, and agent-authored custom widgets run sandboxed behind an approval gate.
 
 - [KyuRish/mcp-dashboards](https://github.com/KyuRish/mcp-dashboards) [![mcp-dashboards MCP server](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards/badges/score.svg)](https://glama.ai/mcp/servers/@KyuRish/mcp-dashboards) 📇 🏠 🍎 🪟 🐧 - 45+ interactive chart types (bar, line, pie, candlestick, sankey, geo, radar, funnel, treemap, and more), dashboards with KPI cards, drill-down navigation, live API polling, 20 themes, and export to PNG/PPT/A4. Built on MCP Apps.
 


### PR DESCRIPTION
Adds [Boardstate](https://github.com/100yenadmin/boardstate) to **Data Visualization**.

**What it is:** an MIT, layout-as-data dashboard substrate: the entire dashboard — tabs, widgets, layout, data bindings, and the registry of agent-authored custom widgets — is one validated JSON document. `@boardstate/mcp` exposes the full `boardstate_*` tool set (tab/widget CRUD, layout, workspace replace/undo, a design-review lint, widget scaffolding) to any MCP client; the same document renders as embeddable web components with drag & drop human editing, and agent-authored widgets run in a no-network sandbox behind an explicit approval gate.

- Repo: https://github.com/100yenadmin/boardstate (MIT, TypeScript, npm `@boardstate/*` with 8 packages)
- Live demo (no key needed): https://100yenadmin.github.io/boardstate/app/
- The MCP tools drive the same control plane humans use — one entry line, follows the section's format with legend emojis.

Per CONTRIBUTING's note: this PR was prepared by an automated agent on behalf of the project owner — opting into the agent fast-track. 🤖🤖🤖