### PR TITLE
Add opula (AI wealth analyst) to Finance & Fintech 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1839,6 +1839,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 px goldbean-mcp\.
 - [bevanding/signaldaemon](https://github.com/bevanding/signaldaemon) [![bevanding/signaldaemon MCP server](https://glama.ai/mcp/servers/bevanding/signaldaemon/badges/score.svg)](https://glama.ai/mcp/servers/bevanding/signaldaemon) 🐍 ☁️ - Narrative & signal intelligence for AI agents (crypto/AI/macro): cross-source narrative convergence and capital-vs-narrative divergence. Remote MCP server, self-serve keys, fails safe (says "no coverage" rather than hallucinating).
 - [ENTIA-IA/entia-mcp-server](https://github.com/ENTIA-IA/entia-mcp-server) [![ENTIA-IA/entia-mcp-server MCP server](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ENTIA-IA/entia-mcp-server) 🎖️ 🐍 ☁️ - Verified business-identity intelligence for AI agents & MCP clients — company verification, VAT, BORME, GLEIF, ownership and risk signals across 34 countries. Remote MCP server, free tier. `npx mcp-remote https://mcp.entia.systems/mcp`
+- [opula](https://opula.io) ☁️ - AI wealth analyst inside Claude that unifies every asset your bank can't sync (crypto, real estate, private holdings) and answers portfolio questions with deterministic, rule-computed facts. Remote MCP at https://opula.io/api/mcp
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds **opula** to the Finance & Fintech section.

- **What it is:** A hosted MCP server that acts as an AI wealth analyst inside Claude. It unifies assets a bank can't sync (crypto, real estate, private holdings) and answers portfolio questions with deterministic, rule-computed facts rather than hallucinations.
- **Transport:** Streamable HTTP (remote), endpoint `https://opula.io/api/mcp`
- **Homepage:** https://opula.io
- **Glama connector:** https://glama.ai/mcp/connectors/io.github.evan-moon/opula (ownership verified)

Follows the existing format for hosted/remote servers (e.g. entries linked to a homepage). One-line addition, alphabetical section unchanged otherwise.
