### PR TITLE
Add Vaultbeat MCP server to Health & Wellness 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,7 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
-- [Fino-wind/vaultbeat-mcp](https://github.com/Fino-wind/vaultbeat-mcp) 🐍 ☁️ 🍎 🪟 🐧 - AI agent reads Apple Health data (sleep, HRV, cycle, weight, workouts) end-to-end encrypted from the companion iOS app — decrypts only on your machine. Requires the Vaultbeat iOS app (Pro).
+- [Fino-wind/vaultbeat-mcp](https://github.com/Fino-wind/vaultbeat-mcp) [![Fino-wind/vaultbeat-mcp MCP server](https://glama.ai/mcp/servers/Fino-wind/vaultbeat-mcp/badges/score.svg)](https://glama.ai/mcp/servers/Fino-wind/vaultbeat-mcp) 🐍 🏠 🍎 🪟 🐧 - AI agent reads Apple Health data (sleep, HRV, cycle, weight, workouts) end-to-end encrypted from the companion iOS app — decrypts only on your machine. Requires the Vaultbeat iOS app (Pro).
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 

--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [Fino-wind/vaultbeat-mcp](https://github.com/Fino-wind/vaultbeat-mcp) 🐍 ☁️ 🍎 🪟 🐧 - AI agent reads Apple Health data (sleep, HRV, cycle, weight, workouts) end-to-end encrypted from the companion iOS app — decrypts only on your machine. Requires the Vaultbeat iOS app (Pro).
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Adds [Fino-wind/vaultbeat-mcp](https://github.com/Fino-wind/vaultbeat-mcp) to the Health & Wellness section, one line, alphabetically after the existing entry.

Local MCP server (Python, stdio) that lets an AI agent read Apple Health data — sleep, HRV, menstrual cycle, weight, workouts — synced end-to-end encrypted from the companion Vaultbeat iOS app, decrypted only on the user's own machine. Requires the Vaultbeat iOS app (Pro subscription).

Also listed on the official MCP Registry (`io.github.Fino-wind/vaultbeat`) and PyPI (`vaultbeat-mcp`).