### PR TITLE
Add a11y-toolkit (new Accessibility category) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ MCP servers for creating, coordinating, and executing agreements: commitments, e
 - [CNSLabs/agreements-api-sdk](https://github.com/CNSLabs/agreements-api-sdk) [![CNSLabs/agreements-api-sdk MCP server](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk/badges/score.svg)](https://glama.ai/mcp/servers/CNSLabs/agreements-api-sdk) 📇 ☁️ 🏠 - Remote Streamable HTTP and local stdio MCP server for defining, validating, deploying, and operating machine-readable agreements with EIP-712 permit preparation, signed participant inputs, state reads, and input history.
 - [humanforai/humanforai-mcp](https://github.com/humanforai/humanforai-mcp) [![humanforai/humanforai-mcp MCP server](https://glama.ai/mcp/servers/humanforai/humanforai-mcp/badges/score.svg)](https://glama.ai/mcp/servers/humanforai/humanforai-mcp) 🎖️ 📇 ☁️ - Hire a real human operator for tasks that need physical presence, perception, or judgment: real-world verification, product testing, AI output review, data collection, and local errands. Remote streamable HTTP at https://humanforai.dev/mcp or local stdio via `npx -y humanforai`.
 
+### ♿ <a name="accessibility"></a>Accessibility
+
+- [kinti/a11y-toolkit](https://github.com/kinti/a11y-toolkit) 🐍 🏠 - MCP server + CLI for WCAG 2.2 accessibility: color contrast (pairs plus pixel-level text-over-image sampling), EU accessibility declaration generation (RD 1112/2018, Ley 11/2023 / European Accessibility Act, EN 301 549), and an aria-live announcement monitor. Multilanguage es/en, zero dependencies.
+
 ### 🎨 <a name="art-and-culture"></a>Art & Culture
 
 Access and explore art collections, cultural heritage, and museum databases. Enables AI models to search and analyze artistic and cultural content.


### PR DESCRIPTION
## What

Adds **[kinti/a11y-toolkit](https://github.com/kinti/a11y-toolkit)** under a new **♿ Accessibility** category (no accessibility section existed yet).

## Why

WCAG 2.2 toolkit with genuinely uncovered capabilities in the list:

- **Color contrast, pairs AND text-over-image** — pixel-level sampling of the real background behind the text (worst/median ratio, % of area passing AA). Pair-only checkers miss the most common real-world case.
- **EU accessibility declaration generator** — legal HTML per RD 1112/2018 (Spain, art. 10) and Ley 11/2023 / Directive (EU) 2019/882 (European Accessibility Act); EN/ES wording, output itself accessible.
- **aria-live announcement monitor** — injectable snippet that logs dynamic-region announcements (time, politeness, role, text).
- Plus a build-to-build accessibility diff CLI (focus order + accessible names regressions).

Zero-dependency Python stdio server (MCP), 5 tools, CI-tested, MIT, multilanguage es/en. Author has audited WCAG since 2009.

## Checklist

- [x] Server name links to its repository
- [x] Brief description following existing style
- [x] New category created with anchor