### PR TITLE
Add Juno Open Health Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2171,6 +2171,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
+- [io.github.MarshallBear1/juno-open-health-tools](https://github.com/MarshallBear1/juno-open-health-tools) 📇 ☁️ - Consent-gated, no-account tools that turn non-identifying symptom notes into plain-language symptom descriptions, health timelines, flare reflections, and appointment briefs. Five read-only, non-diagnostic tools; inputs are processed transiently without intentional application storage.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation

--- a/README.md
+++ b/README.md
@@ -2171,7 +2171,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
-- [io.github.MarshallBear1/juno-open-health-tools](https://github.com/MarshallBear1/juno-open-health-tools) 📇 ☁️ - Consent-gated, no-account tools that turn non-identifying symptom notes into plain-language symptom descriptions, health timelines, flare reflections, and appointment briefs. Five read-only, non-diagnostic tools; inputs are processed transiently without intentional application storage.
+- [io.github.MarshallBear1/juno-open-health-tools](https://github.com/MarshallBear1/juno-open-health-tools) 📇 ☁️ - Consent-gated, no-account tools that turn non-identifying symptom notes into plain-language symptom descriptions, health timelines, flare reflections, and appointment briefs. Five read-only, non-diagnostic tools; inputs are processed transiently without intentional application storage. Listed as a [healthy hosted connector on Glama](https://glama.ai/mcp/connectors/io.github.MarshallBear1/juno-open-health-tools).
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
## What changed

Adds `io.github.MarshallBear1/juno-open-health-tools` to the Health & Wellness section.

## Why

Juno Open Health Tools is a public, no-account MCP server with five consent-gated, read-only tools for organising non-identifying symptom notes into plain-language symptom descriptions, timelines, flare reflections, and appointment briefs. The tools are explicitly non-diagnostic and process submitted text transiently without intentional application storage.

The server is published in the official MCP Registry as `io.github.MarshallBear1/juno-open-health-tools`.

## Validation

- Verified the public MCP endpoint initializes as version `1.1.0` and exposes five tools.
- Verified the consent gate, output schemas, and read-only annotations with the repository's endpoint checker.
- Verified the official MCP Registry returns the exact server name and version.
- Confirmed the repository link returns HTTP 200.
- Ran `git diff --check`.

This PR was prepared with automated-agent assistance, using the opt-in marker described in the contribution guide.
