### PR TITLE
Add Wagglet under Product Management 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2812,6 +2812,8 @@ Tools for product planning, customer feedback analysis, and prioritization.
 auto-download. Install via `npx atlassian-trello-mcp`.
 - [mohamed-ashraf-elsaed/loupe](https://github.com/mohamed-ashraf-elsaed/loupe) [![mohamed-ashraf-elsaed/loupe MCP server](https://glama.ai/mcp/servers/mohamed-ashraf-elsaed/loupe/badges/score.svg)](https://glama.ai/mcp/servers/mohamed-ashraf-elsaed/loupe) 🎖️ 📇 🏠 - Turns pinned visual product feedback into an actionable backlog: list comments, read one with its target element's HTML, computed styles and screenshot, and update its status. Powers the [Loupe](https://mohamed-ashraf-elsaed.github.io/loupe/) SDK, browser extension, and `loupekit/laravel` package. Install `@loupekit/mcp` (binary `loupe-mcp`).
 
+- [Wagglet](https://wagglet.com/docs/mcp) 🎖️ ☁️ - Prepared-task handoff for teams working with coding agents: read the authorized ticket, Story or person record, then move work with explicit lifecycle actions (claim, deliver, review) rather than free-form status writes, with a fresh operation id per mutation so a retry is not a duplicate. Hosted remote server at `https://wagglet.com/api/mcp`; a personal MCP token names one connection and never overrides that person's current Team roles or permissions, and Team-level MCP access is off by default.
+
 ### 🏠 <a name="real-estate"></a>Real Estate
 
 MCP servers for real estate CRM, property management, and agent workflows.


### PR DESCRIPTION
Adds one entry for **Wagglet** to the Product Management section.

Wagglet is a hosted MCP server for prepared-task handoff between a human teammate and their own coding agent. Rather than exposing generic record writes, the interface keeps the product's lifecycle rules: an agent reads the authorized ticket or Story, then uses explicit actions (claim, deliver, review) and passes a fresh operation id per mutation, so a retry is distinguishable from a duplicate.

- Endpoint: `https://wagglet.com/api/mcp`
- Docs: https://wagglet.com/docs/mcp
- Auth: personal MCP token. The token identifies one named connection and never overrides that person's current Team membership, roles or permissions. Team-level MCP access is off by default, and disabling it rejects connection requests immediately without deleting the connections.

Notes on the entry:

- Format follows the surrounding entries, with 🎖️ (official implementation) and ☁️ (cloud service). No Glama badge, since this is a hosted endpoint rather than a source repository - happy to drop the 🎖️ or restructure if you would rather it link somewhere else.
- I checked for an existing Wagglet entry before adding.
- Per CONTRIBUTING, this PR was prepared by an automated agent, so the title carries the 🤖🤖🤖 opt-in.