### PR TITLE
Add Proxies.sx MCP server — mobile/residential proxies for agents 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Web content access and automation capabilities. Enables searching, scraping, and
 - [automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright) 🐍 - An MCP server for browser automation using Playwright
 - [BB-fat/browser-use-rs](https://github.com/BB-fat/browser-use-rs) 🦀 Lightweight browser automation MCP server in Rust with zero dependencies.
 - [blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp) 🐍 - An MCP python server using Playwright for browser automation,more suitable for llm
+- [bolivian-peru/proxies-sx-mcp-server](https://github.com/bolivian-peru/proxies-sx-mcp-server) 📇 ☁️ - Mobile and residential proxies for AI agents: 70 tools to buy GB with an API key or USDC via x402, mint gateway sessions, rotate IPs and check stock per country (Proxies.sx).
 - [browserbase/mcp-server-browserbase](https://github.com/browserbase/mcp-server-browserbase) 🎖️ 📇 - Automate browser interactions in the cloud (e.g. web navigation, data extraction, form filling, and more)
 - [browsermcp/mcp](https://github.com/browsermcp/mcp) 📇 🏠 - Automate your local Chrome browser
 - [brutalzinn/simple-mcp-selenium](https://github.com/brutalzinn/simple-mcp-selenium) 📇 🏠 - An MCP Selenium Server for controlling browsers using natural language in Cursor IDE. Perfect for testing, automation, and multi-user scenarios.


### PR DESCRIPTION
Adds [bolivian-peru/proxies-sx-mcp-server](https://github.com/bolivian-peru/proxies-sx-mcp-server) under **Browser Automation**.

- npm: [`@proxies-sx/mcp-server`](https://www.npmjs.com/package/@proxies-sx/mcp-server) (MIT, TypeScript, stdio)
- 70 tools: buy proxy bandwidth with an API key or USDC via x402, mint pool-gateway sessions, rotate IPs, check stock per country, manage dedicated ports
- Docs for agents: https://agents.proxies.sx/mcp/ · https://agents.proxies.sx/skill.md
- Placed alphabetically; entry follows the list's format (📇 TypeScript, ☁️ cloud service).

🤖 Submitted by an agent on behalf of the maintainer.