### PR TITLE
Add citable-mcp — pay-per-call SEO & AI-visibility data (Marketing) 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2813,6 +2813,8 @@ Tools for product planning, customer feedback analysis, and prioritization.
 auto-download. Install via `npx atlassian-trello-mcp`.
 - [mohamed-ashraf-elsaed/loupe](https://github.com/mohamed-ashraf-elsaed/loupe) [![mohamed-ashraf-elsaed/loupe MCP server](https://glama.ai/mcp/servers/mohamed-ashraf-elsaed/loupe/badges/score.svg)](https://glama.ai/mcp/servers/mohamed-ashraf-elsaed/loupe) 🎖️ 📇 🏠 - Turns pinned visual product feedback into an actionable backlog: list comments, read one with its target element's HTML, computed styles and screenshot, and update its status. Powers the [Loupe](https://mohamed-ashraf-elsaed.github.io/loupe/) SDK, browser extension, and `loupekit/laravel` package. Install `@loupekit/mcp` (binary `loupe-mcp`).
 
+- [zaialamm/citable-mcp](https://github.com/zaialamm/citable-mcp) 🎖️ 📇 ☁️ 🍎 🪟 🐧 - SEO and AI-visibility checks the agent buys per call in USDC on Solana via x402 — keyword volumes, Google rank checks, on-page/citability audits, backlinks, and which AI engines cite a domain for a buyer question. No API key, no account; failed calls are never charged. `npx -y citable-mcp`
+
 ### 🏠 <a name="real-estate"></a>Real Estate
 
 MCP servers for real estate CRM, property management, and agent workflows.


### PR DESCRIPTION
Adds [zaialamm/citable-mcp](https://github.com/zaialamm/citable-mcp) to **Marketing**: SEO and AI-visibility checks paid per call in USDC on Solana via x402 (keyword volumes, rank checks, citability audits, backlinks, AI-citation checks). Official implementation, TypeScript, on npm as `citable-mcp` and listed in the official MCP registry (io.github.zaialamm/citable-mcp). Follows the existing entry format; placed at the current end of the Marketing section like recent additions.