### PR TITLE
 Add ChainHelix Intel to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🛒 - [E-Commerce](#e-commerce)
 * 🌳 - [Environment & Nature](#environment-and-nature)
 * 📂 - [File Systems](#file-systems)
-* 💰 - [Finance & Fintech](#finance--fintech)
+* 💰 - [Finance & Fintech](finance--fintech)
 * 🎮 - [Gaming](#gaming)
 * 🏠 - [Home Automation](#home-automation)
 * 🏭 - [Industrial & IoT](#industrial--iot)
@@ -1806,6 +1806,9 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp) [![de-bridge MCP server](https://glama.ai/mcp/servers/@debridge-finance/de-bridge/badges/score.svg)](https://glama.ai/mcp/servers/@debridge-finance/de-bridge) 📇 🏠 ☁️ - Cross-chain swaps and bridging across EVM and Solana blockchains via the deBridge protocol. Enables AI agents to discover optimal routes, evaluate fees, and initiate non-custodial trades.
 - [decidefyi/decide](https://github.com/decidefyi/decide) 📇 ☁️ - Deterministic refund eligibility notary MCP server. Returns ALLOWED / DENIED / UNKNOWN for subscription refunds (Adobe, Spotify, etc.) via a stateless rules engine.
 - [debtstack-ai/debtstack-python](https://github.com/debtstack-ai/debtstack-python) 🐍 ☁️ - Corporate debt structure data for AI agents. Search 250+ issuers, 5,000+ bonds with leverage ratios, seniority, covenants, guarantor chains, and FINRA TRACE pricing.
+ - [ChainHelix Intel](https://mcp.chainhelix.io) ☁️  - Nine chain onchain intelligence with a verifiable track record — every signal sealed on chain before its outcome
+  exists, revealed 72h later with a Merkle path. Proof tools free; market data, S/R wall maps, MEV and whale flow tools paid per call via x402.
+
 - [decksaga/market-pulse-mcp](https://github.com/decksaga/market-pulse-mcp) [![decksaga/market-pulse-mcp MCP server](https://glama.ai/mcp/servers/decksaga/market-pulse-mcp/badges/score.svg)](https://glama.ai/mcp/servers/decksaga/market-pulse-mcp) 📇 ☁️ - Live market data for AI agents — crypto prices, stocks (any ticker), S&P 500/NASDAQ/Dow indices, forex (150+ pairs), trending coins, and Fear & Greed Index. 8 tools, zero API keys, zero cost. Uses CoinGecko, Yahoo Finance, and ExchangeRate API.
 - [Declan142/calcnook-mcp-server](https://github.com/Declan142/calcnook-mcp-server) [![Declan142/calcnook-mcp-server MCP server](https://glama.ai/mcp/servers/Declan142/calcnook-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/Declan142/calcnook-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Personal finance calculations across 7 countries (US, UK, CA, AU, AE, SA, India) plus Sharia-compliant Islamic finance (Zakat, Murabaha, Ijarah, Mudarabah, Hajj savings, halal stock screening). 17 tools wrapping the deterministic [calcnook](https://pypi.org/project/calcnook/) engine — income tax, SIP/EMI/loans, retirement, EOSG, VAT, currency formatting (incl. Indian lakh/crore), and BMI/BMR/TDEE. Zero API keys, pure stdlib. Install with `uvx calcnook-mcp`.
 - [deficlow/zipp-mcp](https://github.com/deficlow/zipp-mcp) [![deficlow/zipp-mcp MCP server](https://glama.ai/mcp/servers/deficlow/zipp-mcp/badges/score.svg)](https://glama.ai/mcp/servers/deficlow/zipp-mcp) 🐍 ☁️ - Multi-language crypto news for AI assistants — editorial summaries with sentiment labels (BULLISH/NEUTRAL/BEARISH) and importance scores (0–100). 6 tools across 8 languages, every story credits the original publisher. Install: `uvx zipp-mcp` or `ghcr.io/deficlow/zipp-mcp`. Public Streamable HTTP endpoint at `https://zippfeed.com/mcp/`; listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=zipp).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🛒 - [E-Commerce](#e-commerce)
 * 🌳 - [Environment & Nature](#environment-and-nature)
 * 📂 - [File Systems](#file-systems)
-* 💰 - [Finance & Fintech](finance--fintech)
+* 💰 - [Finance & Fintech](#finance--fintech)
 * 🎮 - [Gaming](#gaming)
 * 🏠 - [Home Automation](#home-automation)
 * 🏭 - [Industrial & IoT](#industrial--iot)
@@ -1806,9 +1806,7 @@ Provides direct access to local file systems with configurable permissions. Enab
 - [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp) [![de-bridge MCP server](https://glama.ai/mcp/servers/@debridge-finance/de-bridge/badges/score.svg)](https://glama.ai/mcp/servers/@debridge-finance/de-bridge) 📇 🏠 ☁️ - Cross-chain swaps and bridging across EVM and Solana blockchains via the deBridge protocol. Enables AI agents to discover optimal routes, evaluate fees, and initiate non-custodial trades.
 - [decidefyi/decide](https://github.com/decidefyi/decide) 📇 ☁️ - Deterministic refund eligibility notary MCP server. Returns ALLOWED / DENIED / UNKNOWN for subscription refunds (Adobe, Spotify, etc.) via a stateless rules engine.
 - [debtstack-ai/debtstack-python](https://github.com/debtstack-ai/debtstack-python) 🐍 ☁️ - Corporate debt structure data for AI agents. Search 250+ issuers, 5,000+ bonds with leverage ratios, seniority, covenants, guarantor chains, and FINRA TRACE pricing.
- - [ChainHelix Intel](https://mcp.chainhelix.io) ☁️  - Nine chain onchain intelligence with a verifiable track record — every signal sealed on chain before its outcome
-  exists, revealed 72h later with a Merkle path. Proof tools free; market data, S/R wall maps, MEV and whale flow tools paid per call via x402.
-
+- [ChainHelix Intel](https://mcp.chainhelix.io) ☁️ - Nine chain onchain intelligence with a verifiable track record — every signal sealed on chain before its outcome exists, revealed 72h later with a Merkle path. Proof tools free; market data, S/R wall maps, MEV and whale flow tools paid per call via x402.
 - [decksaga/market-pulse-mcp](https://github.com/decksaga/market-pulse-mcp) [![decksaga/market-pulse-mcp MCP server](https://glama.ai/mcp/servers/decksaga/market-pulse-mcp/badges/score.svg)](https://glama.ai/mcp/servers/decksaga/market-pulse-mcp) 📇 ☁️ - Live market data for AI agents — crypto prices, stocks (any ticker), S&P 500/NASDAQ/Dow indices, forex (150+ pairs), trending coins, and Fear & Greed Index. 8 tools, zero API keys, zero cost. Uses CoinGecko, Yahoo Finance, and ExchangeRate API.
 - [Declan142/calcnook-mcp-server](https://github.com/Declan142/calcnook-mcp-server) [![Declan142/calcnook-mcp-server MCP server](https://glama.ai/mcp/servers/Declan142/calcnook-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/Declan142/calcnook-mcp-server) 🐍 🏠 🍎 🪟 🐧 - Personal finance calculations across 7 countries (US, UK, CA, AU, AE, SA, India) plus Sharia-compliant Islamic finance (Zakat, Murabaha, Ijarah, Mudarabah, Hajj savings, halal stock screening). 17 tools wrapping the deterministic [calcnook](https://pypi.org/project/calcnook/) engine — income tax, SIP/EMI/loans, retirement, EOSG, VAT, currency formatting (incl. Indian lakh/crore), and BMI/BMR/TDEE. Zero API keys, pure stdlib. Install with `uvx calcnook-mcp`.
 - [deficlow/zipp-mcp](https://github.com/deficlow/zipp-mcp) [![deficlow/zipp-mcp MCP server](https://glama.ai/mcp/servers/deficlow/zipp-mcp/badges/score.svg)](https://glama.ai/mcp/servers/deficlow/zipp-mcp) 🐍 ☁️ - Multi-language crypto news for AI assistants — editorial summaries with sentiment labels (BULLISH/NEUTRAL/BEARISH) and importance scores (0–100). 6 tools across 8 languages, every story credits the original publisher. Install: `uvx zipp-mcp` or `ghcr.io/deficlow/zipp-mcp`. Public Streamable HTTP endpoint at `https://zippfeed.com/mcp/`; listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=zipp).


### PR DESCRIPTION
 Adds ChainHelix Intel — a remote MCP server covering nine chains (Bitcoin, Ethereum, BNB, Solana, Avalanche, XRP, Tron, Polygon, Sui). Free tools serve a
  cryptographically verifiable signal record (on-chain commitments with 72h Merkle-path reveals); data tools are pay-per-call via x402. Server card:
  https://mcp.chainhelix.io/.well-known/mcp.json

  
