### PR TITLE
Add tutorial: publishing an MCP server to the MCP Registry 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 * [Tool Definition Quality Score (TDQS)](https://github.com/glama-ai/tool-definition-quality-score)
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
+* [How to publish your MCP server to the MCP Registry](https://mcporbit.com/blog/publish-mcp-server-to-registry)
 
 ## Community
 


### PR DESCRIPTION
Adds one link to the **Tutorials** section: a step-by-step guide to publishing an MCP server to the official MCP Registry.

**Affiliation disclosure:** I work on MCPOrbit and the linked article is on our blog. I am submitting it because the Tutorials section has nothing on registry publishing, not because it is ours. If you would rather not link vendor blogs here, close this and no hard feelings.

**What the article covers**

- adding an `mcpName` field to `package.json`
- publishing the package to npm
- writing `server.json` so its `name` matches `mcpName`
- running `mcp-publisher login github` and `mcp-publisher publish`
- the version-pinned schema and the preview-reset caveat

It is a plain how-to. There is no signup wall, no product pitch in the body, and every command in it was run before it shipped.

Per CONTRIBUTING, this PR is opted into the automated-agent fast track.
