### PR TITLE
Add wardline 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3683,6 +3683,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [kiarash-portfolio-mcp](https://kiarash-adl.pages.dev/.well-known/mcp.llmfeed.json) – WebMCP-enabled portfolio with Ed25519 signed discovery. AI agents can query projects, skills, and execute terminal commands. Built on Cloudflare Pages Functions.
 - [kimtth/mcp-remote-call-ping-pong](https://github.com/kimtth/mcp-remote-call-ping-pong) 🐍 🏠 - An experimental and educational app for Ping-pong server demonstrating remote MCP (Model Context Protocol) calls
 - [kiwamizamurai/mcp-kibela-server](https://github.com/kiwamizamurai/mcp-kibela-server) - 📇 ☁️ Powerfully interact with Kibela API.
+- [kabirnarang39/wardline](https://github.com/kabirnarang39/wardline) 🏎️ 🏠 🍎 🪟 🐧 - Control-plane proxy that sits in front of MCP servers, enforcing per-identity policy (YAML/OPA/Cedar), budget limits, an audit trail, and real-time auto-block on anomalous agent behavior.
 - [kj455/mcp-kibela](https://github.com/kj455/mcp-kibela) - 📇 ☁️ Allows AI models to interact with [Kibela](https://kibe.la/)
 - [Klavis-AI/YouTube](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/youtube) 🐍 📇 - Extract and convert YouTube video information.
 - [KS-GEN-AI/confluence-mcp-server](https://github.com/KS-GEN-AI/confluence-mcp-server) 📇 ☁️ 🍎 🪟 - Get Confluence data via CQL and read pages.


### PR DESCRIPTION
Adds [wardline](https://github.com/kabirnarang39/wardline) — a control-plane proxy for MCP servers: per-identity policy (YAML/OPA/Cedar), budget limits, an audit trail, and anomaly-based auto-block for a compromised agent. Go, Apache-2.0.

One line, alphabetical position, existing format kept.