### PR TITLE
Add easakura/japan-company-leads-mcp (Japan B2B company lead search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2292,6 +2292,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
 
 ### 🎯 <a name="marketing"></a>Marketing
+- [easakura/japan-company-leads-mcp](https://github.com/easakura/japan-company-leads-mcp) [![easakura/japan-company-leads-mcp MCP server](https://glama.ai/mcp/servers/easakura/japan-company-leads-mcp/badges/score.svg)](https://glama.ai/mcp/servers/easakura/japan-company-leads-mcp) 📇 ☁️ - B2B lead generation for Japan: search 1M+ companies by size, capital, location, and government-subsidy history, with executive names and procurement records (official METI gBizINFO data).
 
 Tools for creating and editing marketing content, working with web meta data, product positioning, and editing guides.
 


### PR DESCRIPTION
Adds one server to **🎯 Marketing**.

This is a resubmission split out from #9622 per the maintainer's request to submit one server per PR.

**Server:** [easakura/japan-company-leads-mcp](https://github.com/easakura/japan-company-leads-mcp) — B2B lead generation for Japan: search 1M+ companies by size, capital, location, and government-subsidy history, with executive names and procurement records (official METI gBizINFO data). Remote (Streamable HTTP), official government data, no scraping.