### PR TITLE
Add brian-mitchell-sec/workspace-tools-mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2775,6 +2775,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 - [zoomeye-ai/mcp_zoomeye](https://github.com/zoomeye-ai/mcp_zoomeye) 📇 ☁️ - Querying network asset information by ZoomEye MCP Server
 - [juergenkoller-software/pdf-content-search-mcp](https://github.com/juergenkoller-software/pdf-content-search-mcp) [![juergenkoller-software/pdf-content-search-mcp MCP server](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/juergenkoller-software/pdf-content-search-mcp) 🏠 🍎 - MCP bridge for [PDF Content Search](https://store.juergenkoller.software/en/apps/pdf-content-search) — full-text PDF search with Apple Vision OCR across thousands of documents in under a second. Advanced filters (date, category, sender, amount), wildcards, boolean operators.
 - [rejifald/StitchAPI](https://github.com/rejifald/StitchAPI) [![rejifald/StitchAPI MCP server](https://glama.ai/mcp/servers/rejifald/StitchAPI/badges/score.svg)](https://glama.ai/mcp/servers/rejifald/StitchAPI) 📇 ☁️ - Semantic search over the StitchAPI documentation (the hosted docs MCP): `search_docs` returns the most relevant doc sections with deep links, `get_doc` fetches a full page. Hosted endpoint `https://stitchapi.dev/api/mcp`, no auth.
+- [brian-mitchell-sec/workspace-tools-mcp](https://github.com/brian-mitchell-sec/workspace-tools-mcp) 🐍 ☁️ - Search documents, read files, run read-only queries, and list integration credentials against a synthetic sandbox workspace.
 
 ### 🔒 <a name="security"></a>Security
 


### PR DESCRIPTION
Adds an entry under **Search & Data Extraction**.

**workspace-tools-mcp** — a remote MCP server exposing workspace-style tools (search documents, read files, run read-only queries, list integration credentials) against a synthetic sandbox. Python, hosted remote endpoint.

Repo: https://github.com/brian-mitchell-sec/workspace-tools-mcp