### PR TITLE
Add SmartTools MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1390,6 +1390,7 @@ Tools and integrations that enhance the development workflow and environment man
 - [SimplyLiz/CodeMCP](https://github.com/SimplyLiz/CodeMCP) 🏎️ 🏠 🍎 🪟 🐧 - Code intelligence MCP server with 80+ tools for semantic code search, impact analysis, call graphs, ownership detection, and architectural understanding. Supports Go, TypeScript, Python, Rust, Java via SCIP indexing.
 - [simplypixi/bugbug-mcp-server](https://github.com/simplypixi/bugbug-mcp-server) ☁️ - MCP for BugBug API, to manage test and suites on BugBug
 - [skullzarmy/vibealive](https://github.com/skullzarmy/vibealive) 📇 🏠 🍎 🪟 🐧 — Full-featured utility to test Next.js projects for unused files and APIs, with an MCP server that exposes project analysis tools to AI assistants.
+- [SmartTools](https://smart-tools.xyz/en/mcp) 📇 ☁️ - Free scientific calculator plus 72 other calculators, unit converters and text/dev utilities over one no-auth HTTP endpoint; every result returns a source_url back to the tool page. `claude mcp add --transport http smart-tools https://smart-tools.xyz/mcp`
 - [snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server) 🏎️ 🏠 - Connect any HTTP/REST API server using an Open API spec (v3)
 - [softvoyagers/linkshrink-api](https://github.com/softvoyagers/linkshrink-api) 📇 ☁️ - Free privacy-first URL shortener API with analytics and link management. No API key required.
 - [softvoyagers/ogforge-api](https://github.com/softvoyagers/ogforge-api) 📇 ☁️ - Free Open Graph image generator API with themes, Lucide icons, and custom layouts. No API key required.


### PR DESCRIPTION
Adds **SmartTools** to the Developer Tools section (alphabetically, between `skullzarmy` and `snaggle-ai`).

- **What it is:** a remote, no-auth Streamable HTTP MCP server exposing a scientific calculator (a full expression evaluator — order of operations, powers, roots, trig, logs, factorial) plus 72 other calculators, unit converters and text/dev utilities (base64, hashing, JWT, regex, cron, subnet, UUID, JSON, and more).
- **Why it's useful:** LLMs are unreliable at arithmetic; this hands the sum to a real evaluator. Every result also returns a `source_url` back to the tool page.
- **Endpoint:** `https://smart-tools.xyz/mcp` · **Docs:** https://smart-tools.xyz/en/mcp
- Stateless, no API key, no sign-up. One-line install: `claude mcp add --transport http smart-tools https://smart-tools.xyz/mcp`

Single-line addition; follows the existing format and the alphabetical-order guideline.
