### PR TITLE
Add WebAbility accessibility MCP server (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,7 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
-- [snayyar00/abilyo](https://github.com/snayyar00/abilyo) 🎖️ 📇 🏠 ☁️ - WebAbility — accessibility testing + AI fixes for coding agents (Cursor, Claude Code, Copilot, Windsurf, VS Code). Free local WCAG scans, framework-aware fixes you apply in your own code, a vision pass axe can't do, one-call fix verification, and full audit reports. `npx @webability/mcp`
+- [snayyar00/webability-mcp](https://github.com/snayyar00/webability-mcp) 🎖️ 📇 🏠 ☁️ - WebAbility — accessibility testing + AI fixes for coding agents (Cursor, Claude Code, Copilot, Windsurf, VS Code). Free local WCAG scans, framework-aware fixes you apply in your own code, a vision pass axe can't do, one-call fix verification, and full audit reports. `npx @webability/mcp`
 
 ### 🔒 <a name="delivery"></a>Delivery
 

--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [snayyar00/abilyo](https://github.com/snayyar00/abilyo) 🎖️ 📇 🏠 ☁️ - WebAbility — accessibility testing + AI fixes for coding agents (Cursor, Claude Code, Copilot, Windsurf, VS Code). Free local WCAG scans, framework-aware fixes you apply in your own code, a vision pass axe can't do, one-call fix verification, and full audit reports. `npx @webability/mcp`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds **WebAbility** — the official accessibility MCP server for AI coding agents — under **Developer Tools** (no accessibility category exists; this is the closest fit).

- Entry: `- [snayyar00/abilyo](https://github.com/snayyar00/abilyo) 🎖️ 📇 🏠 ☁️ - WebAbility — accessibility testing + AI fixes for coding agents (Cursor, Claude Code, Copilot, Windsurf, VS Code). Free local WCAG scans, framework-aware fixes you apply in your own code, a vision pass axe can't do, one-call fix verification, and full audit reports. \`npx @webability/mcp\``
- npm: `@webability/mcp` (bin `webability-mcp`, stdio) · hosted endpoint https://mcp.webability.io
- Source: https://github.com/snayyar00/abilyo · Homepage: https://webability.io
- DOM scan/fix tools are free + local (no account); `visual_audit` / `start_audit` need a WebAbility account.

Format matches existing entries (linked repo name, language + scope icons, concise description). Alphabetical/append order preserved within the section.