### PR TITLE
Add gittr-mcp (Git on Nostr via gittr.space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3128,6 +3128,7 @@ Access to travel and transportation information. Enables querying schedules, rou
 
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.
 
+- [arbadacarbaYK/gittr-mcp](https://github.com/arbadacarbaYK/gittr-mcp) 📇 🏠 - Git on Nostr via [gittr.space](https://gittr.space): push, issues, PRs, stars, bounties, private repos. NIP-34 + NIP-98 bridge auth.
 - [adhikasp/mcp-git-ingest](https://github.com/adhikasp/mcp-git-ingest) 🐍 🏠 - Read and analyze GitHub repositories with your LLM
 - [costajohnt/oss-autopilot](https://github.com/costajohnt/oss-autopilot) [![costajohnt/oss-autopilot MCP server](https://glama.ai/mcp/servers/costajohnt/oss-autopilot/badges/score.svg)](https://glama.ai/mcp/servers/costajohnt/oss-autopilot) 📇 ☁️ 🏠 🍎 🪟 🐧 - Open source contribution manager with PR tracking across repos, issue discovery, CI failure diagnosis, and maintainer response drafting. Available as CLI, MCP server, and Claude Code plugin.
 - [daniloneto/bitbucket-mcp](https://github.com/daniloneto/bitbucket-mcp) [![daniloneto/bitbucket-mcp MCP server](https://glama.ai/mcp/servers/daniloneto/bitbucket-mcp/badges/score.svg)](https://glama.ai/mcp/servers/daniloneto/bitbucket-mcp) 📇 ☁️ - MCP server for Bitbucket Cloud focused on pull-request review — read PRs, diffs, comments, commits, files and the repo tree; post inline/general comments, approve, or request changes. Uses Atlassian API tokens (stdio).


### PR DESCRIPTION
## Summary

Adds [gittr-mcp](https://github.com/arbadacarbaYK/gittr-mcp) to the Version Control section.

- Decentralized git on Nostr via [gittr.space](https://gittr.space)
- MCP tools for repos, push, issues, PRs, stars, bounties, and private repos
- Nostr identity (NIP-34) + bridge auth (NIP-98)
- Listed in the [official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.arbadacarbaYK/gittr-mcp`

## Test plan

- [x] Link resolves to https://github.com/arbadacarbaYK/gittr-mcp
- [x] Placed alphabetically in Version Control (after adhikasp, before costajohnt)
