### PR TITLE
Add Pineify MCP to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+- [pineifyapp/pineify-mcp](https://github.com/pineifyapp/pineify-mcp) 🎖️ ☁️ - Official hosted, read-only MCP server with 14 tools for Pine Script v6, MQL5 and cTrader validation, stock research, technical analysis, unusual options flow, dark-pool activity, congressional trades, market tide and event briefings. Remote Streamable HTTP; Bearer-token authentication.
 [![ไทย](https://img.shields.io/badge/Thai-Click-blue)](README-th.md)
 [![English](https://img.shields.io/badge/English-Click-yellow)](README.md)
 [![繁體中文](https://img.shields.io/badge/繁體中文-點擊查看-orange)](README-zh_TW.md)


### PR DESCRIPTION
## Summary

Adds the official Pineify MCP server to **Finance & Fintech**.

Pineify MCP is a remote, read-only server with 14 tools covering Pine Script, MQL5 and cTrader validation, stock research, technical analysis, options flow, dark-pool activity, congressional trades and event briefings.

- Transport: Streamable HTTP
- Authentication: Bearer token
- Pricing: Paid API key
- Trade execution: Not supported
- Repository: https://github.com/pineifyapp/pineify-mcp
- Documentation: https://pineify.app/mcp

Disclosure: This is an official Pineify team submission.