### PR TITLE
Add MatPlotLibNet under Data Visualization 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1793,6 +1793,8 @@ Interactive charts, dashboards, and visual data tools rendered inside AI convers
 - [nteract/semiotic](https://github.com/nteract/semiotic) [![nteract/semiotic MCP server](https://glama.ai/mcp/servers/nteract/semiotic/badges/score.svg)](https://glama.ai/mcp/servers/nteract/semiotic) 📇 🏠 🍎 🪟 🐧 - React data visualization MCP server with 30+ chart types. 5 tools: suggest charts for a dataset, render validated React configs to SVG, diagnose configuration anti-patterns, get component schemas, and report issues. 
 - [subhatta123/twilize](https://github.com/subhatta123/twilize) [![subhatta123/twilize MCP server](https://glama.ai/mcp/servers/subhatta123/twilize/badges/score.svg)](https://glama.ai/mcp/servers/subhatta123/twilize) 🐍 🏠 🍎 🪟 🐧 - Programmatic Tableau workbook (.twb/.twbx) generation — 47 MCP tools for charts, dashboards, calculated fields, dashboard actions, workbook migration, and CSV-to-dashboard pipelines. Install via `uvx twilize`.
 
+- [xkqg/MatPlotLibNet](https://github.com/xkqg/MatPlotLibNet) #️⃣ 🏠 🍎 🪟 🐧 - Charts an agent can look at. Hand it the JSON for a figure and it renders a PNG and says in one line what it drew; ask for SVG or PDF and it writes the file and tells you where. 83 chart types, from a line plot to a candlestick to a 3-D surface, and the spec is checked before anything is drawn, so a typo comes back named instead of blank. Runs on your machine as a .NET tool.
+
 ### 📟 <a name="embedded-system"></a>Embedded System
 
 Provides access to documentation and shortcuts for working on embedded devices.


### PR DESCRIPTION
MatPlotLibNet is a charting library for .NET, and this adds its MCP server to Data Visualization.

What it does: you hand it the JSON for a figure and it renders a PNG, with one line of text beside it saying
what it drew, so a model that cannot see the image still knows what it made. SVG and PDF go to a file instead —
a single SVG is tens of thousands of characters of context. It knows 83 chart types, from a line plot to a
candlestick to a 3-D surface.

The part worth mentioning: the library's own JSON reader is lenient by design, because a newer document has to
load in an older build. Handed a document a model typed, that lenience turns every typo into a blank chart
reported as a success — so the server validates first and names the offending field ("'lien' is not a chart
type, did you mean 'line'?") instead of drawing nothing.

It is a .NET tool, so a host starts it with `dnx MatPlotLibNet.Mcp`; it runs locally, nothing leaves the
machine. MIT licensed, and it is in the MCP registry as `io.github.xkqg/matplotlibnet`.

- Repository: https://github.com/xkqg/MatPlotLibNet
- NuGet: https://www.nuget.org/packages/MatPlotLibNet.Mcp
- Docs: https://xkqg.github.io/MatPlotLibNet/cookbook/mcp.html
