### PR TITLE
Add PodLearn (podcast/YouTube transcription & lessons) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2892,6 +2892,7 @@ Translation tools and services to enable AI assistants to translate content betw
 
 ### 🎙️ <a name="speech-to-text"></a>Speech-to-Text
 
+- [blutrich/podlearn-plugin](https://github.com/blutrich/podlearn-plugin) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - Search 4M+ podcasts (PodcastIndex) and YouTube, transcribe any episode or video URL (even without captions), bulk-transcribe whole feeds, full-text-search transcripts, and generate AI lessons and LinkedIn posts via the hosted [PodLearn](https://podlearn.ai) API. 25 tools over Streamable HTTP.
 - [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) [![eviscerations/whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
 - [spokenmd/spoken](https://github.com/spokenmd/spoken) [![spokenmd/spoken MCP server](https://glama.ai/mcp/servers/spokenmd/spoken/badges/score.svg)](https://glama.ai/mcp/servers/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
 


### PR DESCRIPTION
Adds PodLearn under Speech-to-Text (alphabetical position: first). Hosted Streamable HTTP MCP server, 25 tools: podcast/YouTube search (PodcastIndex, 4M+ feeds), transcription of any episode/video URL including caption-less videos, feed bulk-transcription, full-text transcript search, AI lesson + LinkedIn post generation. Docs: https://podlearn.ai/mcp-docs • Repo: https://github.com/blutrich/podlearn-plugin (AGPL-3.0).