### PR TITLE
Add Arcaeon Ledger to Security 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3274,6 +3274,7 @@ Tools for conducting research, surveys, interviews, and data collection.
 
 - [mastyf-ai/mastyf.ai](https://github.com/mastyf-ai/mastyf.ai) [![mastyf-ai/mastyf.ai MCP server](https://glama.ai/mcp/servers/mastyf-ai/mastyf.ai/badges/score.svg)](https://glama.ai/mcp/servers/mastyf-ai/mastyf.ai) 📇 🏠 🍎 🪟 🐧 - Open-source runtime security proxy for MCP. Transparently intercepts every tools/call through an 18-class attack defense pipeline (prompt injection, SSRF, shell injection, SQL injection, credential exfil, polyglot attacks) with a YAML policy engine and 304-entry adversarial corpus. Trust scoring for npm MCP packages with 0-100 badges. Cloud dashboard, Docker image, Python SDK. MIT.
 - [timescale/rsigma](https://github.com/timescale/rsigma) [![timescale/rsigma MCP server](https://glama.ai/mcp/servers/timescale/rsigma/badges/score.svg)](https://glama.ai/mcp/servers/timescale/rsigma) 🎖️ 🦀 🏠 🍎 🪟 🐧 - Exposes the RSigma Sigma detection-engineering toolkit to AI agents over stdio or Streamable HTTP with `rsigma mcp serve`. Tools to author, lint, validate, and convert Sigma detection rules, evaluate and explain detections against log events, and inspect correlation state, all backed by a native Rust engine.
+- [dan8433-user/ledger](https://github.com/dan8433-user/ledger) 🐍 🏠 - Tamper-evident action logging for AI agents: hash-chained append/verify, one JSONL file, zero dependencies. Edit, delete, or reorder a line and verification names the exact break. `pip install arcaeon-ledger`
 
 ### 🌐 <a name="social-media"></a>Social Media
 


### PR DESCRIPTION
Adds `arcaeon-ledger` under Security.

Tamper-evident action logging for AI agents: two MCP tools (`ledger_append`,
`ledger_verify`) over a hash-chained JSONL file. Verification names the exact
line where an edit, delete, or reorder broke the chain. Zero dependencies,
MIT license, Python, local-only (stdio transport).

- PyPI: https://pypi.org/project/arcaeon-ledger/ (0.5.3, live)
- Official MCP Registry: `io.arcaeon/ledger` (domain-verified namespace, live)
- Repo README documents what the hash chain does and does not prove
  (doesn't alone prove truncation or authorship — states each limit next
  to the feature it bounds).

Follows the existing Security-section entry format (owner/repo link,
capability tags, description, install command). Placed at the end of the
section — the existing list isn't strictly alpha-ordered in practice, so
appending avoids a disruptive mid-list splice.
