### PR TITLE
Add SteamGPTnet MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2166,7 +2166,7 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
-- [SteamGPTnet/steamgpt-mcp](https://github.com/SteamGPTnet/steamgpt-mcp) 🎖️ 📇 ☁️ - Steam profiles, SteamID conversion, VAC/game bans, FACEIT stats and friends. Free, no API key.
+- [SteamGPTnet/steamgpt-mcp](https://github.com/SteamGPTnet/steamgpt-mcp) 🎖️ 📇 ☁️ - Steam profiles, SteamID conversion, VAC/game bans, FACEIT stats and friends. Free, no API key. [![SteamGPTnet/steamgpt-mcp MCP server](https://glama.ai/mcp/servers/q1y6yl24ol/badges/score.svg)](https://glama.ai/mcp/servers/SteamGPTnet/steamgpt-mcp)
 
 ### 🏥 <a name="health-and-wellness"></a>Health & Wellness
 

--- a/README.md
+++ b/README.md
@@ -2166,6 +2166,7 @@ Integration with gaming related data, game engines, and services
 - [tomholford/mcp-tic-tac-toe](https://github.com/tomholford/mcp-tic-tac-toe) 🏎️ 🏠 - Play Tic Tac Toe against an AI opponent using this MCP server.
 - [youichi-uda/godot-mcp-pro](https://github.com/youichi-uda/godot-mcp-pro) 📇 🏠 🍎 🪟 🐧 - Premium MCP server for Godot game engine with 84 tools for scene editing, scripting, animation, tilemap, shader, input simulation, and runtime debugging.
 - [HadiCherkaoui/crafty-mcp](https://github.com/HadiCherkaoui/crafty-mcp) [![HadiCherkaoui/crafty-mcp MCP server](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp/badges/score.svg)](https://glama.ai/mcp/servers/HadiCherkaoui/crafty-mcp) 📇 🏠 🍎 🪟 🐧 - MCP server for managing Minecraft servers through [Crafty Controller 4](https://craftycontrol.com). Start, stop, backup, send commands, manage files, schedules, webhooks, and users via the Crafty API.
+- [SteamGPTnet/steamgpt-mcp](https://github.com/SteamGPTnet/steamgpt-mcp) 🎖️ 📇 ☁️ - Steam profiles, SteamID conversion, VAC/game bans, FACEIT stats and friends. Free, no API key.
 
 ### 🏥 <a name="health-and-wellness"></a>Health & Wellness
 


### PR DESCRIPTION
Adds SteamGPT to the 🎮 Gaming section.

SteamGPT is a free, no-auth Steam data MCP server: player profiles, SteamID conversion (steamid64 / STEAM_1:0:x / [U:1:x] / vanity names), VAC and game ban checks, FACEIT levels and ELO, public friend graphs, batch lookups (up to 100 players in one call) and side-by-side player comparison - 8 read-only tools.

- Remote Streamable HTTP server at `https://steamgpt.net/mcp` (no API key, no OAuth), plus an npx stdio proxy: `npx -y steamgpt-mcp`
- Listed in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/net.steamgpt%2Fsteamgpt/versions/latest) as `net.steamgpt/steamgpt`
- npm: https://www.npmjs.com/package/steamgpt-mcp
- Agent docs: https://steamgpt.net/ai

The entry follows the list format (🎖️ official, 📇 TypeScript, ☁️ cloud service) and is placed in alphabetical order within the section.