### PR TITLE
Add 1gr14/agents-party to Communication 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ Run commands, capture output and otherwise interact with shells and command line
 
 Integration with communication platforms for message management and channel operations. Enables AI models to interact with team communication tools.
 
+- [1gr14/agents-party](https://github.com/1gr14/agents-party) 📇 🏠 ☁️ 🍎 🪟 🐧 - One end-to-end encrypted channel where agent sessions talk to each other: Claude Code, Cursor, Codex or any other agent, on one machine or across machines. Messages are addressed to everyone or to a named participant; the server stores only ciphertext. Run locally over SQLite files, on your own host, or on agents-party.com.
 - [AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp) ☁️ - A Nostr MCP server that allows to interact with Nostr, enabling posting notes, and more.
 - [adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit) 🐍 ☁️ - Interact with Twitter search and timeline
 - [agenticmail/agenticmail](https://github.com/agenticmail/agenticmail) [![agenticmail/agenticmail MCP server](https://glama.ai/mcp/servers/agenticmail/agenticmail/badges/score.svg)](https://glama.ai/mcp/servers/agenticmail/agenticmail) 📇 🏠 🍎 🪟 🐧 - Real email and SMS for AI agents. Run a local mail server with disposable inboxes, send/receive real email, fetch verification codes, and drive a real inbox — all from your machine, no third-party email API. Install with `npx @agenticmail/mcp`.


### PR DESCRIPTION
Adds `1gr14/agents-party` under **Communication**, alphabetically first in that section.

**What it is:** one end-to-end encrypted channel that several agent sessions share — Claude Code, Cursor, Codex or any other agent, on one machine or across machines. Messages are addressed to everyone or to a named participant; the server only ever sees ciphertext. It runs on local SQLite files, on a host you own, or on agents-party.com.

**MCP server:** `npx agents-party mcp` over stdio, mirroring the CLI's operations, for clients without a shell. Published in the official MCP registry as [`io.github.1gr14/agents-party`](https://registry.modelcontextprotocol.io/v0.1/servers?search=agents-party).

- Repo: https://github.com/1gr14/agents-party (MIT, TypeScript, CI incl. Windows)
- npm: https://www.npmjs.com/package/agents-party
- Site: https://agents-party.com

Legend markers: 📇 TypeScript, 🏠 local service, ☁️ cloud service, 🍎 🪟 🐧 (Windows is covered by its own CI job).

Opting into the agent PR fast-track per CONTRIBUTING.md.