### PR TITLE
Add ManSio/MSPortfolio — MCP-native engineering portfolio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3594,6 +3594,8 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
+- [ManSio/MSPortfolio](https://github.com/ManSio/MSPortfolio) [![ManSio/msp-portfolio MCP server](https://glama.ai/mcp/servers/ManSio/msp-portfolio/badges/score.svg)](https://glama.ai/mcp/servers/ManSio/msp-portfolio) 📇 ☁️ - Live MCP server for Mikhail (ManSio)'s engineering portfolio: projects with decision logs, engineering principles, stack-fit analysis, architecture failure simulation, and the full lab (experiments, diary, known issues) — one source of truth with an evidence score. Remote Streamable HTTP, no auth.
+
 - [atomno-mcp/mcp-rosreestr](https://github.com/atomno-mcp/mcp-rosreestr) [![atomno-mcp/mcp-rosreestr MCP server](https://glama.ai/mcp/servers/atomno-mcp/mcp-rosreestr/badges/score.svg)](https://glama.ai/mcp/servers/atomno-mcp/mcp-rosreestr) 🐍 ☁️ - MCP-сервер над открытыми данными Росреестра: проверка квартиры/участка, история сделок (по доступным данным), кадастровая стоимость
 - [douglasgan/asktian](https://github.com/douglasgan/asktian-mcp) [![douglasgan/asktian-mcp MCP server](https://glama.ai/mcp/servers/douglasgan/asktian-mcp/badges/score.svg)](https://glama.ai/mcp/servers/douglasgan/asktian-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Chinese metaphysics (bazi 八字, qimen 奇門, 5-element, daily 干支) as decision-support tools. Ask "when should I do X" and get specific time windows instead of vague advice. 5 tools: daily reading, compat, best-time-for-action, today's energy, name analysis. `npm install -g @asktian/mcp-server`
 


### PR DESCRIPTION
Adds [ManSio/MSPortfolio](https://github.com/ManSio/MSPortfolio): a live MCP server exposing an engineering portfolio — projects with decision logs, engineering principles, stack-fit analysis, architecture failure simulation, and a lab (experiments, diary, known issues) with a deterministic evidence score. Remote Streamable HTTP on Cloudflare Workers, no auth required. Already published in the official MCP Registry (io.github.ManSio/msp-portfolio) and ready on Smithery.