### PR TITLE
Add mi-fitness-data-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [shkyyy18/mi-fitness-data-bridge](https://github.com/shkyyy18/mi-fitness-data-bridge) [![shkyyy18/mi-fitness-data-bridge MCP server](https://glama.ai/mcp/servers/shkyyy18/mi-fitness-data-bridge/badges/score.svg)](https://glama.ai/mcp/servers/shkyyy18/mi-fitness-data-bridge) 🐍 🏠 - Local-first bridge for your own Mi Fitness (Xiaomi) health data — sync daily activity, sleep, workouts, heart rate, SpO2 and stress into a local SQLite database, export portable JSON/CSV, and query it over MCP.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
Local-first bridge that exports your own Mi Fitness (Xiaomi) health data — daily activity, sleep, workouts, heart rate, SpO2, stress — into a local SQLite database, with portable JSON/CSV exports and local MCP query tools.

Listed on Glama: https://glama.ai/mcp/servers/shkyyy18/mi-fitness-data-bridge (score badge included in the entry).

Filed under Health & Wellness: the server is a personal health-data connector, matching the category's existing health-platform entries (e.g. health-export-mcp for Apple Health).