### PR TITLE
Add givewell-donate: charitable donations via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2280,3 +2280,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+- [ajfrai/givewell-donate](https://github.com/ajfrai/givewell-donate) 🏎️ ☁️ - Donate to GiveWell (evidence-backed global health charities) in BTC, ETH, and USDC. Three of five tools need no API key.


### PR DESCRIPTION
Adds [`givewell-donate`](https://github.com/ajfrai/givewell-donate), an MCP server for donating to [GiveWell](https://www.givewell.org).

**What it does:** exposes donation as a tool call. Humans have card checkout flows; agents don't, so an agent holding funds has no ordinary way to give any of it away.

**Notable design points:**
- Three of five tools require **no API key and no configuration** (`get_donation_address`, `prepare_donation`, `broadcast_signed_donation`), so agents holding their own keys aren't gated on operator setup.
- Destination addresses are **fixed in code** — no parameter can redirect funds. The worst outcome, even from a compromised agent, is donating money it already had authority to spend.
- The relay path never receives a private key; the agent signs locally and the server only validates that the transaction pays GiveWell before broadcasting.
- Documents that agents should donate **only funds they have authority to spend**.

Supports BTC, ETH, and USDC. Install: `npx -y givewell-donate`

Verified working end-to-end against mainnet, including real donations.