### PR TITLE
Add Bareun MCP — Korean NLP & spell/grammar checking 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * 🏃 - [Sports](#sports)
 * 🎧 - [Support & Service Management](#support-and-service-management)
 * 🌎 - [Translation Services](#translation-services)
+* ✍️ - [Text Analysis & Proofreading](#text-analysis-and-proofreading)
 * 🎧 - [Text-to-Speech](#text-to-speech)
 * 🎙️ - [Speech-to-Text](#speech-to-text)
 * 🚆 - [Travel & Transportation](#travel-and-transportation)
@@ -3402,6 +3403,12 @@ Translation tools and services to enable AI assistants to translate content betw
 - [eviscerations/whisper-windows-mcp](https://github.com/eviscerations/whisper-windows-mcp) [![eviscerations/whisper-windows-mcp MCP server](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eviscerations/whisper-windows-mcp) 📇 🏠 🪟 - Windows-native local audio and video transcription using whisper.cpp with Vulkan GPU acceleration. No cloud APIs, no Python. Batch processing, multilingual support, model management, and background job handling built in.
 - [ankurmans/pepys-mcp](https://github.com/ankurmans/pepys-mcp) [![ankurmans/pepys-mcp MCP server](https://glama.ai/mcp/servers/ankurmans/pepys-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ankurmans/pepys-mcp) 📇 ☁️ 🏠 - Pay-once transcription for audio, video, and whole podcast feeds via [Pepys](https://pepys.co). Transcribe a file or a pasted YouTube/podcast link, get speaker diarization, export SRT/VTT, search a transcript, and check credit balance. Hosted connector (OAuth, no API key) or `npx pepys-mcp`. 99+ languages.
 - [spokenmd/spoken](https://github.com/spokenmd/spoken) [![spokenmd/spoken MCP server](https://glama.ai/mcp/servers/spokenmd/spoken/badges/score.svg)](https://glama.ai/mcp/servers/spokenmd/spoken) 📇 ☁️ - Fetch published podcast transcripts as clean Markdown with real speaker names (not "Speaker 1") via the [Spoken](https://spoken.md) API. Search episodes, get transcripts, check credit balance.
+
+### ✍️ <a name="text-analysis-and-proofreading"></a>Text Analysis & Proofreading
+
+Linguistic analysis, grammar and spelling correction, and other text-quality tooling.
+
+- [gih2yun/bareun-mcp](https://github.com/gih2yun/bareun-mcp) [![gih2yun/bareun-mcp MCP server](https://glama.ai/mcp/servers/gih2yun/bareun-mcp/badges/score.svg)](https://glama.ai/mcp/servers/gih2yun/bareun-mcp) 🎖️ ☁️ - Korean morphological analysis (47-tag POS tagging, tokenization, homograph sense disambiguation) and spelling/spacing correction via the Bareun (바른) engine. Hosted streamable-HTTP endpoint at https://api.bareun.ai/mcp with api-key auth; self-hosted installs expose the same tools.
 
 ### 🎧 <a name="text-to-speech"></a>Text-to-Speech
 


### PR DESCRIPTION
Adds **Bareun (바른)** — a hosted MCP server for Korean morphological analysis and spelling/spacing correction.

- Repo: https://github.com/gih2yun/bareun-mcp (MIT)
- Endpoint: `https://api.bareun.ai/mcp` — Streamable HTTP, `api-key` header
- Glama: https://glama.ai/mcp/servers/gih2yun/bareun-mcp (score badge included in the entry)
- Tools: `analyze_syntax`, `analyze_syntax_raw`, `tokenize`, `correct_grammar`, `list_pos_tags` — all annotated `readOnlyHint: true`

### New category

There is no NLP / proofreading section today, so this adds **✍️ Text Analysis & Proofreading** (CONTRIBUTING allows creating one), placed alphabetically in both the Contents list and the body. Happy to move the entry into `Other Tools and Integrations` instead if you would rather not add a category for a single server.

### Emoji choices

🎖️ (official implementation — maintained by the Bareun team) and ☁️ (cloud service). No language emoji: the linked repository holds the manifests and docs, not the engine source, so marking a codebase language would be misleading.

Opened by an automated agent, hence the 🤖🤖🤖 opt-in from CONTRIBUTING.