### PR TITLE
Add mcp-dev-network to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,8 @@ Integration with communication platforms for message management and channel oper
 - [loglux/whatsapp-mcp-stream](https://github.com/loglux/whatsapp-mcp-stream) [![whatsapp-mcp-stream MCP server](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream/badges/score.svg)](https://glama.ai/mcp/servers/@loglux/whatsapp-mcp-stream) 📇 🏠 🍎 🪟 🐧 - WhatsApp MCP server over Streamable HTTP with web admin UI (QR/status/settings), bidirectional media upload/download, and SQLite persistence.
 - [Zacccck/Claude-MCP-Read-Email-Attachments](https://github.com/Zacccck/Claude-MCP-Read-Email-Attachments) [![Zacccck/Claude-MCP-Read-Email-Attachments MCP server](https://glama.ai/mcp/servers/Zacccck/Claude-MCP-Read-Email-Attachments/badges/score.svg)](https://glama.ai/mcp/servers/Zacccck/Claude-MCP-Read-Email-Attachments) 📇 ☁️ 🏠 🪟 - Remote HTTP MCP server that reads Outlook email attachments via Microsoft Graph. Parses PDF, Word (with embedded image extraction for multimodal analysis), Excel, and text files in-memory and returns structured content directly to Claude.
 
+• [mcpnet-devmesh/mcp-dev-network](https://github.com/mcpnet-devmesh/mcp-dev-network) 🐍 ☁️ - Developer social network as an MCP server. Self-service auth, encrypted messaging (AES-256-GCM), public feed, user search by tech stack, resource sharing. 10 tools, cross-IDE.
+
 
 ### 🗣️ <a name="conversational-ai"></a>Conversational AI
 


### PR DESCRIPTION
## New MCP Server: mcp-dev-network

A developer social network as an MCP server.

**Category:** Communication
**Repo:** https://github.com/mcpnet-devmesh/mcp-dev-network
**Language:** Python
**Scope:** Cloud

### Features
- Self-service auth (signup/login, JWT RS256)
- Encrypted messaging (AES-256-GCM)
- Public feed (posts with tags)
- User search by tech stack
- Resource sharing with full-text search
- Content moderation
- 10 MCP tools
- Cross-IDE (Kiro, Cursor, Antigravity, Claude Desktop)
- Rate limiting, Row-Level Security in PostgreSQL