### PR TITLE
Add trvux/chrome-eye

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+- [trvux/chrome-eye](https://github.com/trvux/chrome-eye) 🏎️ 🏠 🍎 - Structured JSON view into a real Chrome tab via CDP instead of screenshots — click/type/snapshot the real DOM, read layout and design tokens, emulate viewports/network/geolocation, mock requests, diff screenshots, record and replay sessions.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
Adds chrome-eye to Browser Automation: an MCP server giving Claude Code a fast, cheap structured-JSON eye into real Chrome via the Chrome DevTools Protocol — snapshot/click/type against the real DOM, read layout and design tokens, emulate viewports/network/geolocation, mock requests, diff screenshots, record/replay sessions. Go codebase, 56 MCP tools.

Follows CONTRIBUTING.md: one line, alphabetically placed in the Browser Automation section, existing format/icons (🏎️ Go, 🏠 Local, 🍎 macOS).