### PR TITLE
Add Helisoma to Health & Wellness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2171,6 +2171,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
+- [Helisoma](https://helisoma.com) 🎖️ ☁️ - Serve a user's hand-checked DNA wellness report (caffeine response, sleep timing, training, nutrient absorption) to Claude over OAuth. The raw 23andMe/Ancestry file is parsed in the browser and never uploaded; every finding states its effect size and links to its source paper. No disease risk scores.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
Adds [Helisoma](https://helisoma.com), a hosted (remote) MCP server at `https://api.helisoma.com/mcp` with OAuth 2.1.

It serves a user's DNA wellness report to Claude: caffeine response, sleep timing, training, nutrient absorption. The raw 23andMe/Ancestry file is parsed in the user's browser and never uploaded; only the ~600 markers the report needs reach the server. Every finding states its effect size and links to its source paper (GWAS Catalog, PharmGKB). Deliberately no disease risk scores.

I'm the founder, marked 🎖️ ☁️ accordingly. Placed as the second entry of Health & Wellness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)