### PR TITLE
Add Kiln (3D printer control MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,6 +1402,7 @@ Provides access to documentation and shortcuts for working on embedded devices.
 - [yoelbassin/gnuradioMCP](https://github.com/yoelbassin/gnuradioMCP) 🐍 📟 🏠 - An MCP server for GNU Radio that enables LLMs to autonomously create and modify RF `.grc` flowcharts.
 - [catallo/misterclaw](https://github.com/catallo/misterclaw) [![catallo/misterclaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/score.svg)](https://glama.ai/mcp/servers/catallo/misterclaw) 🏎️ 📟 🏠 🐧 🍎 - MiSTerClaw — MCP remote control for MiSTer-FPGA. Launch games, search ROMs, take screenshots, manage systems, and set up Tailscale VPN. Auto-discovers 70+ systems with dynamic core/ROM scanning.
 - [zackpeters93/ugs-mcp](https://github.com/zackpeters93/ugs-mcp) [![zackpeters93/ugs-mcp MCP server](https://glama.ai/mcp/servers/zackpeters93/ugs-mcp/badges/score.svg)](https://glama.ai/mcp/servers/zackpeters93/ugs-mcp) 🐍 📟 🏠 🍎 - CNC machine control via Universal G-code Sender (GRBL). Jog axes, home, run G-code files, inspect toolpaths, estimate cycle times. Motion commands require two-step token confirmation — Claude cannot move hardware autonomously.
+- [codeofaxel/Kiln](https://github.com/codeofaxel/Kiln) 🐍 📟 🏠 🍎 🪟 🐧 - MCP server that lets AI agents drive real 3D printers end to end — design, slice, queue, monitor via camera, and recover from failures — across Bambu Lab, Creality, Prusa, Elegoo, and more over OctoPrint, Moonraker/Klipper, PrusaLink, and USB. AGPL-3.0, `pip install kiln3d`.
 
 ### 🎓 <a name="education"></a>Education
 


### PR DESCRIPTION
Kiln is an open-source MCP server that lets AI agents drive real 3D printers end to end — design, slice, queue, monitor via camera, and recover from failures — across Bambu Lab, Creality, Prusa, Elegoo, and more, over OctoPrint, Moonraker/Klipper, PrusaLink, and USB.

Placed in Embedded System next to the existing CNC/G-code entry (ugs-mcp), which is the closest sibling in scope.

- Repo: https://github.com/codeofaxel/Kiln
- License: AGPL-3.0
- Install: `pip install kiln3d`