### PR TITLE
Add PodKit to Podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2526,6 +2526,7 @@ Servers for podcast analytics, search, hosting, and discovery.
 
 - [conorbronsdon/op3-mcp](https://github.com/conorbronsdon/op3-mcp) [![conorbronsdon/op3-mcp MCP server](https://glama.ai/mcp/servers/conorbronsdon/op3-mcp/badges/score.svg)](https://glama.ai/mcp/servers/conorbronsdon/op3-mcp) 📇 ☁️ - Podcast analytics from OP3, the Open Podcast Prefix Project: downloads over time, listener geography, app share, and per-episode breakdowns. Read-only by design.
 - [conorbronsdon/Transistor-MCP](https://github.com/conorbronsdon/Transistor-MCP) [![conorbronsdon/Transistor-MCP MCP server](https://glama.ai/mcp/servers/conorbronsdon/Transistor-MCP/badges/score.svg)](https://glama.ai/mcp/servers/conorbronsdon/Transistor-MCP) 📇 ☁️ - Manage Transistor.fm podcasts: episodes, analytics, download summaries, episode comparisons, transcripts, and webhooks.
+- [PodKit](https://podkitapp.com/mcp) 🎖️ 📇 ☁️ - Podcast search, metadata, chapters, and transcripts for AI agents.
 
 ### 📋 <a name="product-management"></a>Product Management
 


### PR DESCRIPTION
Adds PodKit to the 🎙️ Podcasts section.

PodKit is a hosted, first-party MCP server for podcast data — search, metadata,
chapters, and transcripts for AI agents (also available as a REST API).
Streamable HTTP endpoint: https://podkitapp.com/mcp

Legend flags: 🎖️ official (first-party server for the PodKit API) · 📇 TypeScript
· ☁️ cloud/hosted service.

Single-line addition, placed alphabetically within the Podcasts section; no other changes.