### PR TITLE
Add FastMCP4J to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,6 +1579,7 @@ Interact with Git repositories and version control platforms. Enables repository
 - [Epistates/TurboMCP](https://github.com/Epistates/turbomcp) 🦀 - TurboMCP SDK: Enterprise MCP SDK in Rust
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [FastMCP](https://github.com/punkpeye/fastmcp) 📇 - A high-level framework for building MCP servers in TypeScript
+- [FastMCP4J](https://github.com/tersePrompts/fastMCP4J) ☕ - A high-level annotation-driven framework for building MCP servers in Java 17+ — tools, resources, prompts, and a sandboxed bash terminal so agents can run commands without host access
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp) 🐍 - AI Agents framework with 64+ built-in tools for search, memory, workflows, code execution, and file operations. Turn any AI assistant into a multi-agent system with MCP.
 
 ## Tips and Tricks


### PR DESCRIPTION
Resubmitting #1778 (closed as inactive in March — the project has matured a lot since, so this is a fresh PR rather than a reopen).

Adds [FastMCP4J](https://github.com/tersePrompts/fastMCP4J) to the **Frameworks** section, right after the Python and TypeScript FastMCP entries — this is the Java member of that family.

Annotation-driven: one annotation turns a class into an MCP server (tools, resources, prompts, memory) over stdio/SSE/streamable HTTP, on Java 17+ and the official MCP Java SDK (spec 2.0.1). Cold start under 500 ms, twelve dependencies, published to Maven Central. Its differentiator for agent builders: a sandboxed bash terminal tool (powered by [bashkit4j](https://github.com/tersePrompts/bashkit4j)) where the host is unreachable by construction — virtual filesystem, virtual identity, network denied, host mounts only via natively-allowlisted opt-in.