### PR TITLE
Add mcp-hello-tools to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 ## Tutorials
 
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
+* [mcp-hello-tools](https://github.com/neuroxinc/mcp-hello-tools) - The smallest working MCP server in Python — one-minute read, plus the 3 most common setup pitfalls (EN/JA)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
 


### PR DESCRIPTION
Adds [mcp-hello-tools](https://github.com/neuroxinc/mcp-hello-tools) to the Tutorials section: the smallest working MCP server in Python (FastMCP, ~30 lines), aimed at first-time MCP builders. README covers the 3 most common setup pitfalls (config path per OS, silent failures, schema mistakes) in English and Japanese. MIT licensed.

Disclosure: the README links to a paid Japanese tutorial pack by the same author; the listed repo itself is free and self-contained.