### PR TITLE
Add asyntai/mcp-bridge to Support & Service Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3483,6 +3483,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
+- [asyntai/mcp-bridge](https://github.com/asyntai/mcp-bridge) 🎖️ 📇 ☁️ - Run your website's Asyntai AI support agent from any MCP client: manage the knowledge base, edit agent instructions, read conversations and leads, reply live to visitors and check plan usage.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.

--- a/README.md
+++ b/README.md
@@ -3483,7 +3483,7 @@ Tools for accessing sports-related data, results, and statistics.
 ### 🎧 <a name="support-and-service-management"></a>Support & Service Management
 Tools for managing customer support, IT service management, and helpdesk operations.
 - [aikts/yandex-tracker-mcp](https://github.com/aikts/yandex-tracker-mcp) 🐍 ☁️ 🏠 - MCP Server for Yandex Tracker. Provides tools for searching and retrieving information about issues, queues, users.
-- [asyntai/mcp-bridge](https://github.com/asyntai/mcp-bridge) 🎖️ 📇 ☁️ - Run your website's Asyntai AI support agent from any MCP client: manage the knowledge base, edit agent instructions, read conversations and leads, reply live to visitors and check plan usage.
+- [asyntai/mcp-bridge](https://github.com/asyntai/mcp-bridge) [![MCP Score](https://glama.ai/mcp/servers/asyntai/mcp-bridge/badge)](https://glama.ai/mcp/servers/asyntai/mcp-bridge) 🎖️ 📇 ☁️ - Run your website's Asyntai AI support agent from any MCP client: manage the knowledge base, edit agent instructions, read conversations and leads, reply live to visitors and check plan usage.
 - [Berckan/bugherd-mcp](https://github.com/Berckan/bugherd-mcp) 📇 ☁️ - MCP server for BugHerd bug tracking. List projects, view tasks with filtering by status/priority/tags, get task details, and read comments.
 - [effytech/freshdesk-mcp](https://github.com/effytech/freshdesk_mcp) 🐍 ☁️ - MCP server that integrates with Freshdesk, enabling AI models to interact with Freshdesk modules and perform various support operations.
 - [incentivai/quickchat-ai-mcp](https://github.com/incentivai/quickchat-ai-mcp) 🐍 🏠 ☁️ - Launch your conversational Quickchat AI agent as an MCP to give AI apps real-time access to its Knowledge Base and conversational capabilities.


### PR DESCRIPTION
Adds Asyntai, an official MCP server for running a website's AI support agent from any MCP client. Hosted remote server with OAuth 2.1, plus an npm bridge for stdio-only clients.

- Repo: https://github.com/asyntai/mcp-bridge
- npm: https://www.npmjs.com/package/@asyntai/mcp
- Docs: https://asyntai.com/documentation/mcp/

Placed alphabetically in Support & Service Management. Tags: official, TypeScript/JavaScript, cloud.