### PR TITLE
Add proscar87/oura-mcp to Health & Wellness 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,7 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
-- [proscar87/oura-mcp](https://github.com/proscar87/oura-mcp) 🐍 📇 🏠 ☁️ 🍎 🪟 🐧 - All 19 Oura Ring v2 collections in three tools, with no analysis done in the server. Paginates to exhaustion and reports the page count: one local day of heart rate is 1,231 samples across 2 pages, and a client that stops at the first returns 81% of them with nothing saying so. One-click `.mcpb` for Claude Desktop, and it runs on Oura's official sample data with no account.
+- [proscar87/oura-mcp](https://github.com/proscar87/oura-mcp) [![proscar87/oura-mcp MCP server](https://glama.ai/mcp/servers/proscar87/oura-mcp/badges/score.svg)](https://glama.ai/mcp/servers/proscar87/oura-mcp) 🐍 📇 🏠 ☁️ 🍎 🪟 🐧 - All 19 Oura Ring v2 collections in three tools, with no analysis done in the server. Paginates to exhaustion and reports the page count: one local day of heart rate is 1,231 samples across 2 pages, and a client that stops at the first returns 81% of them with nothing saying so. One-click `.mcpb` for Claude Desktop, and it runs on Oura's official sample data with no account.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 

--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [proscar87/oura-mcp](https://github.com/proscar87/oura-mcp) 🐍 📇 🏠 ☁️ 🍎 🪟 🐧 - All 19 Oura Ring v2 collections in three tools, with no analysis done in the server. Paginates to exhaustion and reports the page count: one local day of heart rate is 1,231 samples across 2 pages, and a client that stops at the first returns 81% of them with nothing saying so. One-click `.mcpb` for Claude Desktop, and it runs on Oura's official sample data with no account.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adds [proscar87/oura-mcp](https://github.com/proscar87/oura-mcp) under Health & Wellness, after the existing entry in alphabetical order.

**What it is:** the Oura Ring v2 API as an MCP server — all 19 collections, three tools, no dependencies beyond the MCP SDK. Python and TypeScript implementations, verified against each other on the real API.

**Why it's distinct from the Oura servers already listed:** it paginates to exhaustion inside the server and reports the page count, rather than exposing a cursor as a tool parameter. One local day of heart rate is 1,231 samples across 2 pages — measured — and a client that stops at the first page returns 81% of them with nothing indicating anything is missing. It also computes nothing server-side: no averages, correlations or trends, so any analysis reaches the model with its method intact.

Ships a one-click `.mcpb` for Claude Desktop and runs on Oura's official sample data with no account, so it can be tried without credentials.

Published on PyPI as `mcp-oura` and in the MCP registry as `io.github.proscar87/oura-mcp`. MIT licensed.

Opting into the agent fast-track per CONTRIBUTING.md.