### PR TITLE
Add sprytools to Aggregators ✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ไทย](https://img.shields.io/badge/Thai-Click-blue)](README-th.md)
+﻿[![ไทย](https://img.shields.io/badge/Thai-Click-blue)](README-th.md)
 [![English](https://img.shields.io/badge/English-Click-yellow)](README.md)
 [![繁體中文](https://img.shields.io/badge/繁體中文-點擊查看-orange)](README-zh_TW.md)
 [![简体中文](https://img.shields.io/badge/简体中文-点击查看-orange)](README-zh.md)
@@ -233,6 +233,7 @@ Servers for accessing many apps and tools through a single MCP server.
 - [gregario/astronomy-oracle](https://github.com/gregario/astronomy-oracle) [![astronomy-oracle MCP server](https://glama.ai/mcp/servers/gregario/astronomy-oracle/badges/score.svg)](https://glama.ai/mcp/servers/gregario/astronomy-oracle) 📇 🏠 🍎 🪟 🐧 - Accurate astronomical catalog data and observing session planner. 13,000+ deep-sky objects from OpenNGC with deterministic visibility, rise/transit/set, and alt/az calculations. `npx astronomy-oracle`
 - [IO-Aerospace-software-community/mcp-server](https://github.com/IO-Aerospace-software-engineering/mcp-server) #️⃣ ☁️/🏠 🐧 - IO Aerospace MCP Server: a .NET-based MCP server for aerospace & astrodynamics — ephemeris, orbital conversions, DSS tools, time conversions, and unit/math utilities. Supports STDIO and SSE transports; Docker and native .NET deployment documented.
 
+- [sprytools](https://sprytools.com) 📇 ☁️ - Hub of 30+ developer & utility APIs as MCP tools: hashing, text stats, validation, DNS, currency, IP geolocation, IBAN, QR codes, GEO audits. Hosted, API-key auth.
 ### 🤝 <a name="agreements--coordination"></a>Agreements & Coordination
 
 MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.


### PR DESCRIPTION
Adds [sprytools](https://sprytools.com) to the Aggregators section.

SpryTools is a hub of 30+ developer & utility APIs exposed as a single hosted MCP server (Streamable HTTP, 9 tools, API-key auth + quota). One key gives agents access to hashing, text stats, validation, DNS lookups, currency rates, IP geolocation, IBAN validation, QR generation, GEO audits, and more.

- Repo: https://github.com/Grenzfrei/sprytools-mcp
- MCP endpoint: \https://api.sprytools.com/mcp\
- Server-card: \https://api.sprytools.com/.well-known/mcp/server-card.json\
- Listed in the official MCP Registry as \com.sprytools/sprytools\ (v1.0.1)