### PR TITLE
Add katekruger/segment-mcp to Customer Data Platforms 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,7 @@ Provides access to customer profiles inside of customer data platforms
 - [tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird) 🐍 ☁️ - An MCP server to interact with a Tinybird Workspace from any MCP client.
 - [lionkiii/google-searchconsole-mcp](https://github.com/lionkiii/google-searchconsole-mcp) [![google-searchconsole-mcp MCP server](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lionkiii/google-searchconsole-mcp) 📇 🏠 - Google Search Console MCP server with 13 SEO tools — search analytics, URL inspection, sitemap management, keyword opportunities, brand analysis, and performance comparison.
 - [saurabhsharma2u/search-console-mcp](https://github.com/saurabhsharma2u/search-console-mcp)  - An MCP server to interact with Google Search Console and Bing Webmasters.
+- [katekruger/segment-mcp](https://github.com/katekruger/segment-mcp) 🐍 ☁️ - Read-first MCP server for [Twilio Segment](https://segment.com). Composes reads into five questions (which destinations get which events, which sources are dead, is an event governed by anything) instead of exposing raw endpoints. `SEGMENT_MCP_MODE` defaults to read-only, and data-deletion creation is permanently unreachable in every mode, checked three independent ways — not gated, refused. MIT.
 
 ### 🗄️ <a name="databases"></a>Databases
 


### PR DESCRIPTION
Adds a read-first MCP server for Twilio Segment to the Customer Data Platforms section.

- Composes five questions (which destinations get which events, which sources are dead, is an event governed by anything, is a destination silently failing, which sources allow unplanned events) instead of exposing raw endpoints.
- Read-only by default (`SEGMENT_MCP_MODE=read`); data-deletion creation is permanently unreachable in every mode.
- MIT licensed, published on PyPI as `segment-mcp`.

Followed CONTRIBUTING.md's format (owner/repo link, language/scope emoji, one-line description). Tagged 🤖🤖🤖 per the note in CONTRIBUTING.md for automated-agent PRs.