### PR TITLE
Add datamcp hosted MCP gateway 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ Secure database access with schema inspection capabilities. Enables querying and
 - [Couchbase-Ecosystem/mcp-server-couchbase](https://github.com/Couchbase-Ecosystem/mcp-server-couchbase) 🎖️ 🐍 ☁️ 🏠 - Couchbase MCP server provides unfied access to both Capella cloud and self-managed clusters for document operations, SQL++ queries and natural language data analysis.
 - [cr7258/elasticsearch-mcp-server](https://github.com/cr7258/elasticsearch-mcp-server) 🐍 🏠 - MCP Server implementation that provides Elasticsearch interaction
 - [crystaldba/postgres-mcp](https://github.com/crystaldba/postgres-mcp) 🐍 🏠 - All-in-one MCP server for Postgres development and operations, with tools for performance analysis, tuning, and health checks
+- [datamcpapp/datamcp-app](https://github.com/datamcpapp/datamcp-app) 🎖️ ☁️ - Hosted MCP gateway for PostgreSQL 12+, MySQL, and OpenAPI 3.x with scoped links, server-side credentials, and remote Streamable HTTP access.
 - [Dataring-engineering/mcp-server-trino](https://github.com/Dataring-engineering/mcp-server-trino) 🐍 ☁️ - Trino MCP Server to query and access data from Trino Clusters.
 - [davewind/mysql-mcp-server](https://github.com/dave-wind/mysql-mcp-server) 🏎️ 🏠 A – user-friendly read-only mysql mcp server for cursor and n8n...
 - [designcomputer/mysql_mcp_server](https://github.com/designcomputer/mysql_mcp_server) 🐍 🏠 - MySQL database integration with configurable access controls, schema inspection, and comprehensive security guidelines


### PR DESCRIPTION
Adds the official datamcp hosted MCP gateway to the Databases section.

- Supports PostgreSQL 12+, MySQL, and OpenAPI 3.x / Swagger sources
- Provides scoped MCP links with server-side credential storage
- Uses remote Streamable HTTP access
- Description checked against the official public repository and product documentation