### PR TITLE
Add AutoRev MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3846,6 +3846,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [autorevai/autorev-mcp](https://github.com/autorevai/autorev-mcp) 📇 ☁️ 🏠 - Run a field service business from an MCP client. Answer and review calls, book and dispatch jobs, build and send estimates, chase invoices, manage the pricebook and pull daily numbers for HVAC, plumbing, electrical, roofing and pest control companies. Remote streamable HTTP with OAuth 2.1, or stdio via `@autorevai/mcp-server` on npm.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.


### PR DESCRIPTION
Adds [autorevai/autorev-mcp](https://github.com/autorevai/autorev-mcp) under **Support & Service Management**, inserted alphabetically between `aikts` and `Berckan`.

AutoRev is field service operations for the trades: answering calls, booking and dispatching jobs, building estimates and chasing invoices for HVAC, plumbing, electrical, roofing and pest control companies. The MCP server exposes that from Claude.

- **Official implementation** 🎖️ (maintained by the vendor)
- **JavaScript** 📇, **Cloud service** ☁️
- Auth is OAuth 2.1 via `mcp-remote`. The package holds no credentials and never sees a token. Tools are scope-filtered server-side per token and tenant, tenant membership re-checked on every call. Destructive bulk operations are gated server-side and not exposed in the public manifest.
- Repo is public, MIT, and carries a `server.json` registry manifest.

No install command in the entry yet: the npm package is not published at the time of this PR, and I would rather ship no command than one that 404s. Happy to follow up with `npx -y @autorev/mcp-server` once it is live if you would like it included.

Opted into the agent fast-track per CONTRIBUTING.md.