### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README-fa-ir.md
+++ b/README-fa-ir.md
@@ -1304,10 +1304,10 @@ https://modelcontextprotocol.io/llms-full.txt
 
 ## تاریخچه ستاره‌ها
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README-ja.md
+++ b/README-ja.md
@@ -689,11 +689,11 @@ https://modelcontextprotocol.io/llms-full.txt
 
 ## スター履歴
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -678,10 +678,10 @@ Claude에게 MCP 서버 작성 및 작동 방식에 대한 질문해보세요!
 
 ## 스타 히스토리
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -586,10 +586,10 @@ Agora o Claude pode responder perguntas sobre como escrever servidores MCP e com
 
 ## Histórico de Estrelas
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README-th.md
+++ b/README-th.md
@@ -745,10 +745,10 @@ https://modelcontextprotocol.io/llms-full.txt
 
 ## Star History
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README-zh.md
+++ b/README-zh.md
@@ -735,10 +735,10 @@ https://modelcontextprotocol.io/llms-full.txt
 
 ## 收藏历史
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README-zh_TW.md
+++ b/README-zh_TW.md
@@ -588,10 +588,10 @@ https://modelcontextprotocol.io/llms-full.txt
 
 ## 收藏歷史
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -3812,10 +3812,10 @@ Now Claude can answer questions about writing MCP servers and how they work
 
 ## Star History
 
-<a href="https://star-history.com/#punkpeye/awesome-mcp-servers&Date">
+<a href="https://star-history.dera.page/#punkpeye/awesome-mcp-servers&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History chart at the bottom of the READMEs is currently broken and no longer renders, which prevents visitors from seeing the project's growth. This PR updates the chart links across README.md and all localized README versions (fa-ir, ja, ko, pt_BR, th, zh, zh_TW) so the star history displays correctly again.

A proper star history is valuable for this project as it showcases the community growth at a glance, so fixing this is important.