### PR TITLE
Add SuperBased Observer MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [ozers/hooksense-mcp](https://github.com/ozers/hooksense-mcp) [![ozers/hooksense-mcp MCP server](https://glama.ai/mcp/servers/ozers/hooksense-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ozers/hooksense-mcp) 📇 ☁️ - Webhook & callback layer for AI agents: create a callback URL, then `wait_for_callback` to block until the webhook lands — signature-verified and decrypted — instead of polling. Verify HMAC, list/replay callbacks. `npx -y @hooksense/mcp`
 
 - [Eltortilla1/synapse-code-mcp](https://github.com/Eltortilla1/synapse-code-mcp) 📇 🏠 🍎 🪟 🐧 - Structural code context server for AI agents — compressed symbol indexes, dependency graphs, and git diffs via TypeScript AST analysis. Zero external dependencies, no vector database or embedding API required.
+- [marmutapp/superbased-observer](https://github.com/marmutapp/superbased-observer) 🏎️ 🏠 🍎 🪟 🐧 - Local-first MCP server that lets a coding agent query its own project history — file/command freshness, past test failures, cost & token spend, and cross-tool session handoff — across 26 supported coding-agent adapters (Claude Code, Cursor, Codex, and more). 100% local, no telemetry.
 
 ### 🔒 <a name="delivery"></a>Delivery
 


### PR DESCRIPTION
SuperBased Observer is a local-first Go tool that captures, normalizes, and analyzes tool-call activity across 26 AI coding-agent adapters (Claude Code, Cursor, Codex, and more). It bundles a stdio MCP server (25 tools: 21 always-on + 4 conditional) that lets a coding agent query its own captured project history — file/command freshness, past test failures, cost & token spend, and cross-tool session handoff.

Everything runs 100% locally in SQLite with no telemetry; the MCP server is opt-in (`observer init`) and spawned by the AI tool itself.

- Repo: https://github.com/marmutapp/superbased-observer
- Docs: https://superbased.app/docs
