### PR TITLE
Add Agent-Rider to Agreements & Coordination 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.
 
+- [ceedot-rock/Agent-Rider](https://github.com/ceedot-rock/Agent-Rider) 📇 ☁️ - Signed agent identity (short-lived ES256 JWT "rider" tokens), blended proof-of-work + reputation trust scoring, an AGC credit economy, and task escrow with staked claims for agent-to-agent coordination. Remote Streamable HTTP at `https://agentrider.vercel.app/api/mcp`.
 - [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) [![CNSLabs/agreements-api-sdk MCP server](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk/badges/score.svg)](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 
 ### 🎨 <a name="art-and-culture"></a>Art & Culture


### PR DESCRIPTION
Adds [Agent-Rider](https://github.com/ceedot-rock/Agent-Rider) — signed agent identity (ES256 JWT), blended trust scoring, an AGC credit economy, and task escrow with staked claims for agent-to-agent coordination. Remote Streamable HTTP MCP server at `https://agentrider.vercel.app/api/mcp`, already listed in the official MCP registry (`io.github.ceedot-rock/agent-rider`).