### PR TITLE
Add semantic-tool-router to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3242,7 +3242,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
-- [arunmm8335/semantic-tool-router](https://github.com/arunmm8335/semantic-tool-router) 🐍 🏠 - Semantic Tool Router: A Retrieval-Augmented Generation (RAG) pre-processing layer for MCP tools. Dynamically routes only the top-K relevant tools to your LLM's context window to reduce token costs and hallucinations.
+- [arunmm8335/semantic-tool-router](https://github.com/arunmm8335/semantic-tool-router) [![arunmm8335/semantic-tool-router MCP server](https://glama.ai/mcp/servers/arunmm8335/semantic-tool-router/badges/score.svg)](https://glama.ai/mcp/servers/arunmm8335/semantic-tool-router) 🐍 🏠 - Semantic Tool Router: A Retrieval-Augmented Generation (RAG) pre-processing layer for MCP tools. Dynamically routes only the top-K relevant tools to your LLM's context window to reduce token costs and hallucinations.
 - [douglasgan/asktian](https://github.com/douglasgan/asktian-mcp) [![douglasgan/asktian-mcp MCP server](https://glama.ai/mcp/servers/douglasgan/asktian-mcp/badges/score.svg)](https://glama.ai/mcp/servers/douglasgan/asktian-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Chinese metaphysics (bazi 八字, qimen 奇門, 5-element, daily 干支) as decision-support tools. Ask "when should I do X" and get specific time windows instead of vague advice. 5 tools: daily reading, compat, best-time-for-action, today's energy, name analysis. `npm install -g @asktian/mcp-server`
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.

--- a/README.md
+++ b/README.md
@@ -3242,6 +3242,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
+- [arunmm8335/semantic-tool-router](https://github.com/arunmm8335/semantic-tool-router) 🐍 🏠 - Semantic Tool Router: A Retrieval-Augmented Generation (RAG) pre-processing layer for MCP tools. Dynamically routes only the top-K relevant tools to your LLM's context window to reduce token costs and hallucinations.
 - [douglasgan/asktian](https://github.com/douglasgan/asktian-mcp) [![douglasgan/asktian-mcp MCP server](https://glama.ai/mcp/servers/douglasgan/asktian-mcp/badges/score.svg)](https://glama.ai/mcp/servers/douglasgan/asktian-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Chinese metaphysics (bazi 八字, qimen 奇門, 5-element, daily 干支) as decision-support tools. Ask "when should I do X" and get specific time windows instead of vague advice. 5 tools: daily reading, compat, best-time-for-action, today's energy, name analysis. `npm install -g @asktian/mcp-server`
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.


### PR DESCRIPTION
Adding semantic-tool-router, a retrieval-augmented generation (RAG) pre-processing layer for MCP tools that dynamically routes only the top-K relevant tools to the LLM's context window.