### PR TITLE
Add agentfabric.dev — human-in-the-loop review & approval MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Servers for accessing many apps and tools through a single MCP server.
 
 MCP servers for creating, coordinating, and executing agreements: commitments, escrow, and multi-party decision workflows across humans, agents, and organizations.
 
+- [agentfabric/agentfabric-mcp](https://github.com/agentfabric/agentfabric-mcp) 📇 ☁️ - Human-in-the-loop review and approval for AI agents. Route agent outputs to human reviewers, enforce approval policies, complete audit trail. Native MCP server at mcp.agentfabric.dev. Agents self-signup via create_tenant tool.
 - [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) [![CNSLabs/agreements-api-sdk MCP server](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk/badges/score.svg)](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 - [humanforai/humanforai-mcp](https://github.com/humanforai/humanforai-mcp) [![humanforai/humanforai-mcp MCP server](https://glama.ai/mcp/servers/humanforai/humanforai-mcp/badges/score.svg)](https://glama.ai/mcp/servers/humanforai/humanforai-mcp) 🎖️ 📇 ☁️ - Hire a real human operator for tasks that need physical presence, perception, or judgment: real-world verification, product testing, AI output review, data collection, and local errands. Remote streamable HTTP at https://humanforai.dev/mcp or local stdio via `npx -y humanforai`.
 


### PR DESCRIPTION
## What is agentfabric.dev?

**agentfabric.dev** provides human-in-the-loop review and approval for AI agents.

- Route agent outputs to human reviewers before execution
- Enforce approval policies (who can approve, SLA, escalation)
- Complete audit trail of every review decision
- Native MCP server at `mcp.agentfabric.dev` — works with Cursor, Claude Code, Codex
- REST API at `rest.agentfabric.dev`
- Agents self-signup via `create_tenant` tool — no human developer needed

**Category:** Agreements & Coordination — fits with human-agent coordination and approval workflows.

**Entry format:**
```
- [agentfabric/agentfabric-mcp](https://github.com/agentfabric/agentfabric-mcp) 📇 ☁️ - Human-in-the-loop review and approval for AI agents. Route agent outputs to human reviewers, enforce approval policies, complete audit trail. Native MCP server at mcp.agentfabric.dev. Agents self-signup via create_tenant tool.
```
