### PR TITLE
Add maintenance-ranked MCP server directory to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [Awesome MCP Servers: 65 Ranked by What's Maintained (2026)](https://maketocreate.com/awesome-mcp-servers-65-ranked-by-whats-maintained-2026/)
 
 ## Community
 


### PR DESCRIPTION
This adds our independently researched directory ranking 65 MCP servers by maintenance status (Maintained / Experimental / Abandoned), graded on hard repo signals as of June 2026. What it adds beyond the list itself: a maintenance audit of the ecosystem's most-linked servers, including 5 that are effectively abandoned and the 13 reference servers Anthropic archived.

Full disclosure: I'm the author. Happy to adjust placement/wording, or convert this into an issue with the raw data if articles aren't accepted here.