### PR TITLE
Add easakura/japan-real-estate-mcp (Japan real-estate transaction & land prices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2512,6 +2512,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 auto-download. Install via `npx atlassian-trello-mcp`.
 
 ### 🏠 <a name="real-estate"></a>Real Estate
+- [easakura/japan-real-estate-mcp](https://github.com/easakura/japan-real-estate-mcp) [![easakura/japan-real-estate-mcp MCP server](https://glama.ai/mcp/servers/easakura/japan-real-estate-mcp/badges/score.svg)](https://glama.ai/mcp/servers/easakura/japan-real-estate-mcp) 📇 ☁️ - Japanese real-estate actual transaction prices and official land prices (official MLIT Reinfolib data): search by area, period, and property type, with published land-price reference points.
 
 MCP servers for real estate CRM, property management, and agent workflows.
 


### PR DESCRIPTION
Adds one server to **🏠 Real Estate**.

This is a resubmission split out from #9622 per the maintainer's request to submit one server per PR.

**Server:** [easakura/japan-real-estate-mcp](https://github.com/easakura/japan-real-estate-mcp) — Japanese real-estate actual transaction prices and official land prices using the official MLIT Reinfolib API (search by area, period, and property type). Remote (Streamable HTTP), official government data, no scraping.