### PR TITLE
Add smart-me server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2190,6 +2190,7 @@ Control smart home devices, home network equipment, and automation systems.
 
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
+- [eCarUp/smart-me-mcp](https://github.com/eCarUp/smart-me-mcp) 🎖️ ☁️ - Real-time energy data for a whole building from the smart-me platform: live meter readings, quarter-hourly load profiles and daily series, EV charging stations with their sessions and load-management groups, and tariffs, invoice positions and ZEV (tenant) billing. Hosted remote server at `mcp.smart-me.com/mcp` — OAuth, nothing to install, no API key.
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory


### PR DESCRIPTION
Adds [eCarUp/smart-me-mcp](https://github.com/eCarUp/smart-me-mcp) — the official remote MCP server for the [smart-me](https://web.smart-me.com/) energy platform (smart metering, EV charging and ZEV/tenant billing, Switzerland).

It gives an assistant read access to live meter readings, quarter-hourly load profiles and daily series, EV charging stations with their sessions and load-management groups, and the tariffs, invoice positions and consumption of a billing property — plus confirmed writes for renaming meters, switching relays, setting current limits and configuring tariffs and billing.

Hosted at `https://mcp.smart-me.com/mcp` (streamable HTTP, OAuth 2.1 with dynamic client registration), so there is nothing to install and no API key. It is published in the official MCP registry as `com.smart-me/smart-me` and listed in the [Claude connector directory](https://claude.ai/directory/smart-me).

Notes on the entry:

- **Category:** filed under *Industrial & IoT* as the closest fit — building-level telemetry, monitoring and control. There is no energy/utilities category, and *Home Automation* reads wrong for a B2B multi-tenant billing platform. Happy for you to move it if you see a better home.
- **Markers:** 🎖️ because smart-me AG operates both the server and the underlying API, and ☁️ because it talks to a remote API. No language marker: the server is C#, but the linked repository holds documentation and the Gemini CLI manifest rather than source, so claiming a codebase marker would be misleading.
- Placed first in the category to keep alphabetical order (`eCarUp` before `FoundryNet`).

One line changed.