### PR TITLE
Add CuttingToolsAI carbide grade cross-reference server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2191,6 +2191,7 @@ Control smart home devices, home network equipment, and automation systems.
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
+- [memmizgezgin-creator/cuttingtoolsai-mcp](https://github.com/memmizgezgin-creator/cuttingtoolsai-mcp) 📇 ☁️ - Brand-neutral carbide grade cross-reference for machining: catalog-verified comparable insert grades across manufacturers via the grade_xref tool. Hosted, no auth.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 

--- a/README.md
+++ b/README.md
@@ -2191,7 +2191,7 @@ Control smart home devices, home network equipment, and automation systems.
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
-- [memmizgezgin-creator/cuttingtoolsai-mcp](https://github.com/memmizgezgin-creator/cuttingtoolsai-mcp) 📇 ☁️ - Brand-neutral carbide grade cross-reference for machining: catalog-verified comparable insert grades across manufacturers via the grade_xref tool. Hosted, no auth.
+- [memmizgezgin-creator/cuttingtoolsai-mcp](https://github.com/memmizgezgin-creator/cuttingtoolsai-mcp) 📇 ☁️ - Brand-neutral carbide grade cross-reference for machining: catalog-verified comparable insert grades across manufacturers via the grade_xref tool. Hosted, no auth. [![memmizgezgin-creator/cuttingtoolsai-mcp MCP server](https://glama.ai/mcp/servers/memmizgezgin-creator/cuttingtoolsai-mcp/badges/score.svg)](https://glama.ai/mcp/servers/memmizgezgin-creator/cuttingtoolsai-mcp)
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds CuttingToolsAI MCP server to Industrial & IoT (alphabetical, after FoundryNet/forge-mcp).

What it does: brand-neutral carbide grade cross-referencing for machining. The grade_xref tool takes a manufacturer grade (e.g. GC4325) and returns catalog-verified comparable grades across manufacturers, with the honest caveat that comparability at the same ISO application position is a starting point, not interchangeability.

Hosted (Streamable HTTP, JSON-RPC 2.0), no auth, read-only: https://cuttingtoolsai-mcp.memmizgezgin.workers.dev

Repo: https://github.com/memmizgezgin-creator/cuttingtoolsai-mcp

Data layer: cross-reference table extracted from manufacturer catalogs with multi-source verification tiers. The server never invents a grade; unknown codes return an empty result.