### PR TITLE
Add CordFind generator compatibility MCP 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2258,6 +2258,7 @@ Connect AI agents to industrial equipment, machinery, and operational technology
 
 - [Extelligence-ai/bagel](https://github.com/Extelligence-ai/bagel) [![Extelligence-ai/bagel MCP server](https://glama.ai/mcp/servers/Extelligence-ai/bagel/badges/score.svg)](https://glama.ai/mcp/servers/Extelligence-ai/bagel) 🐍 🏠 - Ask questions about robotics, drone, and IoT data (ROS 1/2 bags, MCAP, PX4/ArduPilot/Betaflight logs, CAN/MF4, live MQTT) in plain English; answers are DuckDB SQL over the actual messages, with an intelligent edge data-reduction pipeline and exports to Rerun, PlotJuggler, and LeRobot.
 - [FoundryNet/forge-mcp](https://github.com/FoundryNet/forge-mcp) 🐍 ☁️ - Industrial AI infrastructure that connects any AI agent to industrial equipment: 14 protocols, 18 manufacturers, 30 tools, cross-OEM telemetry normalization, health index, and failure prediction. The first physical-world MCP server. Free tier available. ([Smithery](https://smithery.ai/server/@foundrynet/forge)) [![FoundryNet/forge-mcp MCP server](https://glama.ai/mcp/servers/FoundryNet/forge-mcp/badges/score.svg)](https://glama.ai/mcp/servers/FoundryNet/forge-mcp)
+- [gokimedia/cordfind-mcp](https://github.com/gokimedia/cordfind-mcp) ☁️ - Public remote MCP server for generator guide search, connector compatibility screening, and extension-cord sizing at [CordFind](https://cordfind.com/mcp).
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
Adds CordFind, a public remote MCP server for generator guide search, connector compatibility screening, and extension-cord sizing.\n\n- Repository: https://github.com/gokimedia/cordfind-mcp\n- Live MCP: https://cordfind.com/api/mcp\n- Documentation: https://cordfind.com/mcp