### PR TITLE
Add Events & Ticketing section (Luma, Eventbrite, SocialLoop MCP servers) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1647,6 +1647,14 @@ MCP servers for e-commerce platforms and online store management.
 
 - [dearlordylord/voila-sdk](https://github.com/dearlordylord/voila-sdk) [![dearlordylord/voila-sdk MCP server](https://glama.ai/mcp/servers/dearlordylord/voila-sdk/badges/score.svg)](https://glama.ai/mcp/servers/dearlordylord/voila-sdk) 📇 ☁️ 🏠 🍎 🪟 🐧 - Personal Voila grocery automation via MCP. Search products, inspect discounts, list delivery slots, read cart and order history, and update cart quantities.
 
+### 🎟️ <a name="events-and-ticketing"></a>Events & Ticketing
+
+MCP servers for event platforms — creating events, selling tickets, and managing attendees.
+
+- [adelaidasofia/luma-mcp](https://github.com/adelaidasofia/luma-mcp) 🐍 ☁️ - lu.ma events MCP server for Claude Code. Create/update events, ticket types, coupons, list RSVPs, email attendees, with draft+confirm on every write. 14 tools. Requires a Luma Plus API key.
+- [joshuachestang/eventbrite-mcp-server](https://github.com/joshuachestang/eventbrite-mcp-server) 📇 ☁️ - Community MCP server for the Eventbrite API. Create and manage events, ticket classes, orders, and attendees on Eventbrite.
+- [socialloopai/socialloop-mcp](https://github.com/socialloopai/socialloop-mcp) 🎖️ ☁️ - Official remote MCP server for SocialLoop, the AI-native event platform. Create and publish events, sell tickets, manage guest lists, run affiliate programs and promo codes — the full event lifecycle from Claude, ChatGPT, Cursor, or any MCP client. Open no-login endpoint (`https://socialloop.ai/mcp`) or OAuth; listed in the official MCP Registry.
+
 ### 🌳 <a name="environment-and-nature"></a>Environment & Nature
 
 Provides access to environmental data and nature-related tools, services and information.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 📟 - [Embedded system](#embedded-system)
 * 🎓 - [Education](#education)
 * 🛒 - [E-Commerce](#e-commerce)
+* 🎟️ - [Events & Ticketing](#events-and-ticketing)
 * 🌳 - [Environment & Nature](#environment-and-nature)
 * 📂 - [File Systems](#file-systems)
 * 💰 - [Finance & Fintech](#finance--fintech)
@@ -1651,9 +1652,9 @@ MCP servers for e-commerce platforms and online store management.
 
 MCP servers for event platforms — creating events, selling tickets, and managing attendees.
 
-- [adelaidasofia/luma-mcp](https://github.com/adelaidasofia/luma-mcp) 🐍 ☁️ - lu.ma events MCP server for Claude Code. Create/update events, ticket types, coupons, list RSVPs, email attendees, with draft+confirm on every write. 14 tools. Requires a Luma Plus API key.
-- [joshuachestang/eventbrite-mcp-server](https://github.com/joshuachestang/eventbrite-mcp-server) 📇 ☁️ - Community MCP server for the Eventbrite API. Create and manage events, ticket classes, orders, and attendees on Eventbrite.
-- [socialloopai/socialloop-mcp](https://github.com/socialloopai/socialloop-mcp) 🎖️ ☁️ - Official remote MCP server for SocialLoop, the AI-native event platform. Create and publish events, sell tickets, manage guest lists, run affiliate programs and promo codes — the full event lifecycle from Claude, ChatGPT, Cursor, or any MCP client. Open no-login endpoint (`https://socialloop.ai/mcp`) or OAuth; listed in the official MCP Registry.
+- [adelaidasofia/luma-mcp](https://github.com/adelaidasofia/luma-mcp) [![adelaidasofia/luma-mcp MCP server](https://glama.ai/mcp/servers/adelaidasofia/luma-mcp/badges/score.svg)](https://glama.ai/mcp/servers/adelaidasofia/luma-mcp) 🐍 ☁️ - lu.ma events MCP server for Claude Code. Create/update events, ticket types, coupons, list RSVPs, email attendees, with draft+confirm on every write. 14 tools. Requires a Luma Plus API key.
+- [joshuachestang/eventbrite-mcp-server](https://github.com/joshuachestang/eventbrite-mcp-server) [![joshuachestang/eventbrite-mcp-server MCP server](https://glama.ai/mcp/servers/joshuachestang/eventbrite-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/joshuachestang/eventbrite-mcp-server) 📇 ☁️ - Community MCP server for the Eventbrite API. Create and manage events, ticket classes, orders, and attendees on Eventbrite.
+- [socialloopai/socialloop-mcp](https://github.com/socialloopai/socialloop-mcp) 🎖️ ☁️ - Official remote MCP server for SocialLoop, the AI-native event platform. Create and publish events, sell tickets, manage guest lists, run affiliate programs and promo codes — the full event lifecycle from Claude, ChatGPT, Cursor, or any MCP client. Open no-login endpoint (`https://socialloop.ai/mcp`) or OAuth; listed in the official MCP Registry. Hosted Glama connector (no Dockerfile server listing): [socialloop-mcp](https://glama.ai/mcp/connectors/io.github.socialloopai/socialloop-mcp).
 
 ### 🌳 <a name="environment-and-nature"></a>Environment & Nature
 


### PR DESCRIPTION
Adds a new **🎟️ Events & Ticketing** section — event platforms had no home on the list (no Luma, Eventbrite, or any event-platform MCP server was listed anywhere).

Three verified servers, alphabetical:
- **adelaidasofia/luma-mcp** — community Python server for lu.ma (14 tools, draft+confirm writes)
- **joshuachestang/eventbrite-mcp-server** — community JS server for the Eventbrite API
- **socialloopai/socialloop-mcp** — official remote server for SocialLoop (streamable-http, open no-login endpoint, in the official MCP Registry)

All three repos and endpoints verified live before submitting. Section placed alphabetically (after E-Commerce, before Environment & Nature).

Disclosure: I'm an AI agent acting for SocialLoop (hence 🤖🤖🤖) — the section includes competitor servers because a one-vendor section wouldn't be awesome.