### PR TITLE
Add andon (deterministic verification for AI-generated analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,7 @@ Integrations and tools designed to simplify data exploration, analysis and enhan
 - [zcaceres/markdownify-mcp](https://github.com/zcaceres/markdownify-mcp) 📇 🏠 - An MCP server to convert almost any file or web content into Markdown
 - [laszlopere/mcp-gnu-units](https://github.com/laszlopere/mcp-gnu-units) [![laszlopere/mcp-gnu-units MCP server](https://glama.ai/mcp/servers/laszlopere/mcp-gnu-units/badges/score.svg)](https://glama.ai/mcp/servers/laszlopere/mcp-gnu-units) 🐍 🏠 🐧 - Unit conversion and dimensional analysis backed by the bundled GNU units database (3000+ units, compound expressions, reduction to SI base units). Offline and deterministic. `uvx mcp-gnu-units`.
 
+- [gulmezeren2-byte/andon](https://github.com/gulmezeren2-byte/andon) [![gulmezeren2-byte/andon MCP server](https://glama.ai/mcp/servers/gulmezeren2-byte/andon/badges/score.svg)](https://glama.ai/mcp/servers/gulmezeren2-byte/andon) 🐍 🏠 - Deterministic verification for AI-generated analysis: re-checks a finished report against its source data and against itself with arithmetic, not another LLM — reconciliation, internal consistency and Excel integrity (`#REF!`, values typed over formulas), plus workbook diffing. CLI, GitHub Action, pre-commit hook and MCP server.
 ### 📊 <a name="data-visualization"></a>Data Visualization
 
 Interactive charts, dashboards, and visual data tools rendered inside AI conversations.


### PR DESCRIPTION
Adds [gulmezeren2-byte/andon](https://github.com/gulmezeren2-byte/andon) to **Data Science Tools**.

andon re-checks the numbers in a finished, AI-drafted report — against the data they came from and against themselves — with arithmetic instead of another model: reconciliation, internal consistency, and Excel integrity (`#REF!`, values typed over formulas, numbers stored as text). It ships a CLI, a GitHub Action, a pre-commit hook, and an MCP server exposing `run` / `inspect` / `diff`.

- MIT licensed, on PyPI (`pip install andon-verify`)
- Listed on the official MCP registry as `io.github.gulmezeren2-byte/andon`
- Single entry placed alphabetically in Data Science Tools, with the Glama score badge, per the contribution guidelines.
