### PR TITLE
Add io.github.PhilipAD/health-export-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2125,7 +2125,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
-- [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 

--- a/README.md
+++ b/README.md
@@ -2120,7 +2120,12 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
-- 
+
+### 🏥 <a name="health-and-wellness"></a>Health & Wellness
+
+Access health metrics, wellness data, and medical information through various health platforms.
+
+- [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 

--- a/README.md
+++ b/README.md
@@ -2125,7 +2125,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
-- [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adding io.github.PhilipAD/health-export-mcp.

Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.

**Repository**: https://github.com/PhilipAD/health-export-mcp

---
*Submitted via [mcp-submit](https://github.com/jordanlyall/mcp-submit)*