### PR TITLE
Add "How to Build an MCP Server (Step by Step)" to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [How to Build an MCP Server (Step by Step)](https://aiarch.dev/how-to-build-an-mcp-server)
 
 ## Community
 


### PR DESCRIPTION
Adds a step-by-step MCP server tutorial to the Tutorials section.

Walks building a server's tools, resources and prompts and connecting it to an agent, written for engineers who already ship production services. It targets revision 2025-11-25, still the spec site's current revision, and carries a section on what the published 2026-07-28 revision changes.