### PR TITLE
Add AIops-tools/MySQL-AIops governed MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ Provides access to customer profiles inside of customer data platforms
 ### 🗄️ <a name="databases"></a>Databases
 
 Secure database access with schema inspection capabilities. Enables querying and analyzing data with configurable security controls including read-only access.
+- [AIops-tools/MySQL-AIops](https://github.com/AIops-tools/MySQL-AIops) 🐍 🏠 - Governed MySQL + MariaDB DBA operations — slow-query, lock-wait/deadlock, replication, and fragmentation RCA, plus guardrailed writes (35 tools) with unbypassable audit logging (MCP + CLI), budget/runaway guards, dry-run, and undo/rollback.
 
 - [AIops-tools/Postgres-AIops](https://github.com/AIops-tools/Postgres-AIops) [![AIops-tools/Postgres-AIops MCP server](https://glama.ai/mcp/servers/AIops-tools/Postgres-AIops/badges/score.svg)](https://glama.ai/mcp/servers/AIops-tools/Postgres-AIops) 🐍 🏠 - Governed PostgreSQL DBA operations — slow-query, bloat, and blocking-lock RCA, index management, vacuum/analyze, and replication lag (35 tools) with unbypassable audit logging (MCP + CLI), budget/runaway guards, dry-run, and undo/rollback.
 - [Aiven-Open/mcp-aiven](https://github.com/Aiven-Open/mcp-aiven) - 🐍 ☁️ 🎖️ -  Navigate your [Aiven projects](https://go.aiven.io/mcp-server) and interact with the PostgreSQL®, Apache Kafka®, ClickHouse® and OpenSearch® services


### PR DESCRIPTION
Adds **MySQL-AIops** to the **Databases** section — one server per PR, as requested on #8559.

MIT-licensed, Python. Governed MySQL + MariaDB DBA operations — slow-query, lock-wait/deadlock, replication, and fragmentation RCA, plus guardrailed writes (35 tools). Every state change lands on an unbypassable audit trail (same path for MCP and CLI); destructive ops carry undo/rollback, and a budget/runaway guard caps stuck loops.

- Repo: https://github.com/AIops-tools/MySQL-AIops

Entry inserted alphabetically in Databases.