### PR TITLE
Add nikhonit/indeed-skills to Search & Data Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2624,6 +2624,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [zlatkoc/youtube-summarize](https://github.com/zlatkoc/youtube-summarize) 🐍 ☁️ - MCP server that fetches YouTube video transcripts and optionally summarizes them. Supports multiple transcript formats (text, JSON, SRT, WebVTT), multi-language retrieval, and flexible YouTube URL parsing.
 - [zoomeye-ai/mcp_zoomeye](https://github.com/zoomeye-ai/mcp_zoomeye) 📇 ☁️ - Querying network asset information by ZoomEye MCP Server
 - [juergenkoller-software/pdf-content-search-mcp](https://github.com/juergenkoller-software/pdf-content-search-mcp) [![juergenkoller-software/pdf-content-search-mcp MCP server](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp) 🏠 🍎 - MCP bridge for [PDF Content Search](https://store.juergenkoller.software/en/apps/pdf-content-search) — full-text PDF search with Apple Vision OCR across thousands of documents in under a second. Advanced filters (date, category, sender, amount), wildcards, boolean operators.
+- [nikhonit/indeed-skills](https://github.com/nikhonit/indeed-skills) 🐍 ☁️ 🏠 🍎 🪟 🐧 - Live Indeed job-postings data via the RolesAPI REST API — search listings by keyword/location and fetch role details, salary, description, company, and benefits across 60+ country editions. Free tier available.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds indeed-skills — three drop-in agent skills plus a hosted MCP server for live Indeed job-postings data via the RolesAPI REST API (search listings by keyword/location; role details, salary, description, company, and benefits across 60+ country editions). Python stdlib, MIT-0, free tier.