### PR TITLE
Add gitlog-mcp server to Version Control section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3468,6 +3468,8 @@ Access to travel and transportation information. Enables querying schedules, rou
 ### 🔄 <a name="version-control"></a>Version Control
 
 Interact with Git repositories and version control platforms. Enables repository management, code analysis, pull request handling, issue tracking, and other version control operations through standardized APIs.
+- [gitlog-mcp](https://github.com/ManiaSacha/gitlog-mcp) [![gitlog-mcp MCP server](https://glama.ai/mcp/servers/ManiaSacha/gitlog-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ManiaSacha/gitlog-mcp) 🐍 🏠 🍎 🪟 🐧 - Give AI coding agents structured access to git history — changelogs, commit analysis, blame attribution, and release notes via MCP. Zero runtime dependencies.
+
 
 - [adhikasp/mcp-git-ingest](https://github.com/adhikasp/mcp-git-ingest) 🐍 🏠 - Read and analyze GitHub repositories with your LLM
 - [costajohnt/oss-autopilot](https://github.com/costajohnt/oss-autopilot) [![costajohnt/oss-autopilot MCP server](https://glama.ai/mcp/servers/costajohnt/oss-autopilot/badges/score.svg)](https://glama.ai/mcp/servers/costajohnt/oss-autopilot) 📇 ☁️ 🏠 🍎 🪟 🐧 - Open source contribution manager with PR tracking across repos, issue discovery, CI failure diagnosis, and maintainer response drafting. Available as CLI, MCP server, and Claude Code plugin.


### PR DESCRIPTION
Adds gitlog-mcp (https://github.com/ManiaSacha/gitlog-mcp) — a single-file, zero-dependency MCP server that gives AI coding agents structured access to git history (changelogs, commit analysis, blame, and release notes).