### PR TITLE
Fix duplicate e-commerce README anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1510,7 +1510,7 @@ MCP servers for e-commerce platforms and online store management.
 - [slookisen/lokal](https://github.com/slookisen/lokal) [![slookisen/lokal MCP server](https://glama.ai/mcp/servers/slookisen/lokal/badges/score.svg)](https://glama.ai/mcp/servers/slookisen/lokal) 📇 ☁️ 🍎 🪟 🐧 - Search and discover 1,400+ verified local food producers in Norway — farms, REKO rings, farmers' markets, and farm shops. Natural-language search (NO/EN), geo-filtered discovery, and A2A protocol support, backed by [rettfrabonden.com](https://rettfrabonden.com). Install via `npx lokal-mcp`.
 - [tokenofesteem/mcp](https://github.com/tokenofesteem/mcp) [![tokenofesteem/mcp MCP server](https://glama.ai/mcp/servers/tokenofesteem/mcp/badges/score.svg)](https://glama.ai/mcp/servers/tokenofesteem/mcp) 🎖️ 📇 ☁️ - An agent can commission a funny, personalized printed booklet and have it printed and mailed as a gift, including a surprise for its own user. Pay with an account token, or tokenless with a single-use Stripe payment over HTTP 402. Remote MCP, US shipping, $19.99.
 
-### 🛒 <a name="e-commerce"></a>E-Commerce
+### 🛒 <a name="grocery"></a>Grocery
 
 - [dearlordylord/voila-sdk](https://github.com/dearlordylord/voila-sdk) [![dearlordylord/voila-sdk MCP server](https://glama.ai/mcp/servers/dearlordylord/voila-sdk/badges/score.svg)](https://glama.ai/mcp/servers/dearlordylord/voila-sdk) 📇 ☁️ 🏠 🍎 🪟 🐧 - Personal Voila grocery automation via MCP. Search products, inspect discounts, list delivery slots, read cart and order history, and update cart quantities.
 


### PR DESCRIPTION
## Summary
- rename the second one-item E-Commerce section to Grocery
- remove the duplicate e-commerce anchor while keeping the main E-Commerce section intact

## Validation
- git diff --check
- verified README now has one e-commerce anchor and one grocery anchor