### PR TITLE
Add MCP Servers Directory to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Checkout [awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients/)
 
 * [r/mcp Reddit](https://www.reddit.com/r/mcp)
 * [Discord Server](https://glama.ai/mcp/discord)
+* [MCP Servers Directory](https://renhongtao2-cell.github.io/mcpdirectory/) – A curated web-based catalog of MCP servers, browsable by category with search and free submissions.
 
 ## Legend
 


### PR DESCRIPTION
Hi! Adding a free community resource to the **Community** section, next to the existing r/mcp and Discord links.

**[MCP Servers Directory](https://renhongtao2-cell.github.io/mcpdirectory/)** - a curated, web-based catalog of MCP servers:

- 30+ servers across 8 categories (Developer Tools, Productivity, Data & Databases, Web & Search, Communication, E-commerce & Finance, AI & Agents, Files & Docs)
- Category browsing + live search
- Free submissions from the community via GitHub issue
- Maintained actively; featured/sponsor placements clearly separated from organic listings

It complements this repository by giving people a browsable web interface for discovering MCP servers (the same role glama.ai plays for the synced repo listing).

Happy to adjust wording or placement. Thanks for maintaining this awesome list!