### PR TITLE
Add anatome (workout + nutrition logging over MCP) to Health & Wellness 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2171,6 +2171,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
+- [anatome](https://anatome.dev) ☁️ - Log workouts and meals by telling your AI. 873 exercises with muscle-anatomy diagrams (SVG), food and barcode lookup, per-user workout/meal/cardio/bodyweight logging, weekly check-ins and progression analytics (PRs, volume, training load, recovery). Hosted at `https://anatome.dev/mcp`; exercise search, diagrams and food lookup answer with no API key, and per-user logging works from a free key minted with one unauthenticated POST.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
Adds **anatome** to Health & Wellness — a category that currently has one entry.

- [anatome](https://anatome.dev) ☁️ — hosted MCP server at `https://anatome.dev/mcp`

**What it does:** log workouts and meals by telling your AI. 873 exercises with muscle-anatomy
diagrams (SVG), food and barcode lookup, per-user workout/meal/cardio/bodyweight logging,
weekly check-ins, and progression analytics (PRs, volume, training load, recovery).

**Why it may be worth a look for this list:** exercise search, muscle diagrams and food lookup
answer with **no API key at all**, and per-user logging works from a free key minted with one
unauthenticated `POST` — so it is testable end to end without an account.

Verified working right now:

```bash
curl -X POST https://anatome.dev/mcp \
  -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"demo","version":"1.0"}}}'
```

Also published to the official MCP registry as `dev.anatome/anatome` (DNS-verified namespace).

It is a hosted service rather than an open-source codebase, so the link points at the product
page — following the existing precedent for hosted entries in this list. Tagged ☁️ only, with
no language emoji, since there is no public codebase to describe.

Opting into the agent fast-track per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)