### PR TITLE
Add moflo (Developer Tools) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [eric-cielo/moflo](https://github.com/eric-cielo/moflo) 📇 🏠 🍎 🪟 🐧 - Local-first semantic memory, code navigation, and agent orchestration for Claude Code. Node-native SQLite + HNSW vector search, learned task routing, memory-first gates, and hooks — no API keys, no cloud. `npm install --save-dev moflo`
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
Adds **moflo** to the Developer Tools section.

[eric-cielo/moflo](https://github.com/eric-cielo/moflo) is a local-first MCP server (`mcp__moflo__*` tools) that gives Claude Code semantic memory, code/guidance navigation, and agent orchestration. Node-native SQLite + HNSW vector search, learned task routing, memory-first gates, and hooks. No API keys, no cloud — everything runs on the user's machine. Installed with `npm install --save-dev moflo`.

- Placed in Developer Tools, following the existing entry format (repo link, language/scope/OS emoji, one-line description).
- Cross-platform (macOS/Linux/Windows), TypeScript, local-first.
- Links verified.

🤖🤖🤖 opting into the streamlined agent-PR process per CONTRIBUTING.