### PR TITLE
Add Jobs & Recruiting category with Remote PM Jobs MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
 * 🏠 - [Home Automation](#home-automation)
+* 💼 - [Jobs & Recruiting](#jobs-and-recruiting)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * ⚖️ - [Legal](#legal)
 * 🗺️ - [Location Services](#location-services)
@@ -2004,6 +2005,12 @@ Control smart home devices, home network equipment, and automation systems.
 - [laszlopere/mcp-kodi](https://github.com/laszlopere/mcp-kodi) [![laszlopere/mcp-kodi MCP server](https://glama.ai/mcp/servers/laszlopere/mcp-kodi/badges/score.svg)](https://glama.ai/mcp/servers/laszlopere/mcp-kodi) 🌊 🏠 🐧 - Control a Kodi media player over its JSON-RPC API — transport, volume, library search, queue management, and playback history. 16 tools, targetable across multiple Kodi instances. Written in C on the GLib stack; builds from source (autotools / .deb).
 - [claymore666/debmatic-mcp](https://github.com/claymore666/debmatic-mcp) [![claymore666/debmatic-mcp MCP server](https://glama.ai/mcp/servers/claymore666/debmatic-mcp/badges/score.svg)](https://glama.ai/mcp/servers/claymore666/debmatic-mcp) 📇 🏠 🍎 🪟 🐧 - Control a HomeMatic / debmatic CCU (eq-3 home automation) over its JSON-RPC and HM-Script APIs — switch and dim actuators, read sensors, system variables and service messages, run programs, and manage rooms, functions, channel links and device assignments. 25 tools over HTTP or stdio; runs locally against your own CCU.
 - [NickoScope/nickol-knx-mcp](https://github.com/NickoScope/nickol-knx-mcp) [![NickoScope/nickol-knx-mcp MCP server](https://glama.ai/mcp/servers/NickoScope/nickol-knx-mcp/badges/score.svg)](https://glama.ai/mcp/servers/NickoScope/nickol-knx-mcp) 🐍 🏠 - Design-time KNX/ETS6 assistant: parses .knxproj (read-only, no bus access), validates DPT/naming/command-status pairing, and generates Home Assistant YAML + ETS XML/CSV exports.
+
+### 💼 <a name="jobs-and-recruiting"></a>Jobs & Recruiting
+
+MCP servers for job search, hiring, and recruiting.
+
+- [Remote PM Jobs](https://remotepmjobs.com/mcp) 🎖️ ☁️ - Search and analyze remote product manager jobs, companies, and salary data from a live job board.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds a new **Jobs & Recruiting** category (none of the existing categories cover job search/recruiting) and one entry: Remote PM Jobs, a hosted MCP server for a remote product manager job board (remotepmjobs.com).

The server exposes ~1,500 live remote PM roles, company data, and salary ranges to AI agents. It's a hosted/remote service with no public repo, following the same pattern as other docs-linked hosted entries already in the list (e.g. BrainGrid MCP, liquidmetal-ai/raindrop-mcp). Tagged 🎖️ (official, first-party implementation) and ☁️ (cloud service).

- Docs: https://remotepmjobs.com/mcp
- Endpoint: https://remotepmjobs.com/api/mcp

New category placed alphabetically between Home Automation and Knowledge & Memory in both the TOC and the body, following existing heading/anchor conventions.