### PR TITLE
Add UnRemind.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -3867,3 +3867,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
+- [UnRemind](https://unremind.me/mcp?src=awesome-mcp) — Context-aware reminders that surface when your situation matches, not at a fixed time

--- a/README.md
+++ b/README.md
@@ -3867,4 +3867,4 @@ Now Claude can answer questions about writing MCP servers and how they work
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=punkpeye/awesome-mcp-servers&type=Date" />
  </picture>
 </a>
-- [UnRemind](https://unremind.me/mcp?src=awesome-mcp) — Context-aware reminders that surface when your situation matches, not at a fixed time
+- [UnRemind.me](https://unremind.me/mcp?src=awesome-mcp) — Context-aware reminders that surface when your situation matches, not at a fixed time


### PR DESCRIPTION
Adds UnRemind — Context-aware reminders that surface when your situation matches, not at a fixed time

UnRemind stores reminders with context tags — location, device, connectivity, people present, energy, available time — and surfaces them when your current context matches, instead of firing at a fixed time. Its MCP server exposes 16 tools covering Unreminders, context tags, delegated tasks, conflict checks and workload review, with per-agent access rights and an audit log.