### PR TITLE
Add quantified-self-mcp to Health & Wellness category

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ Integration with gaming related data, game engines, and services
 Access health metrics, wellness data, and medical information through various health platforms.
 
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
+- [Thecimal/quantified-self-mcp](https://github.com/Thecimal/quantified-self-mcp) 🐍 🏠 - Query your personal health and finance data from Claude Desktop. Two local SQLite files, read directly off disk by a Python process you control — no cloud database, no dashboard, no third-party service.
 
 ### 🏠 <a name="home-automation"></a>Home Automation
 


### PR DESCRIPTION
## Summary
Adds a new MCP server for querying personal health and finance data from Claude Desktop.

## Server Details
- **Repository:** [Thecimal/quantified-self-mcp](https://github.com/Thecimal/quantified-self-mcp)
- **Language:** Python
- **Scope:** Local service
- **Description:** Query your personal health and finance data from Claude Desktop. Two local SQLite files, read directly off disk by a Python process you control — no cloud database, no dashboard, no third-party service.

## Placement
Added under **Health & Wellness** in alphabetical order (after PhilipAD/health-export-mcp).

## Format
Follows existing legend and entry format:
- 🐍 Python codebase
- 🏠 Local service
- Clear, concise feature summary

## Accuracy
- Repository is public and active
- Description reflects actual functionality
- Links verified

Ready for review.