### PR TITLE
Add HELM (Claude Desktop agent supervisor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,8 @@ Tools and integrations that enhance the development workflow and environment man
 - [Bishop81/imagedimensions-mcp](https://github.com/Bishop81/imagedimensions-mcp) [![Bishop81/imagedimensions-mcp MCP server](https://glama.ai/mcp/servers/Bishop81/imagedimensions-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Bishop81/imagedimensions-mcp) 📇 ☁️ - Audit the images on any web page: natural vs rendered dimensions, oversized-image detection, and format breakdown, so agents can check web-image performance. Calls the hosted imagedimensions.com API, so no local browser is required. `npx -y imagedimensions-mcp`
 
 - [sebastienrousseau/rlg](https://github.com/sebastienrousseau/rlg) [![sebastienrousseau/rlg-mcp MCP server](https://glama.ai/mcp/servers/sebastienrousseau/rlg/badges/score.svg)](https://glama.ai/mcp/servers/sebastienrousseau/rlg) 🦀 🏠 🍎 🪟 🐧 - **Log-stream tools for on-call / SRE agent workflows** — expose `rlg` (RustLogs) log files as MCP tools. Three tools: `tail_log` (last N events, filtered by level/target), `filter_log` (JSON-path-style predicates), `summarize_errors` (grouped error taxonomy). Speaks JSON-RPC 2.0 over stdio; near-lock-free structured logging engine underneath (65k-slot ring buffer, 14 output formats, `os_log`/`journald` sinks). Install `cargo install rlg-mcp` or `docker run -i ghcr.io/sebastienrousseau/rlg-mcp`. Dual-licensed MIT OR Apache-2.0.
+
+- [HELM](https://helmforclaude.com) - Windows tray app that supervises Claude Desktop agent sessions: auto-approves routine prompts, escalates risky ones, revives stalled agents. 100% local, no telemetry.
 ### 🔒 <a name="delivery"></a>Delivery
 
 - [jordandalton/doordash-mcp-server](https://github.com/JordanDalton/DoorDash-MCP-Server) 🐍 – DoorDash Delivery (Unofficial)


### PR DESCRIPTION
Adds HELM to the Developer Tools section.

HELM is a Windows tray app that supervises Claude Desktop agent sessions: it auto-approves routine permission prompts, escalates risky ones to your phone, and revives stalled agents. 100% local, no cloud, no telemetry. Free tier available.

Site: https://helmforclaude.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)