### PR TITLE
Add Signbee MCP server 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act) [glama](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act) 📇 ☁️ - EU AI Act compliance scanner that detects regulatory violations in AI codebases with risk classification and remediation guidance.
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
+- [signbee/mcp](https://github.com/signbee/mcp) 📇 ☁️ - Document signing for AI agents. Send contracts for e-signature via [Signbee](https://signb.ee) with email OTP verification and SHA-256 signing certificates. Supports MCP, Agent Skills, and direct API.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 

--- a/README.md
+++ b/README.md
@@ -1281,7 +1281,7 @@ Access to legal information, legislation, and legal databases. Enables AI models
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act) [glama](https://glama.ai/mcp/servers/@ark-forge/mcp-eu-ai-act) 📇 ☁️ - EU AI Act compliance scanner that detects regulatory violations in AI codebases with risk classification and remediation guidance.
 - [buildsyncinc/gibs-mcp](https://github.com/buildsyncinc/gibs-mcp) 🐍 ☁️ - Regulatory compliance (AI Act, GDPR, DORA) with article-level citations
 - [JamesANZ/us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) 📇 ☁️ - An MCP server that provides comprehensive US legislation.
-- [signbee/mcp](https://github.com/signbee/mcp) 📇 ☁️ - Document signing for AI agents. Send contracts for e-signature via [Signbee](https://signb.ee) with email OTP verification and SHA-256 signing certificates. Supports MCP, Agent Skills, and direct API.
+- [signbee/mcp](https://github.com/signbee/mcp) [![signbee/mcp MCP server](https://glama.ai/mcp/servers/signbee/mcp/badges/score.svg)](https://glama.ai/mcp/servers/signbee/mcp) 📇 ☁️ - Document signing for AI agents. Send contracts for e-signature via [Signbee](https://signb.ee) with email OTP verification and SHA-256 signing certificates. Supports MCP, Agent Skills, and direct API.
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
Adds Signbee to the Legal section, alphabetical (after SFHAJJI/lex, before smilemin07).

- [Signbee](https://github.com/signbee/mcp) — two-party SES e-sign for AI agents
- stdio MCP: `npx -y signbee-mcp`
- Tools: `send_document`, `send_document_pdf`

Official server. No prices, no customer names.