### PR TITLE
Add Eterna MCP trading agent starter to Tutorials 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [Build an AI Trading Agent with Eterna MCP](https://github.com/stevevstd-oss/eterna-mcp-agent-starter)
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
-* [Build an AI Trading Agent with Eterna MCP](https://github.com/stevevstd-oss/eterna-mcp-agent-starter)
+* [stevevstd-oss/eterna-mcp-agent-starter](https://github.com/stevevstd-oss/eterna-mcp-agent-starter) 📇 - Tutorial starter repo: build an AI trading agent on Eterna Hybrid Exchange via Claude/MCP, the official CLI, and sandboxed TypeScript strategies.
 
 ## Community
 


### PR DESCRIPTION
This PR adds a tutorial-style starter repository to the Tutorials section.

[eterna-mcp-agent-starter](https://github.com/stevevstd-oss/eterna-mcp-agent-starter) walks through building an AI trading agent on Eterna Hybrid Exchange three ways: connecting Claude to the remote MCP server (`https://mcp.eterna.exchange/mcp`), using the official CLI (`npx @eterna-hybrid-exchange/cli`), and running sandboxed TypeScript strategies. It includes read-only example strategies, guarded agent prompts, and a documented safety model (isolated sub-account, no withdrawal permissions).

Disclosure: the repo contains referral links to the exchange, clearly marked as such.