### PR TITLE
Add huqan project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3273,6 +3273,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 - [mastyf-ai/mastyf.ai](https://github.com/mastyf-ai/mastyf.ai) [![mastyf-ai/mastyf.ai MCP server](https://glama.ai/mcp/servers/mastyf-ai/mastyf.ai/badges/score.svg)](https://glama.ai/mcp/servers/mastyf-ai/mastyf.ai) 📇 🏠 🍎 🪟 🐧 - Open-source runtime security proxy for MCP. Transparently intercepts every tools/call through an 18-class attack defense pipeline (prompt injection, SSRF, shell injection, SQL injection, credential exfil, polyglot attacks) with a YAML policy engine and 304-entry adversarial corpus. Trust scoring for npm MCP packages with 0-100 badges. Cloud dashboard, Docker image, Python SDK. MIT.
 - [timescale/rsigma](https://github.com/timescale/rsigma) [![timescale/rsigma MCP server](https://glama.ai/mcp/servers/timescale/rsigma/badges/score.svg)](https://glama.ai/mcp/servers/timescale/rsigma) 🎖️ 🦀 🏠 🍎 🪟 🐧 - Exposes the RSigma Sigma detection-engineering toolkit to AI agents over stdio or Streamable HTTP with `rsigma mcp serve`. Tools to author, lint, validate, and convert Sigma detection rules, evaluate and explain detections against log events, and inspect correlation state, all backed by a native Rust engine.
+- [ali-ulu/huqan](https://github.com/ali-ulu/huqan) 📇 🏠 - Local-first verification and audit layer for AI agents: checks claims, gates risky actions, and issues auditable Trust Receipts via CLI, REST, and MCP interfaces.
 
 ### 🌐 <a name="social-media"></a>Social Media
 


### PR DESCRIPTION
Adds ali-ulu/huqan to the Security section: a local-first verification and audit layer for AI agents (claim verification, risk gates, approval flows, and auditable Trust Receipts), exposed via CLI, REST, and MCP.