### PR TITLE
Add etim-json (ETIM classification model over MCP) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2191,6 +2191,7 @@ Control smart home devices, home network equipment, and automation systems.
 Connect AI agents to industrial equipment, machinery, and operational technology (OT) — telemetry ingestion, monitoring, and control across manufacturing and factory-floor protocols.
 
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
+- [M-Heath-Consulting/etim-json](https://github.com/M-Heath-Consulting/etim-json) 📇 🏠 - The ETIM classification model (the open standard for electrical, HVAC and industrial products) as clean JSON — served to AI agents over MCP with read-only tools for classes, features, units, values and code lookup. Ships no ETIM data; converts the release you are licensed to use.
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds **[M-Heath-Consulting/etim-json](https://github.com/M-Heath-Consulting/etim-json)** to **Industrial & IoT** (alphabetical, after FoundryNet).

- The ETIM classification model — the open standard for electrical, HVAC and industrial products — as clean JSON, served to AI agents over MCP (stdio).
- Five read-only tools (search classes, full class definitions, code lookup, group map, model info); every tool declares `readOnlyHint` and returns structured content.
- Ships no ETIM data (ODC-BY 1.0 attribution embedded in converted files); `--demo` mode gives a zero-setup synthetic model.
- On npm as `etim-json` (provenance attested), TypeScript, local.

Disclosure: PR prepared by an AI agent (Claude Code) on behalf of the maintainers at Partsgraph.ai / M Heath Consulting Ltd — hence the opt-in marker in the title, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)