### PR TITLE
Add claudeclear-mcp 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -3012,6 +3012,7 @@ Interact with Git repositories and version control platforms. Enables repository
 
 ### 🛠️ <a name="other-tools-and-integrations"></a>Other Tools and Integrations
 
+- [aidevelopers2/claudeclear-mcp](https://github.com/aidevelopers2/claudeclear-mcp) 📇 🏠 🍎 🪟 🐧 - Removes the Claude text watermark by rewriting text through a non-watermarking model, and strips C2PA/EXIF metadata (e.g. "Made with Claude") from images. Install: `npx -y claudeclear-mcp`.
 - [douglasgan/asktian](https://github.com/douglasgan/asktian-mcp) [![douglasgan/asktian-mcp MCP server](https://glama.ai/mcp/servers/douglasgan/asktian-mcp/badges/score.svg)](https://glama.ai/mcp/servers/douglasgan/asktian-mcp) 📇 ☁️ 🏠 🍎 🪟 🐧 - Chinese metaphysics (bazi 八字, qimen 奇門, 5-element, daily 干支) as decision-support tools. Ask "when should I do X" and get specific time windows instead of vague advice. 5 tools: daily reading, compat, best-time-for-action, today's energy, name analysis. `npm install -g @asktian/mcp-server`
 
 - [2niuhe/plantuml_web](https://github.com/2niuhe/plantuml_web) 🐍 🏠 ☁️ 🍎 🪟 🐧 - A web-based PlantUML frontend with MCP server integration, enable plantuml image generation and plantuml syntax validation.


### PR DESCRIPTION
Adds **claudeclear-mcp** under *Other Tools and Integrations*.

Removes the Claude text watermark by rewriting text through a non-watermarking model, and strips C2PA/EXIF image metadata. Two tools: `rewrite_text` and `strip_image_metadata`.

- npm: https://www.npmjs.com/package/claudeclear-mcp
- Repo: https://github.com/aidevelopers2/claudeclear-mcp
- Official MCP registry: `io.github.aidevelopers2/claudeclear-mcp`
- Install: `npx -y claudeclear-mcp`

Single-line addition; markers follow the legend (📇 TypeScript, 🏠 local stdio, cross-platform).