### PR TITLE
feat: add engram-mcp to Knowledge & Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2142,6 +2142,7 @@ Connect AI agents to industrial equipment, machinery, and operational technology
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
+- [lalithbuilds/engram-mcp](https://github.com/lalithbuilds/engram-mcp) 🐍 🏠 🍎 🪟 🐧 - Zero-dependency persistent memory for AI agents (Claude Code, Cursor, Windsurf). Pure Python stdlib — SQLite FTS5 for full-text retrieval, auto-decay algorithm (memories lose importance after 30 days of no access), WAL-mode concurrency for multi-agent workflows, and payload bounding to prevent context-window blowouts. No pip install, no Docker, no API costs. `git clone + python3 server.py`
 
 Persistent memory storage using knowledge graph structures. Enables AI models to maintain and query structured information across sessions.
 


### PR DESCRIPTION
## Summary

Adds [engram-mcp](https://github.com/lalithbuilds/engram-mcp) to the **🧠 Knowledge & Memory** section.

## What is engram-mcp?

A zero-dependency, pure Python stdlib MCP server for persistent AI agent memory. It gives AI coding agents (Claude Code, Cursor, Windsurf) the ability to remember across sessions — without any cloud services, Docker containers, vector databases, or pip dependencies.

**Key differentiators vs. other memory servers in this list:**
- 🐍 **Pure Python stdlib only** — `sqlite3`, `json`, `hashlib`. No `pip install` required at all.
- 🏠 **100% local** — no cloud API keys, no data ever leaves the machine
- ⚡ **SQLite FTS5** — sub-millisecond full-text search, fully offline
- 🔁 **Auto-decay** — memories lose importance after 30 days of no access (prevents stale context poisoning)
- 🔒 **WAL-mode concurrency** — run Cursor + Claude Code simultaneously without database lock crashes

## Checklist
- [x] The server is in the correct section (Knowledge & Memory)
- [x] Entry follows the existing format
- [x] Repository is public and functional
- [x] Has MIT license
- [x] CI passing (GitHub Actions)