### PR TITLE
Add attest-capture-mcp (Browser Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [xspadex/bilibili-mcp](https://github.com/xspadex/bilibili-mcp.git) 📇 🏠 - A FastMCP-based tool that fetches Bilibili's trending videos and exposes them via a standard MCP interface.
 - [ymw0407/auth-fetch-mcp](https://github.com/ymw0407/auth-fetch-mcp) [![ymw0407/auth-fetch-mcp MCP server](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ymw0407/auth-fetch-mcp) 📇 🏠 🍎 🪟 🐧 - Fetch content from login-protected web pages (Notion, Google Docs, Jira, Confluence, etc.) by opening a real browser for authentication with persistent session caching.
 - [PrinceGabriel-lgtm/freshcontext-mcp](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp) [![freshcontext-mcp MCP server](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badges/score.svg)](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) ☁️ 🏠 - Real-time web intelligence with freshness timestamps. GitHub, HN, Scholar, arXiv, YC, jobs, finance, package trends — every result stamped with how old it is.
+- [xthemarketmaker-cmyk/attest-capture-mcp](https://github.com/xthemarketmaker-cmyk/attest-capture-mcp) 📇 ☁️ - Evidence-grade web capture for AI agents: screenshots, PDFs and HTML snapshots with SHA-256 hashes, timestamps and a public evidence page per capture. Free tier, one-time credit packs.
 
 ### ☁️ <a name="cloud-platforms"></a>Cloud Platforms
 


### PR DESCRIPTION
Adds [attest-capture-mcp](https://github.com/xthemarketmaker-cmyk/attest-capture-mcp) to Browser Automation.

Evidence-grade web capture for AI agents: screenshot/PDF/HTML capture where every capture gets a SHA-256 hash, a timestamp and a public evidence page (example: https://getattest.com.au/e/286f91fb-b42d-495e-bc8b-12f6f1516aee). Backed by the hosted API at https://getattest.com.au/capture with a free tier (100 credits, no card, no email).

- MCP stdio server, TypeScript/Node 22+, MIT
- Tool: `capture_url` (png/pdf/html, full-page option)
- 📇 ☁️ flags per the legend

🤖 Generated with [Claude Code](https://claude.com/claude-code)