### PR TITLE
Add Jackxiaozhiren/datasentry MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,6 +1577,7 @@ Tools and integrations that enhance the development workflow and environment man
 
 Integrations and tools designed to simplify data exploration, analysis and enhance data science workflows.
 
+- [Jackxiaozhiren/datasentry](https://github.com/Jackxiaozhiren/datasentry) [![Jackxiaozhiren/datasentry MCP server](https://glama.ai/mcp/servers/Jackxiaozhiren/datasentry/badges/score.svg)](https://glama.ai/mcp/servers/Jackxiaozhiren/datasentry) 🐍 🏠 - Find data-quality problems, inspect evidence and drift, and run controlled repair workflows locally.
 - [abhiphile/fermat-mcp](https://github.com/abhiphile/fermat-mcp) 🐍 🏠 🍎 🪟 🐧 - The ultimate math engine unifying SymPy, NumPy & Matplotlib in one powerful server. Perfect for developers & researchers needing symbolic algebra, numerical computing, and data visualization.
 - [Archerkattri/mathlas](https://github.com/Archerkattri/mathlas) [![Archerkattri/mathlas MCP server](https://glama.ai/mcp/servers/Archerkattri/mathlas/badges/score.svg)](https://glama.ai/mcp/servers/Archerkattri/mathlas) 🐍 🏠 - Airtight math for agents: 3.7M-theorem search, PSLQ constant ID, OEIS, real Lean kernel checks, applicability checklists. No LLM inside, no API key.
 - [arrismo/kaggle-mcp](https://github.com/arrismo/kaggle-mcp) 🐍 ☁️ - Connects to Kaggle, ability to download and analyze datasets.


### PR DESCRIPTION
Adds [DataSentry](https://github.com/Jackxiaozhiren/datasentry) — a local-first data quality copilot with an MCP stdio server (20 tools).

What the MCP server lets agents do:
- run scans over CSV/Parquet/JSONL/XLSX/DuckDB/SQLite/PostgreSQL/MySQL/s3/gcs/az data sources
- list issues with their statistical evidence chain (samples, ratios, confidence)
- propose/apply/rollback repairs — always behind a human approval gate
- create and trigger scheduled scan jobs, query drift between historical scans

Why it fits the list: Python (`pip install datasentry-ai`), local-first (works fully offline; LLM integration optional and can target local Ollama), Apache-2.0, 1200+ tests at ~95% coverage.

Format follows existing entries: repo link, glama badge, language/scope/OS emoji, one-line description.