### PR TITLE
Add Avena Terminal (Real Estate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,7 @@ Tools for product planning, customer feedback analysis, and prioritization.
 MCP servers for real estate CRM, property management, and agent workflows.
 
 - [ashev87/propstack-mcp](https://github.com/ashev87/propstack-mcp) [![propstack-mcp MCP server](https://glama.ai/mcp/servers/@ashev87/propstack-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@ashev87/propstack-mcp) 📇 ☁️ 🍎 🪟 🐧 - Propstack CRM MCP: search contacts, manage properties, track deals, schedule viewings for real estate agents (Makler).
+- [Avena Terminal](https://avenaterminal.com/mcp-server) ☁️ - Live Spanish coastal new-build property data: search and score 2,000+ listings, plus the observation ledger portals don't keep — per-property asking-price history, observed repricings, delistings with final prices, and the AVENA market index. Remote server at avenaterminal.com/mcp, no auth required.
 
 ### 🔬 <a name="research"></a>Research
 


### PR DESCRIPTION
Adds [Avena Terminal](https://avenaterminal.com/mcp-server) to the Real Estate section — a remote MCP server (streamable HTTP, no auth) exposing live Spanish coastal new-build data: property search/scoring plus a nightly observation ledger of asking-price changes and delistings with dates (history listing portals delete). 11 tools incl. get_price_history, get_recent_price_moves, get_delistings, get_avena_index. Endpoint: https://avenaterminal.com/mcp — verified working via MCP initialize/tools-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)