### PR TITLE
Add FindSaunaPlunge MCP server (Health & Wellness) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
+- [FindSaunaPlunge](https://findsaunaplunge.com/mcp) 🎖️ 📇 ☁️ - Cold plunge, sauna and contrast-therapy venues across 23 US metros, with published temperatures and prices quoted from each venue's own pages and dated. Remote Streamable HTTP, no auth; tools: search_venues, get_venue, list_cities, get_city_stats, get_data_freshness.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation

--- a/README.md
+++ b/README.md
@@ -2172,7 +2172,7 @@ Integration with gaming related data, game engines, and services
 
 Access health metrics, wellness data, and medical information through various health platforms.
 
-- [FindSaunaPlunge](https://findsaunaplunge.com/mcp) 🎖️ 📇 ☁️ - Cold plunge, sauna and contrast-therapy venues across 23 US metros, with published temperatures and prices quoted from each venue's own pages and dated. Remote Streamable HTTP, no auth; tools: search_venues, get_venue, list_cities, get_city_stats, get_data_freshness.
+- [findsaunaplunge/mcp](https://github.com/findsaunaplunge/mcp) [![findsaunaplunge/mcp MCP server](https://glama.ai/mcp/servers/findsaunaplunge/mcp/badges/score.svg)](https://glama.ai/mcp/servers/findsaunaplunge/mcp) 🎖️ 📇 ☁️ - Cold plunge, sauna and contrast-therapy venues across 23 US metros, with published temperatures and prices quoted from each venue's own pages and dated. Hosted at https://findsaunaplunge.com/mcp (Streamable HTTP, no auth); tools: search_venues, get_venue, list_cities, get_city_stats, get_data_freshness.
 - [io.github.PhilipAD/health-export-mcp](https://github.com/PhilipAD/health-export-mcp) [![io.github.PhilipAD/health-export-mcp MCP server](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PhilipAD/health-export-mcp) 🍎 🏠 - Query 190 Apple Health metrics from any MCP agent — zero-dependency, read-only, local-first.
 
 ### 🏠 <a name="home-automation"></a>Home Automation


### PR DESCRIPTION
Adds **FindSaunaPlunge** under Health & Wellness.

- Remote MCP server (Streamable HTTP, stateless, no auth, open CORS): `https://findsaunaplunge.com/mcp` — `GET` serves human documentation, `POST` is JSON-RPC.
- Listed in the official MCP registry as `com.findsaunaplunge/findsaunaplunge` (domain-verified).
- Tools: `search_venues`, `get_venue`, `list_cities`, `get_city_stats`, `get_data_freshness`.
- Data: 548 cold plunge / sauna / contrast-therapy venues across 23 US metros; every published temperature and price carries the source page, capture date and verbatim quote. Absent fields mean "not published", never zero.
- Same data is CC BY 4.0 as a feed (`/api/v1/venues.json`) and archived monthly on Zenodo (DOI 10.5281/zenodo.22132913).

Try it:

```bash
curl -s -X POST https://findsaunaplunge.com/mcp -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_venues","arguments":{"citySlug":"austin-tx","modality":"cold_plunge","limit":3}}}'
```

Opened by an automated agent on behalf of the maintainer (hence the title marker). Legend: 🎖️ official, 📇 TypeScript, ☁️ cloud service.