### PR TITLE
Add Manufacturing & Fabrication category with a2a2p 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🧠 - [Knowledge & Memory](#knowledge--memory)
 * ⚖️ - [Legal](#legal)
 * 🗺️ - [Location Services](#location-services)
+* 🏭 - [Manufacturing & Fabrication](#manufacturing--fabrication)
 * 🎯 - [Marketing](#marketing)
 * 📊 - [Monitoring](#monitoring)
 * 🎥 - [Multimedia Process](#multimedia-process)
@@ -2556,6 +2557,12 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 - [xyver/daedal-map](https://github.com/xyver/daedal-map) [![DaedalMap MCP server](https://glama.ai/mcp/servers/xyver/daedal-map/badges/score.svg)](https://glama.ai/mcp/servers/xyver/daedal-map) 🐍 ☁️ - Geographic data packs for disasters, FX rates, and global indicators. New geospatial data packs weekly. Free and x402-paid execution lanes via MCP and HTTP API.
 - [webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo) 🐍 🏠 - Geocoding MCP server for nominatim, ArcGIS, Bing
 - [930m310n/geomelon-mcp](https://github.com/930m310n/geomelon-mcp) [![930m310n/geomelon-mcp MCP server](https://glama.ai/mcp/servers/930m310n/geomelon-mcp/badges/score.svg)](https://glama.ai/mcp/servers/930m310n/geomelon-mcp) 🎖️ 📇 ☁️ - Cities, countries, regions, and languages with multilingual names (50 languages) and a free keyless autocomplete tool. Also runs a public hosted instance at `https://mcp.geomelon.dev/mcp`, no signup required.
+
+### 🏭 <a name="manufacturing--fabrication"></a>Manufacturing & Fabrication
+
+Turn agent intent into physical parts — specification, design-for-manufacture review, quoting, and sourcing of things that do not exist yet (distinct from Industrial & IoT, which connects agents to equipment that already exists).
+
+- [a2a2p](https://github.com/Deadlypillow/a2a2p) 📇 ☁️ - Turns agent intent into manufacturable parts. Describe what must be true about the world ("holds 15kg, outdoors, ten years") and get a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Measures attached STL meshes for true volume and bounding box. Open protocol: the specification is public domain (CC0) and implementable by anyone. No API key.
 
 ### 🎯 <a name="marketing"></a>Marketing
 

--- a/README.md
+++ b/README.md
@@ -2562,7 +2562,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Turn agent intent into physical parts — specification, design-for-manufacture review, quoting, and sourcing of things that do not exist yet (distinct from Industrial & IoT, which connects agents to equipment that already exists).
 
-- [a2a2p](https://github.com/Deadlypillow/a2a2p) 📇 ☁️ - Turns agent intent into manufacturable parts. Describe what must be true about the world ("holds 15kg, outdoors, ten years") and get a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Measures attached STL meshes for true volume and bounding box. Open protocol: the specification is public domain (CC0) and implementable by anyone. No API key.
+- [Deadlypillow/a2a2p](https://github.com/Deadlypillow/a2a2p) 📇 ☁️ - Turns agent intent into manufacturable parts. Describe what must be true about the world ("holds 15kg, outdoors, ten years") and get a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Measures attached STL meshes for true volume and bounding box. Open protocol: the specification is public domain (CC0) and implementable by anyone. No API key.
 
 ### 🎯 <a name="marketing"></a>Marketing
 

--- a/README.md
+++ b/README.md
@@ -2562,7 +2562,7 @@ Location-based services and mapping tools. Enables AI models to work with geogra
 
 Turn agent intent into physical parts — specification, design-for-manufacture review, quoting, and sourcing of things that do not exist yet (distinct from Industrial & IoT, which connects agents to equipment that already exists).
 
-- [Deadlypillow/a2a2p](https://github.com/Deadlypillow/a2a2p) 📇 ☁️ - Turns agent intent into manufacturable parts. Describe what must be true about the world ("holds 15kg, outdoors, ten years") and get a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Measures attached STL meshes for true volume and bounding box. Open protocol: the specification is public domain (CC0) and implementable by anyone. No API key.
+- [Deadlypillow/a2a2p](https://github.com/Deadlypillow/a2a2p) [![Deadlypillow/a2a2p MCP server](https://glama.ai/mcp/servers/Deadlypillow/a2a2p/badges/score.svg)](https://glama.ai/mcp/servers/Deadlypillow/a2a2p) 📇 ☁️ - Turns agent intent into manufacturable parts. Describe what must be true about the world ("holds 15kg, outdoors, ten years") and get a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Measures attached STL meshes for true volume and bounding box. Open protocol: the specification is public domain (CC0) and implementable by anyone. No API key.
 
 ### 🎯 <a name="marketing"></a>Marketing
 


### PR DESCRIPTION
Adds **a2a2p** — an MCP server that turns agent intent into manufacturable physical parts.

**What it does:** describe what must be true about the world ("holds 15 kg, outdoors, ten years") and get back a deterministic engineering review — material properties, process/tolerance compatibility, environment fit, quantity economics — plus pricing and lead time. Attach an STL and it measures the mesh for true volume and bounding box. No API key, no signup: `https://a2a2p.com/mcp`.

The specification is public domain (CC0) and implementable by anyone, including competing products — a2a2p.com is a reference implementation rather than the protocol itself.

**On the new category:** I added `Manufacturing & Fabrication` rather than filing under an existing one, because the fit was genuinely poor:

- **E-Commerce** is about buying products that already exist — this makes things that don't.
- **Industrial & IoT** connects agents to equipment that already exists (telemetry, monitoring, OT control) — this sources and fabricates.

CONTRIBUTING invites new categories where needed; the section is placed alphabetically with a matching TOC entry. **If you'd rather it live under Industrial & IoT, E-Commerce, or Other Tools, just say and I'll move it and drop the category.** I'd rather it be shelved where you want it than where I guessed.

Diff: 7 added lines, no deletions.
