### PR TITLE
Add Orita Provider Resolution MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2171,6 +2171,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
+- [Alkilo-do/orita-mcp](https://github.com/Alkilo-do/orita-mcp) [![Alkilo-do/orita-mcp MCP server](https://glama.ai/mcp/servers/Alkilo-do/orita-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Alkilo-do/orita-mcp) 🐍 ☁️ - Provider resolution and booking infrastructure for AI applications. Search a provider network, apply eligibility rules (language, modality, specialty, accepting-new-clients), resolve real-time availability, return ranked explained options, and safely confirm bookings. Supports resolve → hold → confirm workflow with agent safety rules.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
## Orita Provider Resolution MCP Server

Adding the [Orita MCP server](https://github.com/Alkilo-do/orita-mcp) to the Health & Wellness section.

**What it does:**
Orita is provider resolution and booking infrastructure for AI applications. The MCP server lets agents:
- Search a provider network using structured eligibility constraints
- Return ranked, explained provider-time options
- Hold a selected slot while awaiting customer approval
- Confirm the booking after customer approval

**Workflow:**
```
resolve_scheduling → hold_scheduling_option → confirm_scheduling_resolution
```

**Agent safety:**
- `resolve_scheduling`, `get_resolution` — read-only, no approval required
- `hold_scheduling_option` — application-defined
- `confirm_scheduling_resolution`, `reschedule_booking`, `cancel_booking` — require explicit customer approval

**Links:**
- GitHub: https://github.com/Alkilo-do/orita-mcp
- PyPI: https://pypi.org/project/orita-mcp/
- Remote server: https://orita.online/api/mcp
- Docs: https://orita.online/developers/mcp.md
- MCP Registry: listed as `io.github.Alkilo-do/orita-provider-resolution`

**Primary use case:** AI receptionists and behavioral health platforms that need to route patients to eligible providers.