### PR TITLE
Add answerLoops (Support & Service Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3483,6 +3483,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [answerLoops/answerLoops](https://github.com/answerLoops/answerLoops) 📇 🏠 ☁️ - Open-source AI support agent for communities. Its MCP server lets agents search a self-hosted support knowledge base, read FAQs and tickets, create tickets, and generate answers grounded in your own docs.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.


### PR DESCRIPTION
Adds **answerLoops** to Support & Service Management.

- Repo: https://github.com/answerLoops/answerLoops (AGPL-3.0, self-hostable)
- Open-source AI support agent for communities — answers repeat questions across Discord, Slack, forums, GitHub, Telegram and email, grounded in the team's own docs, with a confidence gate before anything auto-posts.
- MCP server (`POST /api/mcp`, JSON-RPC): agents call `search_kb`, `get_faq`, `get_tickets`, `create_ticket`, `generate_answer` against an org's support data with a per-org API key. Docs: https://answerloops.com/docs/integrations/mcp

Placed alphabetically in the section. Not already listed (searched README + PRs).