### PR TITLE
Update forge-mcp tool count (30 to 32) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2190,7 +2190,7 @@ Control smart home devices, home network equipment, and automation systems.
 
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
-- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
+- [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 32 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Small accuracy fix to the existing FoundryNet/forge-mcp entry under Industrial & IoT. The listing says 30 tools; the server now exposes 32.

Verified against the live endpoint just now:

```
POST https://mcp.foundrynet.io/mcp  ->  serverInfo {"name":"foundrynet","version":"3.4.4"}
tools/list  ->  32 tools
```

Nothing else in the entry changes: link, badges, emoji markers, description and category are all untouched.

Disclosure: I am the maintainer of this server, and this PR was prepared by an automated agent, tagged per the note in CONTRIBUTING.md.