### PR TITLE
Add Kilo IoT Server (Industrial & IoT) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2138,6 +2138,7 @@ Control smart home devices, home network equipment, and automation systems.
 
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
+- [Kiloiot/kilo-mcp](https://github.com/Kiloiot/kilo-mcp) 🏎️ ☁️ - Remote MCP server for the [Kilo IoT Server](https://kiloiot.io), an IoT platform for commercial and industrial sites. Read devices and telemetry, provision LoRaWAN/MQTT/tracker hardware, build, simulate and deploy rules-engine automation, work alarms and dashboards, and send commands to physical equipment. OAuth 2.1 with dynamic client registration — connect with the URL alone, and the connection carries the signed-in user's own permissions. Endpoint: `https://mcp-auth.kiloiot.io/mcp`.
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
Adds **Kilo IoT Server** under 🏭 Industrial & IoT.

It's a hosted, remote MCP server (Streamable HTTP) for a commercial IoT platform. Connected clients can read devices and telemetry, provision LoRaWAN / MQTT / tracker hardware, build and simulate rules-engine automation before deploying it, work the alarm queue and dashboards, and send commands to physical equipment.

- **Repo (public metadata + setup guide):** https://github.com/Kiloiot/kilo-mcp
- **Endpoint:** `https://mcp-auth.kiloiot.io/mcp`
- **Auth:** OAuth 2.1 with dynamic client registration, so the URL alone is enough to connect. The connection carries the signed-in user's own permissions.
- **Docs:** https://docs.kiloiot.io/kilo-iot-server/api/mcp-server
- **Emoji:** 🏎️ (Go) ☁️ (cloud service)

The server itself is closed-source; the linked repository holds the public server.json manifest, the icon and per-client setup instructions, in the same shape as other hosted services on the list.