### PR TITLE
Add League of Spin to Location Services 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2533,6 +2533,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [isdaniel/mcp_weather_server](https://github.com/isdaniel/mcp_weather_server) 🐍 ☁️ - Get weather information from https://api.open-meteo.com API.
 - [jagan-shanmugam/open-streetmap-mcp](https://github.com/jagan-shanmugam/open-streetmap-mcp) 🐍 🏠 - An OpenStreetMap MCP server with location-based services and geospatial data.
 - [kukapay/nearby-search-mcp](https://github.com/kukapay/nearby-search-mcp) 🐍 ☁️ - An MCP server for nearby place searches with IP-based location detection.
+- [League of Spin](https://leagueofspin.com/api/mcp) 📇 ☁️ - Find 27,000+ outdoor ping pong tables worldwide, with spot details and live playing conditions. Built on OpenStreetMap data.
 - [mahdin75/geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) 🏠 – A Model Context Protocol (MCP) server implementation that connects LLMs to the GeoServer REST API, enabling AI assistants to interact with geospatial data and services.
 - [mahdin75/gis-mcp](https://github.com/mahdin75/gis-mcp) 🏠 – A Model Context Protocol (MCP) server implementation that connects Large Language Models (LLMs) to GIS operations using GIS libraries, enabling AI assistants to perform accurate geospatial operations and transformations.
 - [matbel91765/gis-mcp-server](https://github.com/matbel91765/gis-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Geospatial tools for AI agents: geocoding, routing, elevation, spatial analysis, and file I/O (Shapefile, GeoJSON, GeoPackage)


### PR DESCRIPTION
Adds League of Spin (https://leagueofspin.com), a remote MCP server for finding outdoor ping-pong/table-tennis tables. 27,000+ spots worldwide sourced from OpenStreetMap data plus user submissions, with live playing-condition details. Registered in the official MCP registry as `com.leagueofspin/spots`, hosted endpoint at `https://leagueofspin.com/api/mcp` (streamable-http).

One line added under Location Services, alphabetical position, following the existing format.