### PR TITLE
Add STEADYWRK Dispatch (Support & Service Management) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3300,6 +3300,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [app.steadywrk/mcp-dispatch](https://steadywrk.app) 🎖️ 📇 ☁️ - Field-service dispatch for AI agents: instant quotes, tracked work orders, and public capability evals across 8 trade verticals. Remote Streamable HTTP server at steadywrk.app/api/mcp; evals and index tools need no API key.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.


### PR DESCRIPTION
Adds STEADYWRK Dispatch to the Support & Service Management category (alphabetical position, one line, legend emojis per format).

- Official implementation by the vendor; remote Streamable HTTP server (cloud service).
- Endpoint: https://steadywrk.app/api/mcp — `dispatch.evals` and `dispatch.index` are public read-only tools (no key); `dispatch.quote` and `dispatch.order` take an `x-api-key` header.
- Listed in the official MCP Registry as `app.steadywrk/mcp-dispatch` (published 2026-07-26, status active): https://registry.modelcontextprotocol.io/v0/servers?search=steadywrk
- Link points to the service website since this is a hosted remote server; privacy policy at https://www.steadywrk.app/privacy